### PR TITLE
Add deselect all on empty space click

### DIFF
--- a/packages/render/src/render-layer/render-layer.ts
+++ b/packages/render/src/render-layer/render-layer.ts
@@ -28,6 +28,10 @@ export class RenderLayer {
     return this.currentWorkspace
   }
 
+  handleEmptySpaceClick() {
+    this.interactionHandler.handleWorkspaceClick()
+  }
+
   addToMap(elementId: string, instance: SceneElement) {
     this._elements.set(elementId, instance)
     this.removeFromDeleteMap(elementId)

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -35,8 +35,26 @@ class Render {
     this.app.stage.eventMode = 'static'
 
     this._setupStageLayers()
+    this._bindStageEvents()
 
     return this.app
+  }
+
+  private _bindStageEvents() {
+    // Use HTML canvas element for click detection
+    const canvas = this.app?.canvas
+    if (canvas) {
+      canvas.addEventListener('pointerup', (e) => {
+        // Check if we clicked on an actual PixiJS element
+        const pixiEvent = this.app?.renderer.events.rootBoundary
+        const target = pixiEvent?.hitTest(e.clientX, e.clientY)
+
+        // If no PixiJS element was hit, we clicked on empty space
+        if (!target || target === this.app?.stage) {
+          this.viewport.handleEmptySpaceClick()
+        }
+      })
+    }
   }
 
   private _setupStageLayers() {

--- a/packages/render/src/viewport-layer/viewport-layer.ts
+++ b/packages/render/src/viewport-layer/viewport-layer.ts
@@ -20,6 +20,10 @@ export class ViewportLayer {
     return this.layer
   }
 
+  handleEmptySpaceClick() {
+    this.renderLayer.handleEmptySpaceClick()
+  }
+
   getElementById(elementId: string): SceneElement | undefined {
     return this.renderLayer.getElementById(elementId)
   }


### PR DESCRIPTION
- Use HTML canvas element for click detection
- Perform PixiJS hit test to detect element vs empty space
- Deselect all elements when clicking empty space
- Transaction-wrapped for undo/redo support