### PR TITLE
docs(framework): close transaction ACID plan

### DIFF
--- a/docs/ai/framework/CONSTRAINTS.md
+++ b/docs/ai/framework/CONSTRAINTS.md
@@ -55,7 +55,7 @@
 - This is not a database transaction: isolation is Feature-operation
   serialization, not external/remote locking or serializable isolation.
 - Persistence failure does not reverse runtime commit and has no built-in retry.
-- See `plans/transaction-atomicity-and-rollback-plan.md`.
+- See `plans/completed/transaction-atomicity-and-rollback-plan.md`.
 
 8. Yjs network collaboration
 - Current Yjs usage provides local shared-channel registration, buffered or

--- a/docs/ai/framework/PLANS.md
+++ b/docs/ai/framework/PLANS.md
@@ -10,35 +10,27 @@ This file tracks framework planning topics and points to detailed references.
 
 ## Near-Term Plans
 
-1. Transaction atomicity and rollback
-- Complete the ACID-inspired runtime transaction contract without pretending to
-  provide a database transaction.
-- Reuse the existing inverse replay logic for failed active-transaction
-  rollback, separate rollbackable from undoable recording, and define explicit
-  cancel policies.
-- Reference: `docs/ai/framework/plans/transaction-atomicity-and-rollback-plan.md`
-
-2. Preset 2D/3D init profiles
+1. Preset 2D/3D init profiles
 - Provide explicit preset init profiles (`2d`, `3d`, `hybrid`) for fast product bootstrap.
 - Preserve deterministic composition (`shared -> profile -> app override`) and backward-compatible default path.
 - Reference: `docs/ai/framework/plans/preset-2d-3d-init-profile-plan.md`
 
-3. Extendable preset
+2. Extendable preset
 - Allow users to extend preset feature/property behavior through explicit extension points.
 - Keep deterministic fallback path: `unregister -> redefine` when extension points are unavailable.
 - Reference: `docs/ai/framework/plans/extendable-preset-plan.md`
 
-4. Render-engine boundary
+3. Render-engine boundary
 - Split render orchestration from concrete engine implementation.
 - Keep Pixi as default engine via preset wiring while enabling engine swap for future domains.
 - Reference: `docs/ai/framework/plans/render-engine-boundary-plan.md`
 
-5. Canvas debugger
+4. Canvas debugger
 - Add a framework-owned debugging surface to verify render output, render-layer output, and coordinate-space correctness.
 - Keep it optional, deterministic, and renderer-boundary-safe so apps can opt in without coupling domain logic to Pixi internals.
 - Reference: `docs/ai/framework/plans/canvas-debugger-plan.md`
 
-6. Render delta update pipeline
+5. Render delta update pipeline
 - Apply data-channel deltas directly in render update flow to avoid full computed-data rehydrate.
 - Use render-side cached snapshots + key-based invalidation for heavy geometry.
 - Reference: `docs/ai/framework/plans/render-delta-update-plan.md`

--- a/docs/ai/framework/REQUEST_ROUTING.md
+++ b/docs/ai/framework/REQUEST_ROUTING.md
@@ -31,7 +31,7 @@ Use this file to route a new framework request to the right docs first.
   - `rules/data-flow-and-transactions.md`
   - `packages/factory.md`
   - `packages/feature-system.md`
-  - `plans/transaction-atomicity-and-rollback-plan.md`
+  - `plans/completed/transaction-atomicity-and-rollback-plan.md`
 
 - Yjs shared channels/network collaboration/presence/conflict policy
   - `packages/factory.md`

--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -977,3 +977,31 @@ Backfilled entries use decision dates inferred from related commit dates/ranges.
   - Input-system avoids element drag conflicts during overlay capture.
 - Related Plan:
   - `docs/ai/framework/plans/completed/interactive-overlay-input-plan.md`
