### PR TITLE
Add canvas element selection

### DIFF
--- a/packages/render/src/handlers/element-selection.ts
+++ b/packages/render/src/handlers/element-selection.ts
@@ -1,0 +1,19 @@
+import {
+  startTransaction,
+  selectElements,
+  endTransaction
+} from '@asra/reactive-events'
+
+export const ElementSelectionHandlers = {
+  selectElement: (elementId: string) => {
+    startTransaction()
+    selectElements([elementId])
+    endTransaction()
+  },
+
+  deselectAll: () => {
+    startTransaction()
+    selectElements([])
+    endTransaction()
+  }
+}

--- a/packages/render/src/handlers/index.ts
+++ b/packages/render/src/handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './element-selection'

--- a/packages/render/src/render-layer/element-interaction-handler.ts
+++ b/packages/render/src/render-layer/element-interaction-handler.ts
@@ -1,6 +1,15 @@
 import { Container, Graphics, FederatedPointerEvent } from 'pixi.js'
+import { ElementSelectionHandlers } from '../handlers'
 
 export class ElementInteractionHandler {
+  private hasMoved = false
+  private downElementId: string | null = null
+
+  handleWorkspaceClick() {
+    // Deselect all when clicking on empty space
+    ElementSelectionHandlers.deselectAll()
+  }
+
   bindElementEvents(element: Container | Graphics) {
     element.eventMode = 'static'
     element.cursor = 'pointer'
@@ -19,21 +28,28 @@ export class ElementInteractionHandler {
     element: Container | Graphics,
     e: FederatedPointerEvent
   ) {
-    console.log('pointer DOWN on', element)
-    // TODO: Publish selection event here
+    this.hasMoved = false
+    this.downElementId = element.label
+
+    // Select element on mouse down
+    ElementSelectionHandlers.selectElement(element.label)
   }
 
   private handlePointerMove(
     element: Container | Graphics,
     e: FederatedPointerEvent
   ) {
-    console.log('pointer MOVE on', element)
+    if (this.downElementId) {
+      this.hasMoved = true
+    }
   }
 
   private handlePointerUp(
     element: Container | Graphics,
     e: FederatedPointerEvent
   ) {
-    console.log('pointer UP on', element)
+    // Reset state
+    this.hasMoved = false
+    this.downElementId = null
   }
 }

--- a/packages/render/src/render-layer/element-interaction-handler.ts
+++ b/packages/render/src/render-layer/element-interaction-handler.ts
@@ -1,0 +1,39 @@
+import { Container, Graphics, FederatedPointerEvent } from 'pixi.js'
+
+export class ElementInteractionHandler {
+  bindElementEvents(element: Container | Graphics) {
+    element.eventMode = 'static'
+    element.cursor = 'pointer'
+
+    element.on('pointerdown', (e) => this.handlePointerDown(element, e))
+    element.on('pointermove', (e) => this.handlePointerMove(element, e))
+    element.on('pointerup', (e) => this.handlePointerUp(element, e))
+  }
+
+  unbindElementEvents(element: Container | Graphics) {
+    element.eventMode = 'none'
+    element.removeAllListeners()
+  }
+
+  private handlePointerDown(
+    element: Container | Graphics,
+    e: FederatedPointerEvent
+  ) {
+    console.log('pointer DOWN on', element)
+    // TODO: Publish selection event here
+  }
+
+  private handlePointerMove(
+    element: Container | Graphics,
+    e: FederatedPointerEvent
+  ) {
+    console.log('pointer MOVE on', element)
+  }
+
+  private handlePointerUp(
+    element: Container | Graphics,
+    e: FederatedPointerEvent
+  ) {
+    console.log('pointer UP on', element)
+  }
+}

--- a/packages/render/src/render-layer/render-layer.ts
+++ b/packages/render/src/render-layer/render-layer.ts
@@ -129,20 +129,20 @@ export class RenderLayer {
       case 'children': {
         const oldList = new Set(before as string[])
         let deleteCount = 0
-          // Add element
-          ; (after as string[]).forEach((childId, index) => {
-            const child = this.getElementById(childId)
-            if (!child) {
-              return
-            }
+        // Add element
+        ;(after as string[]).forEach((childId, index) => {
+          const child = this.getElementById(childId)
+          if (!child) {
+            return
+          }
 
-            if (oldList.has(childId)) {
-              oldList.delete(childId)
-              deleteCount++
-            } else {
-              element.addChildAt(child, index - deleteCount)
-            }
-          })
+          if (oldList.has(childId)) {
+            oldList.delete(childId)
+            deleteCount++
+          } else {
+            element.addChildAt(child, index - deleteCount)
+          }
+        })
 
         // Remove element
         oldList.forEach((childId) => {

--- a/packages/render/src/render-layer/render-layer.ts
+++ b/packages/render/src/render-layer/render-layer.ts
@@ -1,11 +1,13 @@
 import { Container, Graphics, Point } from 'pixi.js'
 import { SceneElement, RenderContainerData, RenderElementData } from '../types'
 import { DataTypes, EntityTypes } from '@asra/utils'
+import { ElementInteractionHandler } from './element-interaction-handler'
 
 export class RenderLayer {
   private currentWorkspace: Container
   private _elements: Map<string, SceneElement> = new Map()
   private _deleteMap: Map<string, SceneElement> = new Map()
+  private interactionHandler = new ElementInteractionHandler()
 
   constructor() {
     this.currentWorkspace = new Container()
@@ -18,10 +20,12 @@ export class RenderLayer {
   addToMap(elementId: string, instance: SceneElement) {
     this._elements.set(elementId, instance)
     this.removeFromDeleteMap(elementId)
+    this.interactionHandler.bindElementEvents(instance)
   }
 
   removeFromMap(elementId: string) {
     const instance = this.getElementById(elementId) as SceneElement
+    this.interactionHandler.unbindElementEvents(instance)
     this._elements.delete(elementId)
     this.addToDeleteMap(elementId, instance)
   }
@@ -114,20 +118,20 @@ export class RenderLayer {
       case 'children': {
         const oldList = new Set(before as string[])
         let deleteCount = 0
-        // Add element
-        ;(after as string[]).forEach((childId, index) => {
-          const child = this.getElementById(childId)
-          if (!child) {
-            return
-          }
+          // Add element
+          ; (after as string[]).forEach((childId, index) => {
+            const child = this.getElementById(childId)
+            if (!child) {
+              return
+            }
 
-          if (oldList.has(childId)) {
-            oldList.delete(childId)
-            deleteCount++
-          } else {
-            element.addChildAt(child, index - deleteCount)
-          }
-        })
+            if (oldList.has(childId)) {
+              oldList.delete(childId)
+              deleteCount++
+            } else {
+              element.addChildAt(child, index - deleteCount)
+            }
+          })
 
         // Remove element
         oldList.forEach((childId) => {

--- a/packages/render/src/render-layer/render-layer.ts
+++ b/packages/render/src/render-layer/render-layer.ts
@@ -11,6 +11,17 @@ export class RenderLayer {
 
   constructor() {
     this.currentWorkspace = new Container()
+    this.bindWorkspaceEvents()
+  }
+
+  private bindWorkspaceEvents() {
+    this.currentWorkspace.eventMode = 'static'
+    this.currentWorkspace.on('pointerup', (e) => {
+      // Only deselect if clicking on empty space (not on an element)
+      if (e.target === this.currentWorkspace) {
+        this.interactionHandler.handleWorkspaceClick()
+      }
+    })
   }
 
   get view() {

--- a/packages/selection/src/subscribes/element-selection.ts
+++ b/packages/selection/src/subscribes/element-selection.ts
@@ -6,6 +6,8 @@ import { elementSelection } from '../selections/element-selection'
 
 export const initElementSelectionSubscribes = () => {
   subscribeToSelectElements(({ payload }) => {
+    console.log('subscribe select element')
+    console.log(payload)
     elementSelection.select(payload.after)
 
     elementSelection.changes.forEach((change) => {


### PR DESCRIPTION
## Changes
- Add element selection on pointerdown
- Deselect all when clicking empty workspace  
- Create handlers/element-selection.ts with transaction-wrapped selection
- Track hasMoved flag for future drag/resize logic

## Implementation Details
- Created ElementInteractionHandler to manage PixiJS pointer events
- Selection handlers wrap operations in transactions for undo/redo support
- Workspace click handling for deselection

## Testing
Manual testing - no unit tests needed for thin integration layer