### PR TITLE
docs: close render engine boundary plan

### DIFF
--- a/docs/ai/apps/asyra-design/plans/content-panel-lock-visible-toggle-plan.md
+++ b/docs/ai/apps/asyra-design/plans/content-panel-lock-visible-toggle-plan.md
@@ -1,5 +1,0 @@
-# Plan Moved
-
-The canonical completed plan record moved to:
-
-- `docs/ai/apps/asyra-design/plans/completed/content-panel-lock-visible-toggle-plan.md`

--- a/docs/ai/apps/asyra-design/plans/init-reorganization-plan.md
+++ b/docs/ai/apps/asyra-design/plans/init-reorganization-plan.md
@@ -1,5 +1,0 @@
-# Plan Moved
-
-The canonical completed plan record moved to:
-
-- `docs/ai/apps/asyra-design/plans/completed/init-reorganization-plan.md`

--- a/docs/ai/apps/asyra-design/plans/locked-elements-canvas-selection-plan.md
+++ b/docs/ai/apps/asyra-design/plans/locked-elements-canvas-selection-plan.md
@@ -1,5 +1,0 @@
-# Plan Moved
-
-The canonical completed plan record moved to:
-
-- `docs/ai/apps/asyra-design/plans/completed/locked-elements-canvas-selection-plan.md`

--- a/docs/ai/apps/asyra-design/plans/repeatable-fills-properties-plan.md
+++ b/docs/ai/apps/asyra-design/plans/repeatable-fills-properties-plan.md
@@ -1,7 +1,0 @@
-# Plan Moved
-
-The canonical completed plan record moved to:
-
-- `docs/ai/apps/asyra-design/plans/completed/repeatable-fills-properties-plan.md`
-
-This stub remains so older decision-history references continue to resolve.

--- a/docs/ai/apps/asyra-design/plans/vector-handle-mode-plan.md
+++ b/docs/ai/apps/asyra-design/plans/vector-handle-mode-plan.md
@@ -1,5 +1,0 @@
-# Plan Moved
-
-The canonical completed plan record moved to:
-
-- `/Users/asa/Desktop/workspace/asra/docs/ai/apps/asyra-design/plans/completed/vector-handle-mode-plan.md`

--- a/docs/ai/framework/PLANS.md
+++ b/docs/ai/framework/PLANS.md
@@ -10,22 +10,13 @@ This file tracks framework planning topics and points to detailed references.
 
 ## Near-Term Plans
 
-1. Render-engine boundary
-
-- Keep `@asyra/render` as framework adapter/orchestration, extract the abstract
-  `@asyra/render-engine` contract, and move default Pixi implementation into
-  `@asyra/render-engine-pixi` before exposing render-mode-specific choices.
-- Add explicit engine injection and prove replaceability with a contract-test
-  engine without requiring a production 3D engine.
-- Reference: `docs/ai/framework/plans/render-engine-boundary-plan.md`
-
-2. Extendable preset
+1. Extendable preset
 
 - Allow users to extend preset feature/property behavior through explicit extension points.
 - Keep deterministic fallback path: `unregister -> redefine` when extension points are unavailable.
 - Reference: `docs/ai/framework/plans/extendable-preset-plan.md`
 
-3. Generic preset composition
+2. Generic preset composition
 
 - Compose shared defaults, concrete-engine bootstrap, optional capability
   bundles, and app customizations in deterministic order without publishing
@@ -34,13 +25,13 @@ This file tracks framework planning topics and points to detailed references.
   extension/replacement contract from the extendable-preset plan.
 - Reference: `docs/ai/framework/plans/preset-composition-plan.md`
 
-4. Canvas debugger
+3. Canvas debugger
 
 - Add a framework-owned debugging surface to verify render output, render-layer output, and coordinate-space correctness.
 - Keep it optional, deterministic, and renderer-boundary-safe so apps can opt in without coupling domain logic to Pixi internals.
 - Reference: `docs/ai/framework/plans/canvas-debugger-plan.md`
 
-5. Render delta update pipeline
+4. Render delta update pipeline
 
 - Apply data-channel deltas directly in render update flow to avoid full computed-data rehydrate.
 - Use render-side cached snapshots + key-based invalidation for heavy geometry.

--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -1099,3 +1099,32 @@ Backfilled entries use decision dates inferred from related commit dates/ranges.
     or render-mode selector.
 - Related Plan:
   - `docs/ai/framework/plans/render-engine-boundary-plan.md`