+
+## 2026-07-15 - Local application-level transaction ACID completed
+
+- Context:
+  - PR #77 completed and merged the local transaction atomicity, validation,
+    interaction serialization, and persistence acknowledgement work.
+- Decision:
+  - Treat Asyra's local application-level Atomicity, Consistency, Isolation, and
+    Durability contract as complete without claiming database serializability or
+    distributed transaction guarantees.
+  - User-driven interruption defaults to `commit-current` and finalizes the
+    current preview as one undoable action; handler error, timeout, validation
+    failure, explicit rollback, or a feature's true-discard policy use rollback.
+  - Persistence failure reports `persistence-failed` but does not reverse an
+    already committed runtime transaction.
+  - Yjs provider/room/auth, remote canonical apply, origin/dedupe, awareness,
+    reconnect/convergence, and collaborative conflict policy remain outside this
+    completed phase.
+- Consequences:
+  - The active plan is archived at the completed canonical path while the
+    executable Transaction Flow Inspector data, contract test, and viewer remain
+    active source-of-truth artifacts.
+  - `Preset 2D/3D Init Profiles` is now the first Near-Term Plan.
+- Related Plan:
+  - `docs/ai/framework/plans/completed/transaction-atomicity-and-rollback-plan.md`
+- Related Commit(s):
+  - `8ea0e1c9736df40312143edaac499b6109af628e` (`feat(framework): add local transaction ACID semantics (#77)`)
+  - [PR #77](https://github.com/karote00/asyra/pull/77)

--- a/docs/ai/framework/design-principles/extensible-runtime-guarantees.md
+++ b/docs/ai/framework/design-principles/extensible-runtime-guarantees.md
@@ -17,10 +17,12 @@ Preset packages provide working defaults, not hidden ownership. App authors shou
 - One intended user action should map to one intended undo commit.
 - Data-changing paths must be grouped behind transaction boundaries.
 - Cross-store mutations must be coordinated through API boundaries that preserve scene-tree, props-manager, selection, and render consistency.
-- Current scope is grouping, undo/redo replay, and shared-delivery timing.
-- Automatic failed-transaction rollback and explicit cancel policies are a
-  deferred guarantee tracked in
-  `../plans/transaction-atomicity-and-rollback-plan.md`.
+- The current local runtime includes grouping, undo/redo replay, automatic
+  failed-transaction rollback, synchronous commit validation, explicit cancel
+  policies, shared-delivery timing, and separate persistence acknowledgement.
+- This is an application-level guarantee, not database serializability or a
+  distributed transaction contract. See
+  `../plans/completed/transaction-atomicity-and-rollback-plan.md`.
 
 3. Schema Safety Guarantee
 - Runtime invalid writes are rejected before they corrupt active state.

--- a/docs/ai/framework/plans/completed/transaction-atomicity-and-rollback-plan.md
+++ b/docs/ai/framework/plans/completed/transaction-atomicity-and-rollback-plan.md
@@ -2,9 +2,24 @@
 
 ## Status
 
-Implemented contract under final verification. Runtime behavior is governed by
-formal tests and the Transaction Flow Inspector; Yjs network collaboration
-remains a separate deferred plan.
+Completed on 2026-07-15. Local application-level ACID semantics are implemented
+on `main` by PR #77 (`8ea0e1c9736df40312143edaac499b6109af628e`).
+Runtime behavior remains governed by formal tests and the executable Transaction
+Flow Inspector; Yjs network collaboration remains a separate deferred plan.
+
+## Completion Record
+
+- Final decision: accept the local ACID-inspired contract as complete without
+  claiming database serializability or distributed transaction guarantees.
+- Implementation summary: rollbackable journals, synchronous commit validation,
+  serialized feature interactions, explicit cancel outcomes, and detached
+  commit-time persistence snapshots now have distinct runtime owners and status
+  contracts.
+- Exit criteria: all implementation slices are complete, PR #77's CI validation
+  passed, and the Atomicity, Consistency, Isolation, and Durability regression
+  suites pass on the merged implementation.
+- Canonical executable architecture contract:
+  `docs/ai/framework/plans/transaction-flow-inspector.data.cjs`.
 
 ## Context
 

--- a/docs/ai/framework/plans/transaction-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/transaction-flow-inspector.contract.test.cjs
@@ -1,4 +1,6 @@
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
 const test = require('node:test')
 
 const data = require('./transaction-flow-inspector.data.cjs')
@@ -8,6 +10,21 @@ const step = (id) => {
   assert.ok(value, `Missing Inspector step: ${id}`)
   return value
 }
+
+test('completed product contract remains the resolvable Inspector authority', () => {
+  const repoRoot = path.resolve(__dirname, '../../../..')
+  const productContract = data.links.find(
+    (link) => link.id === 'product-contract'
+  )
+
+  assert.ok(productContract, 'Missing product-contract Inspector link')
+  assert.equal(
+    data.authority.specPath,
+    'docs/ai/framework/plans/completed/transaction-atomicity-and-rollback-plan.md'
+  )
+  assert.ok(fs.existsSync(path.resolve(repoRoot, data.authority.specPath)))
+  assert.ok(fs.existsSync(path.resolve(__dirname, productContract.href)))
+})
 
 test('nested rollback is owned by the outer boundary and finalized once', () => {
   const boundary = step('coordinate-transaction-boundary')

--- a/docs/ai/framework/plans/transaction-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/transaction-flow-inspector.data.cjs
@@ -2,7 +2,7 @@
   'use strict'
 
   const specPath =
-    'docs/ai/framework/plans/transaction-atomicity-and-rollback-plan.md'
+    'docs/ai/framework/plans/completed/transaction-atomicity-and-rollback-plan.md'
   const inspectorPath =
     'docs/ai/framework/plans/transaction-flow-inspector.data.cjs'
 
@@ -120,7 +120,7 @@
         'packages/scene-tree/src/__tests__/**',
         'packages/utils/src/types/scene-tree.ts',
         'docs/ai/framework/packages/scene-tree.md',
-        'docs/ai/framework/plans/transaction-atomicity-and-rollback-plan.md'
+        'docs/ai/framework/plans/completed/transaction-atomicity-and-rollback-plan.md'
       ],
       specRefs: ['#rollbackable-vs-undoable', '#ownership'],
       failureOwnerStepId: 'record-reversible-journal'
@@ -310,7 +310,7 @@
         'apps/asyra-design/e2e/delete-element.spec.ts',
         'docs/ai/framework/packages/factory.md',
         'docs/ai/framework/packages/scene-tree.md',
-        'docs/ai/framework/plans/transaction-atomicity-and-rollback-plan.md',
+        'docs/ai/framework/plans/completed/transaction-atomicity-and-rollback-plan.md',
         'docs/ai/framework/rules/data-flow-and-transactions.md'
       ],
       specRefs: [
@@ -638,14 +638,15 @@
     authority: {
       specPath,
       inspectorPath,
-      semanticOwner: 'transaction-atomicity-and-rollback-plan.md',
+      semanticOwner:
+        'completed/transaction-atomicity-and-rollback-plan.md',
       inspectorOwner: 'transaction-flow-inspector.data.cjs'
     },
     links: [
       {
         id: 'product-contract',
         label: 'Transaction Atomicity Contract',
-        href: './transaction-atomicity-and-rollback-plan.md',
+        href: './completed/transaction-atomicity-and-rollback-plan.md',
         kind: 'authority'
       },
       {

--- a/docs/ai/framework/plans/yjs-network-collaboration-plan.md
+++ b/docs/ai/framework/plans/yjs-network-collaboration-plan.md
@@ -32,9 +32,9 @@ Do not begin implementation until these contracts are stable:
 - load validation/migration
 - selective instance ownership and disposal
 
-Primary prerequisite:
+Primary completed prerequisite:
 
-`transaction-atomicity-and-rollback-plan.md`
+`completed/transaction-atomicity-and-rollback-plan.md`
 
 ## Goal
 

--- a/docs/ai/framework/rules/data-flow-and-transactions.md
+++ b/docs/ai/framework/rules/data-flow-and-transactions.md
@@ -133,8 +133,9 @@
   deduplication, reconnect/convergence, and collaborative conflict policy remain
   deferred to `../plans/yjs-network-collaboration-plan.md`.
 
-See `../plans/transaction-atomicity-and-rollback-plan.md` for the product cases
-and the Transaction Flow Inspector contract.
+See `../plans/completed/transaction-atomicity-and-rollback-plan.md` for the
+product cases and `../plans/transaction-flow-inspector.data.cjs` for the
+executable Transaction Flow Inspector contract.
 
 ## Validation Rule
 


### PR DESCRIPTION
## Summary
- archive the completed Transaction atomicity and rollback plan
- remove it from Near-Term Plans and advance Preset 2D/3D init profiles
- update framework references and append the completion decision history
- preserve the executable Transaction Flow Inspector data, contract test, and viewer

## Validation
- PR #77 merged CI validate: success
- ACID focused tests: 142 passed
- Transaction Inspector contract tests: 15 passed
- Flow Inspector viewer tests: 8 passed
- yarn lint:ci: 0 errors
- git diff --check: passed

## Deferred scope
- Yjs network provider, room/auth, remote apply, origin/dedupe, awareness, reconnect/convergence, and conflict policy remain deferred.