### PR TITLE
feat: establish monorepo import rule as highest priority standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,10 +5,11 @@
 ## Essential Reading (in order)
 
 1. **[docs/ai/project/AI_ESSENTIALS.md](docs/ai/project/AI_ESSENTIALS.md)** - Core rules and guidelines (READ FIRST)
-2. **[docs/ai/project/ARCHITECTURE.md](docs/ai/project/ARCHITECTURE.md)** - Technical architecture details
-3. **[docs/ai/project/WORKFLOW.md](docs/ai/project/WORKFLOW.md)** - Development process phases
-4. **[docs/ai/skills/](docs/ai/skills/)** - Reusable AI agent capabilities and skills
-5. **[docs/ai/workflows/](docs/ai/workflows/)** - Universal workflows for guaranteed process execution
+2. **[docs/ai/project/CODING_STANDARDS.md](docs/ai/project/CODING_STANDARDS.md)** - **MONOREPO IMPORT RULE** (READ SECOND - HIGHEST PRIORITY)
+3. **[docs/ai/project/ARCHITECTURE.md](docs/ai/project/ARCHITECTURE.md)** - Technical architecture details
+4. **[docs/ai/project/WORKFLOW.md](docs/ai/project/WORKFLOW.md)** - Development process phases
+5. **[docs/ai/skills/](docs/ai/skills/)** - Reusable AI agent capabilities and skills
+6. **[docs/ai/workflows/](docs/ai/workflows/)** - Universal workflows for guaranteed process execution
 
 ## Quick Reference
 
@@ -91,6 +92,7 @@ yarn workspace @package/name build  # Package-specific build
 
 ## Critical Rules
 
+- **🚨 MONOREPO IMPORT RULE**: **ALWAYS** use `@asra/package-name` for cross-package imports, NEVER use relative paths like `../../../other-package` (see `docs/ai/project/CODING_STANDARDS.md`)
 - **🚨 MAIN BRANCH PROTECTION**: NEVER work on main branch - use feature branches only (see `docs/ai/project/rules/main-branch-protection.md`)
 - **Project Context**: Always read `docs/ai/project/` folder first for architecture patterns
 - **External APIs**: Use Context7 MCP server for libraries/frameworks/APIs (see `.antigravity/rules.md`)

--- a/docs/ai/project/CODING_STANDARDS.md
+++ b/docs/ai/project/CODING_STANDARDS.md
@@ -1,0 +1,75 @@
+# Coding Standards
+
+**READ THIS FIRST** - This document contains essential coding standards for the Asra project.
+
+## 🚨 Prime Directive: Monorepo Import Rule
+
+### CROSS-PACKAGE IMPORTS: USE `@asra/package-name`
+
+**ALWAYS** import from other packages using the monorepo naming convention:
+
+```typescript
+// ✅ CORRECT
+import { Shape, EntityKind } from '@asra/utils'
+import { ShapeEntityImpl } from '@asra/scene-tree'
+import { ShapeRenderSystem } from '@asra/render'
+
+// ❌ FORBIDDEN - Never do this
+import { Shape } from '../../../utils/src/sceneTree/shapeTypes'
+import { ShapeEntityImpl } from '../../../scene-tree/src/components/shape-entity'
+import { ShapeRenderSystem } from '../../../render/src/shape-render-system'
+```
+
+### SAME-PACKAGE IMPORTS: USE RELATIVE PATHS
+
+**WITHIN the same package**, use relative paths to avoid circular dependencies:
+
+```typescript
+// ✅ CORRECT (within @asra/render package)
+import { ShapeRenderSystem } from '../shape-render-system'
+
+// ✅ CORRECT (within @asra/scene-tree package)
+import { ShapeEntityImpl } from './components/shape-entity'
+```
+
+## Why This Matters
+
+1. **Build System Compatibility**: TypeScript can resolve `@asra/package` imports correctly across the monorepo
+2. **Dependency Clarity**: Makes cross-package dependencies explicit and traceable
+3. **Circular Dependency Avoidance**: Relative imports within same package prevent infinite loops
+4. **Monorepo Best Practices**: Follows standard Turborepo/Yarn workspaces conventions
+
+## Enforcement
+
+- **Code Reviews**: Flag any violations of this rule
+- **Pre-commit Hooks**: Consider adding linters to catch violations
+- **IDE Configuration**: Configure your editor to prefer package imports
+
+## Examples from Asra Codebase
+
+### Shape System Implementation (Reference Implementation)
+
+```typescript
+// packages/utils/src/sceneTree/__tests__/integration.test.ts
+import { Shape, ShapeRegistry, EntityKind } from '@asra/utils' // ✅ Cross-package
+import { ShapeEntityImpl } from '@asra/scene-tree' // ✅ Cross-package
+import { ShapeRenderSystem } from '@asra/render' // ✅ Cross-package
+
+// packages/render/src/__tests__/shape-render-system.test.ts
+import { ShapeRenderSystem } from '../shape-render-system' // ✅ Same package
+import { Shape, ShapeRegistry, EntityKind } from '@asra/utils' // ✅ Cross-package
+import { ShapeEntityImpl } from '@asra/scene-tree' // ✅ Cross-package
+```
+
+## Quick Checklist
+
+Before committing code, verify:
+
+- [ ] All cross-package imports use `@asra/package-name` format
+- [ ] No `../../../packages/` or similar deep relative imports
+- [ ] Same-package imports use relative paths
+- [ ] Tests build successfully with `yarn workspace @package/name build:package`
+
+---
+
+**Remember: In a monorepo, package boundaries matter. Respect them!**


### PR DESCRIPTION
- Add CODING_STANDARDS.md documenting monorepo import rule
- Update AI_ESSENTIALS.md to prioritize coding standards
- Update AGENTS.md to emphasize monorepo import rule as CRITICAL

🚨 MONOREPO IMPORT RULE:
- ALWAYS use '@asra/package-name' for cross-package imports
- NEVER use relative paths like '../../../other-package'
- Use relative paths ONLY within same package

This establishes the rule as the second-highest priority after reading AI_ESSENTIALS.md, preventing future import violations.