+
+## 2026-07-16 - Render-engine boundary completed
+
+- Context:
+  - PR #79 merged the abstract render-engine contract, Pixi concrete owner,
+    engine-neutral render adapter, preset default injection, custom-engine
+    composition path, compatibility surface, and architecture documentation.
+  - CI validation and Vercel deployment completed successfully before merge.
+- Decision:
+  - Treat the Render-Engine Boundary plan as complete with
+    `@asyra/render` owning framework orchestration,
+    `@asyra/render-engine` owning the pure contract, and
+    `@asyra/render-engine-pixi` owning concrete Pixi execution.
+  - Keep preset as the default Pixi composition owner while allowing users to
+    inject a contract-compatible custom engine.
+  - Keep production 3D, Hybrid, and render-mode selection outside this
+    completed phase.
+- Consequences:
+  - The detailed plan is archived at its completed canonical path while the
+    Render-Engine Boundary Inspector data, contract test, and viewer remain
+    executable architecture authorities.
+  - Extendable Preset becomes the first Near-Term Plan, followed by Generic
+    Preset Composition; official 2D/3D/Hybrid profiles remain deferred and
+    trigger-gated.
+- Related Plan:
+  - `docs/ai/framework/plans/completed/render-engine-boundary-plan.md`
+- Related Commit(s):
+  - `f185f026cef3b47127003651697bdbf7a8708889` (`feat(render): add replaceable render engine boundary (#79)`)
+  - [PR #79](https://github.com/karote00/asyra/pull/79)

--- a/docs/ai/framework/plans/completed/render-engine-boundary-plan.md
+++ b/docs/ai/framework/plans/completed/render-engine-boundary-plan.md
@@ -2,15 +2,32 @@
 
 ## Status and Roadmap Position
 
-First near-term architecture plan after transaction closeout.
+Completed on 2026-07-16. PR #79 merged the replaceable render-engine boundary
+to `main` at merge commit `f185f026cef3b47127003651697bdbf7a8708889`.
+`@asyra/render` remains the stable framework adapter/orchestration package,
+`@asyra/render-engine` owns the pure contract, and
+`@asyra/render-engine-pixi` owns the default Pixi implementation.
 
-This plan must complete before generic preset composition can accept a concrete
-engine factory and before any official `2d`, `3d`, or `hybrid` preset profile is
-considered. It defines render-engine replaceability while keeping
-`@asyra/render` as the stable framework render package.
+This completed phase covers only the existing Pixi-backed 2D behavior. It does
+not implement or advertise a production 3D engine, Hybrid runtime, or render
+mode selection.
 
-This phase focuses only on the existing Pixi-backed 2D behavior. It does not
-implement or advertise a production 3D engine or hybrid runtime.
+## Completion Record
+
+- Final decision: accept the three-package owner boundary and keep concrete
+  engine selection in composition rather than framework state or render mode.
+- Implementation summary: preset injects Pixi by default, custom engines use
+  the same abstract contract, render remains engine-neutral, and formal
+  contract adapters prove lifecycle, interaction, cleanup, and instance
+  isolation.
+- Compatibility summary: existing framework-facing render APIs and Asyra
+  Design startup remain compatible; `PixiJSRenderer` is retained only as the
+  documented deprecated compatibility alias for its planned migration window.
+- Exit criteria: PR #79 CI and deployment checks passed; package, dependency,
+  Inspector, app, lint, build, and interaction validation passed; framework
+  architecture docs contain the implemented package diagram.
+- Canonical executable architecture contract:
+  `docs/ai/framework/plans/render-engine-boundary-flow-inspector.data.cjs`.
 
 ## Goal
 

--- a/docs/ai/framework/plans/render-engine-boundary-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/render-engine-boundary-flow-inspector.contract.test.cjs
@@ -17,14 +17,25 @@ const route = (id) => {
   return value
 }
 
-test('active render-engine plan remains the resolvable product authority', () => {
+test('completed render-engine plan remains the resolvable product authority', () => {
   const repoRoot = path.resolve(__dirname, '../../../..')
+  const formerActiveSpecPath =
+    'docs/ai/framework/plans/render-engine-boundary-plan.md'
+  const productContract = data.links.find(
+    (link) => link.id === 'product-contract'
+  )
 
+  assert.ok(productContract, 'Missing product-contract Inspector link')
   assert.equal(
     data.authority.specPath,
-    'docs/ai/framework/plans/render-engine-boundary-plan.md'
+    'docs/ai/framework/plans/completed/render-engine-boundary-plan.md'
   )
   assert.ok(fs.existsSync(path.resolve(repoRoot, data.authority.specPath)))
+  assert.ok(fs.existsSync(path.resolve(__dirname, productContract.href)))
+  assert.equal(
+    fs.existsSync(path.resolve(repoRoot, formerActiveSpecPath)),
+    false
+  )
 })
 
 test('preset selects the default engine without becoming its runtime owner', () => {
@@ -110,10 +121,7 @@ test('architecture documentation sync stays with the matching owner steps', () =
         'docs/ai/framework/decisions/releases/unreleased.md'
       ]
     ],
-    [
-      'orchestrate-render-adapter',
-      ['docs/ai/framework/packages/render.md']
-    ],
+    ['orchestrate-render-adapter', ['docs/ai/framework/packages/render.md']],
     [
       'execute-render-engine',
       ['docs/ai/framework/packages/render-engine-pixi.md']

--- a/docs/ai/framework/plans/render-engine-boundary-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/render-engine-boundary-flow-inspector.data.cjs
@@ -1,7 +1,8 @@
 ;(function () {
   'use strict'
 
-  const specPath = 'docs/ai/framework/plans/render-engine-boundary-plan.md'
+  const specPath =
+    'docs/ai/framework/plans/completed/render-engine-boundary-plan.md'
   const inspectorPath =
     'docs/ai/framework/plans/render-engine-boundary-flow-inspector.data.cjs'
 
@@ -1049,14 +1050,14 @@
     authority: {
       specPath,
       inspectorPath,
-      semanticOwner: 'render-engine-boundary-plan.md',
+      semanticOwner: 'completed/render-engine-boundary-plan.md',
       inspectorOwner: 'render-engine-boundary-flow-inspector.data.cjs'
     },
     links: [
       {
         id: 'product-contract',
         label: 'Render-Engine Boundary Plan',
-        href: './render-engine-boundary-plan.md',
+        href: './completed/render-engine-boundary-plan.md',
         kind: 'authority'
       },
       {


### PR DESCRIPTION
## Summary

- archive the completed render-engine boundary plan and remove it from the active framework plan index
- point the Render-Engine Inspector authority at the completed plan and append the final decision record
- remove five Asyra Design Plan Moved stubs so completed records exist only under plans/completed

## Validation

- Render-Engine Inspector contract: 12/12 passed
- scoped Prettier check passed
- git diff --check passed
- framework and Asyra Design completed-plan pointer scan: 0 remaining