### PR TITLE
fix: adjust E2E schedule to Taiwan timezone

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 18 * * *'
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
Fixes the scheduled E2E test time to run at 2 AM Taiwan time instead of 2 AM UTC.

**Change**:  →  (18:00 UTC = 02:00 Taiwan time)

**Why**: GitHub Actions uses UTC, but we want tests to run at 2 AM local Taiwan time.