### PR TITLE
docs(framework): plan property type redefinition

### DIFF
--- a/docs/ai/framework/API_SURFACES.md
+++ b/docs/ai/framework/API_SURFACES.md
@@ -41,6 +41,14 @@ Lifecycle and integration:
   - graph-aware full-capability removal; detaches structural dependents,
     recursively unregisters declared hard dependents, and cleans schema/runtime
     resources
+- planned, not yet implemented:
+  - `getPropertyTypeDefinition(type)` returns a detached normalized config-mode
+    field definition
+  - `redefinePropertyType(type, updater)` atomically rebuilds that definition
+    during open composition
+  - authority: `plans/property-type-redefinition-plan.md`
+  - the planned API is not a general registry replace path and does not rewrite
+    relations, render strategies, UI properties, or migrations
 - component relation APIs:
   - `defineComponent(definition: ComponentDefinition): void`
   - `unregisterComponent(type, options?): boolean | UnregisterComponentResult`

--- a/docs/ai/framework/ARCHITECTURE.md
+++ b/docs/ai/framework/ARCHITECTURE.md
@@ -201,6 +201,11 @@ applyPreset(core, { profile?, defaults? })
 - There is no semantic-equivalence or replace operation. A full implementation
   change is `unregister default -> define custom`; a non-equivalent structural
   change is `remove old relation -> define new relation`.
+- A bounded pre-start declarative property-type redefinition API is planned in
+  `plans/property-type-redefinition-plan.md`. It will atomically rebuild one
+  config-mode schema/runtime definition without inferring semantic equivalence
+  or adding a general registry replace operation. Until implemented, the
+  current unregister-then-define contract remains authoritative.
 - The first `core.start()` closes composition permanently before renderer side
   effects and validates declared relations. Registration composition is not a
   runtime mutation or migration mechanism.

--- a/docs/ai/framework/PLANS.md
+++ b/docs/ai/framework/PLANS.md
@@ -14,7 +14,18 @@ This file tracks framework planning topics and points to detailed references.
   missing output from debug geometry.
 - Reference: `docs/ai/framework/plans/canvas-pipeline-debugger-plan.md`
 
-2. Render delta update pipeline
+2. Declarative property type redefinition
+
+- Let app developers inspect and atomically redefine one config-mode property
+  type after preset composition and before `core.start()`.
+- Keep relation, render strategy, UI-context, and migration changes explicit
+  through existing Core APIs; do not infer that removed and added fields are
+  semantically equivalent.
+- Provide typed custom-field consumption without requiring app casts in the
+  normal property update, render strategy, or UI aggregation paths.
+- Reference: `docs/ai/framework/plans/property-type-redefinition-plan.md`
+
+3. Render delta update pipeline
 
 - Apply data-channel deltas directly in render update flow to avoid full computed-data rehydrate.
 - Use render-side cached snapshots + key-based invalidation for heavy geometry.

--- a/docs/ai/framework/REQUEST_ROUTING.md
+++ b/docs/ai/framework/REQUEST_ROUTING.md
@@ -43,6 +43,8 @@ Use this file to route a new framework request to the right docs first.
   - `packages/core.md`
   - `packages/props-manager.md`
   - `rules/extension-patterns.md`
+  - planned config-mode field customization:
+    `plans/property-type-redefinition-plan.md`
 
 - render engine abstraction and custom render layers
   - `packages/render.md`

--- a/docs/ai/framework/golden-paths/extend-preset-capability.md
+++ b/docs/ai/framework/golden-paths/extend-preset-capability.md
@@ -106,6 +106,17 @@ If a Whiteboard changes Filled shapes into outline-only shapes, it explicitly
 unregisters/registers its Rectangle/Oval render strategies and any app UI
 registrations that differ from the preset.
 
+## Planned Fixed-Field Redefinition
+
+The planned `core.redefinePropertyType(...)` flow is specified by
+`docs/ai/framework/plans/property-type-redefinition-plan.md`. It will provide a
+single atomic config-mode schema/runtime field redefinition during open
+composition. It will not redefine component/child relations, render strategies,
+UI properties, app commands, or migrations.
+
+Until the plan is implemented, the complete-property unregister-then-define
+route above remains the executable golden path.
+
 ## Migration
 
 Registration composition never migrates documents. For an app version change,

--- a/docs/ai/framework/packages/core.md
+++ b/docs/ai/framework/packages/core.md
@@ -207,6 +207,18 @@ System orchestrator and lifecycle coordinator.
 - Core/scene-tree bridge rule: scene-tree recompute should react to committed props transactions, not be manually duplicated in app handlers.
 - Cross-cutting domain logic belongs in app/common APIs, not core.
 
+## Planned Declarative Property Type Redefinition
+
+`plans/property-type-redefinition-plan.md` defines a not-yet-implemented,
+pre-start Core facade for reading and atomically redefining one config-mode
+property type. Core will coordinate the permanent composition lock, graph owner
+metadata, preserved relations, and final structural validation while Props
+Manager remains the schema/runtime rebuild owner.
+
+The planned operation is a bounded declarative exception, not a general replace
+strategy. Render strategies, UI properties, relations, app commands, and load
+migrations remain explicit ordinary app composition.
+
 ## Validation Checklist
 
 - Core initialization works without UI framework assumptions.

--- a/docs/ai/framework/packages/preset.md
+++ b/docs/ai/framework/packages/preset.md
@@ -124,6 +124,12 @@ core.registerRenderStrategy('rect', productRectangleStrategy)
 await core.start(container, renderOptions)
 ```
 
+Planned config-mode field customization is tracked by
+`plans/property-type-redefinition-plan.md`. It will use the same public Core
+facade after `applyPreset(core)` and will not add a preset-specific extension or
+replacement object. Until that API is implemented, apps use the existing
+explicit unregister-then-define route.
+
 ## Validation Checklist
 
 - imports are side-effect free;

--- a/docs/ai/framework/packages/props-manager.md
+++ b/docs/ai/framework/packages/props-manager.md
@@ -94,6 +94,19 @@ packages/props-manager/src/
 - property schema registration
 - state registry for UI/derived helpers
 
+## Planned Declarative Redefinition
+
+`plans/property-type-redefinition-plan.md` assigns Props Manager the planned
+normalized definition projection and atomic schema/config-runtime rebuild for
+config-mode property types. The implementation must stage the complete next
+schema and constructor before mutation, preserve child configuration, reject
+active or replay-retained use, and restore the exact old definition on any
+failure.
+
+Constructor-mode behavior, semantic field migration, relation changes, render,
+and UI remain outside this owner. The current unregister-then-define APIs remain
+authoritative until the plan is implemented.
+
 ## Notes
 
 - `manager/props-manager.ts` is the runtime center for add/remove/update/load/save.

--- a/docs/ai/framework/packages/render.md
+++ b/docs/ai/framework/packages/render.md
@@ -44,6 +44,12 @@ Render strategies registered through Core may include local
 the graph never inspects strategy code. `unregisterRenderStrategy(type)` removes
 the named strategy and its graph relations without inferring a product mode.
 
+Planned app-defined field typing is tracked by
+`plans/property-type-redefinition-plan.md`. It will let an
+`EngineNeutralRenderStrategy` declare its custom computed-data shape without an
+unsafe cast. The plan changes type ergonomics only: render remains downstream,
+engine-neutral, and unaware of property meaning.
+
 ## Runtime Contracts
 
 1. State-driven rendering

--- a/docs/ai/framework/packages/scene-tree.md
+++ b/docs/ai/framework/packages/scene-tree.md
@@ -49,6 +49,11 @@ Own the document entity graph and computed entity data.
 - register component-level computed defaults and normalization behavior
 - validate load payload via `validateLoadData(...)` before apply
 
+Planned app-defined field typing is tracked by
+`plans/property-type-redefinition-plan.md`. Scene Tree will continue to project
+the canonical result of property `getValue()` into computed element data; it
+will not interpret custom field meaning or become a second schema owner.
+
 ## Validation Checklist
 
 - Entity creation updates graph + computed data consistently.

--- a/docs/ai/framework/packages/ui-context.md
+++ b/docs/ai/framework/packages/ui-context.md
@@ -22,6 +22,12 @@ Derived UI-property registration and aggregation runtime.
 
 Apps can bypass ui-context and compute their own derived state from framework subscriptions.
 
+Planned app-defined field typing is tracked by
+`plans/property-type-redefinition-plan.md`. It will allow an app UI-property
+compute callback to declare its custom element-data shape without making
+ui-context canonical property state or automatically creating UI behavior for
+new fields.
+
 ## Runtime Contracts
 
 1. Registration

--- a/docs/ai/framework/plans/property-type-redefinition-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/property-type-redefinition-flow-inspector.contract.test.cjs
@@ -1,0 +1,180 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const data = require('./property-type-redefinition-flow-inspector.data.cjs')
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+const step = (id) => {
+  const value = data.steps.find((item) => item.id === id)
+  assert.ok(value, `Missing Inspector step: ${id}`)
+  return value
+}
+
+const route = (id) => {
+  const value = data.routes.find((item) => item.id === id)
+  assert.ok(value, `Missing Inspector route: ${id}`)
+  return value
+}
+
+const contractText = (owner) =>
+  [
+    owner.purpose,
+    ...owner.inputs,
+    ...owner.outputs,
+    ...owner.conditions,
+    ...owner.bypasses,
+    ...owner.allowedContributors,
+    ...owner.forbiddenContributors,
+    ...owner.implementationBoundary
+  ].join(' ')
+
+test('plan and dedicated Inspector remain resolvable authorities', () => {
+  const productLink = data.links.find((link) => link.id === 'product-contract')
+
+  assert.equal(
+    data.authority.specPath,
+    'docs/ai/framework/plans/property-type-redefinition-plan.md'
+  )
+  assert.equal(
+    data.authority.inspectorPath,
+    'docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs'
+  )
+  assert.ok(productLink)
+  assert.ok(fs.existsSync(path.resolve(repoRoot, data.authority.specPath)))
+  assert.ok(fs.existsSync(path.resolve(__dirname, productLink.href)))
+  assert.ok(
+    fs.existsSync(
+      path.resolve(
+        repoRoot,
+        'docs/ai/framework/plans/property-type-redefinition-flow-inspector.html'
+      )
+    )
+  )
+})
+
+test('app composition uses public Core and keeps semantic consumers explicit', () => {
+  const app = step('compose-property-customization')
+  const contract = contractText(app)
+
+  assert.equal(app.ownerPackage, 'app or user composition')
+  assert.match(contract, /applyPreset\(core\)/)
+  assert.match(contract, /before the first core\.start\(\)/i)
+  assert.match(contract, /relations.*render strategies.*UI properties.*migration/i)
+  assert.match(contract, /public Core instance/i)
+  assert.match(contract, /deep imports/i)
+  assert.match(contract, /direct Props Manager singleton/i)
+  assert.match(contract, /fallback B-to-C mapping/i)
+  assert.deepEqual(app.cacheDimensions, [])
+})
+
+test('Core coordinates a bounded pre-start redefinition without general replace semantics', () => {
+  const core = step('coordinate-property-redefinition')
+  const contract = contractText(core)
+
+  assert.equal(core.ownerPackage, '@asyra/core')
+  assert.match(contract, /read request.*never mutates/i)
+  assert.match(contract, /open composition/i)
+  assert.match(contract, /same type/i)
+  assert.match(contract, /owner metadata changes to the app only after/i)
+  assert.match(contract, /relations are preserved/i)
+  assert.match(contract, /stale fixed component aliases or property-child keys/i)
+  assert.match(contract, /general registry overwrite/i)
+  assert.match(contract, /runtime redefinition after core\.start/i)
+})
+
+test('Props Manager owns detached projection and atomic schema/runtime rebuild', () => {
+  const owner = step('rebuild-declarative-property-type')
+  const contract = contractText(owner)
+
+  assert.equal(owner.ownerPackage, '@asyra/props-manager')
+  assert.match(contract, /deeply detached/i)
+  assert.match(contract, /constructor mode/i)
+  assert.match(contract, /active instances.*replay-retained instances/i)
+  assert.match(contract, /schema and constructor are staged before/i)
+  assert.match(contract, /swaps schema and runtime together/i)
+  assert.match(contract, /preserving the exact existing child configuration/i)
+  assert.match(contract, /invalid-reject/i)
+  assert.match(contract, /deterministic fallback/i)
+  assert.match(contract, /retains the exact prior schema and constructor/i)
+})
+
+test('Scene Tree projects only canonical property values', () => {
+  const projection = step('project-property-values')
+  const contract = contractText(projection)
+
+  assert.equal(projection.ownerPackage, '@asyra/scene-tree')
+  assert.match(contract, /complete getValue result/i)
+  assert.match(contract, /Removed fixed fields are not reconstructed/i)
+  assert.match(contract, /schema\/default reconstruction inside Scene Tree/i)
+  assert.match(contract, /fallback values for removed or missing fields/i)
+})
+
+test('render and UI consumers are typed, explicit, and remain downstream', () => {
+  const render = step('consume-typed-render-data')
+  const ui = step('derive-typed-ui-data')
+  const renderContract = contractText(render)
+  const uiContract = contractText(ui)
+
+  assert.equal(render.ownerPackage, '@asyra/render')
+  assert.match(renderContract, /app-declared custom data shape/i)
+  assert.match(renderContract, /strategy alone decides/i)
+  assert.match(renderContract, /Pixi or concrete render-engine types/i)
+  assert.match(renderContract, /fallback geometry/i)
+
+  assert.equal(ui.ownerPackage, '@asyra/ui-context')
+  assert.match(uiContract, /app-declared element data type/i)
+  assert.match(uiContract, /No UI registration is required/i)
+  assert.match(uiContract, /derived-state runtime/i)
+  assert.match(uiContract, /canonical property ownership/i)
+})
+
+test('routes preserve owner boundaries for definition read, rebuild, and consumers', () => {
+  assert.deepEqual(
+    [
+      route('read-owner-definition').from,
+      route('read-owner-definition').to
+    ],
+    ['coordinate-property-redefinition', 'rebuild-declarative-property-type']
+  )
+  assert.deepEqual(
+    [
+      route('request-atomic-rebuild').from,
+      route('request-atomic-rebuild').to
+    ],
+    ['coordinate-property-redefinition', 'rebuild-declarative-property-type']
+  )
+  assert.equal(
+    route('register-app-render-consumer').to,
+    'consume-typed-render-data'
+  )
+  assert.equal(
+    route('register-app-ui-consumer').to,
+    'derive-typed-ui-data'
+  )
+  assert.equal(route('register-app-load-migration').kind, 'terminal')
+})
+
+test('product contract names bounded cases and rejects scope expansion', () => {
+  const spec = fs.readFileSync(
+    path.resolve(__dirname, 'property-type-redefinition-plan.md'),
+    'utf8'
+  )
+  const acceptance = data.acceptanceContracts
+    .flatMap((contract) => contract.assertions)
+    .join(' ')
+
+  assert.match(spec, /Add field:/)
+  assert.match(spec, /Remove field:/)
+  assert.match(spec, /Nested boundary:/)
+  assert.match(spec, /Failure atomicity:/)
+  assert.match(spec, /Typed consumers:/)
+  assert.match(spec, /no nested\s+property-path API/is)
+  assert.match(spec, /general registry replace operation/i)
+  assert.match(spec, /Definition Of Done/)
+  assert.match(acceptance, /without a preset deep import/i)
+  assert.match(acceptance, /without unsafe casts/i)
+  assert.match(acceptance, /semantic document conversion stays app-owned/i)
+})

--- a/docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs
@@ -1,0 +1,727 @@
+;(function () {
+  'use strict'
+
+  const specPath =
+    'docs/ai/framework/plans/property-type-redefinition-plan.md'
+  const inspectorPath =
+    'docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs'
+
+  const lanes = [
+    { id: 'app', title: 'App Composition', order: 1 },
+    { id: 'core', title: 'Core Coordination', order: 2 },
+    { id: 'property', title: 'Property Runtime', order: 3 },
+    { id: 'projection', title: 'Typed Projections', order: 4 }
+  ]
+
+  const steps = [
+    {
+      id: 'compose-property-customization',
+      order: 1,
+      laneId: 'app',
+      title: 'Compose property customization',
+      ownerPackage: 'app or user composition',
+      purpose:
+        'Inspect or redefine one declarative property type and explicitly adapt every app-owned semantic consumer before startup.',
+      inputs: [
+        'optional applyPreset(core) result',
+        'app-owned field semantics and local custom-field types',
+        'artifact:property-definition-view',
+        'artifact:property-redefinition-result'
+      ],
+      outputs: [
+        'artifact:property-definition-request',
+        'artifact:app-render-strategy-registration',
+        'artifact:app-ui-property-registration',
+        'artifact:app-load-migration'
+      ],
+      conditions: [
+        'Use only the public Core instance after optional preset application and before the first core.start().',
+        'The app updater supplies one complete next fixed-field definition and does not claim that removed B and added C are semantically equivalent.',
+        'Affected relations, render strategies, UI properties, commands, and migration are adapted explicitly through their existing APIs or app code.',
+        'A semantic B-to-C document transform is registered as an app load migration before package validation.'
+      ],
+      bypasses: [
+        'An app that accepts the preset definition performs no redefinition or consumer replacement.',
+        'A custom field with no UI meaning requires no UI-context registration.',
+        'A read-only definition request produces no schema, runtime, relation, render, UI, or migration mutation.'
+      ],
+      allowedContributors: [
+        '@asyra/core public facade',
+        '@asyra/preset public applyPreset entrypoint',
+        'app-owned render strategy, UI property, command, and migration definitions'
+      ],
+      forbiddenContributors: [
+        'preset or framework deep imports',
+        'direct Props Manager singleton or registry mutation',
+        'Pixi or concrete render-engine data',
+        'automatic consumer rewriting or fallback B-to-C mapping'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'docs/ai/framework/golden-paths/extend-preset-capability.md',
+        'docs/ai/framework/API_SURFACES.md',
+        'packages/preset/src/__tests__/**',
+        'packages/core/src/__tests__/**'
+      ],
+      specRefs: [
+        '#product-contract',
+        '#app-consumer-flow',
+        '#product-cases'
+      ],
+      failureOwnerStepId: 'compose-property-customization'
+    },
+    {
+      id: 'coordinate-property-redefinition',
+      order: 1,
+      laneId: 'core',
+      title: 'Coordinate property redefinition',
+      ownerPackage: '@asyra/core',
+      purpose:
+        'Expose the app-facing read/redefine facade, enforce composition state, coordinate the atomic owner call, and preserve graph relations.',
+      inputs: [
+        'artifact:property-definition-request',
+        'artifact:current-property-definition',
+        'artifact:committed-property-definition',
+        'Core composition lock and RegistrationGraph'
+      ],
+      outputs: [
+        'artifact:definition-read-request',
+        'artifact:property-definition-view',
+        'artifact:definition-rebuild-request',
+        'artifact:property-redefinition-result'
+      ],
+      conditions: [
+        'A read request returns a detached definition and never mutates graph or registries.',
+        'A redefine request requires open composition, no pending cleanup, one existing property identity, and the same type in the updater result.',
+        'Graph owner metadata changes to the app only after Props Manager reports an atomic committed definition.',
+        'Incoming and outgoing relations are preserved; final startup validation rejects stale fixed component aliases or property-child keys.',
+        'The Core type facade supports app-declared id-first property fields without an unsafe cast.'
+      ],
+      bypasses: [
+        'getPropertyTypeDefinition bypasses updater execution, rebuild, owner transfer, and relation validation changes.',
+        'A missing type returns undefined only for the getter; redefine fails through the stable property registration error contract.',
+        'Dynamic property aliases follow their explicit dynamic-key policy rather than fixed-field closure validation.'
+      ],
+      allowedContributors: [
+        '@asyra/props-manager definition owner API',
+        'Core RegistrationGraph and permanent composition lock',
+        'existing component/property relation metadata'
+      ],
+      forbiddenContributors: [
+        'partial direct writes to schema or constructor registries',
+        'general registry overwrite or duplicate tolerance',
+        'semantic inspection of render, UI, feature, or migration functions',
+        'runtime redefinition after core.start()'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/core/src/core.ts',
+        'packages/core/src/index.ts',
+        'packages/core/src/types/**',
+        'packages/core/src/__tests__/**',
+        'docs/ai/framework/packages/core.md',
+        'docs/ai/framework/API_SURFACES.md'
+      ],
+      specRefs: [
+        '#public-api',
+        '#composition-and-atomicity',
+        '#ownership-and-boundaries'
+      ],
+      failureOwnerStepId: 'coordinate-property-redefinition'
+    },
+    {
+      id: 'rebuild-declarative-property-type',
+      order: 1,
+      laneId: 'property',
+      title: 'Rebuild declarative property type',
+      ownerPackage: '@asyra/props-manager',
+      purpose:
+        'Project one normalized config-mode definition, validate the complete next definition, and atomically swap schema and runtime.',
+      inputs: [
+        'artifact:definition-read-request',
+        'artifact:definition-rebuild-request',
+        'registered property schema and config-mode runtime definition',
+        'active and replay-retained property usage'
+      ],
+      outputs: [
+        'artifact:current-property-definition',
+        'artifact:committed-property-definition',
+        'artifact:canonical-property-values'
+      ],
+      conditions: [
+        'The read projection normalizes every fixed key into one kind, default, validator, persist, project, and unit contract.',
+        'Returned definitions are deeply detached from registry state.',
+        'Redefinition rejects constructor mode, active instances, replay-retained instances, duplicate/reserved keys, invalid defaults, and schema/runtime drift.',
+        'The complete next schema and constructor are staged before either registry changes.',
+        'Commit swaps schema and runtime together while preserving the exact existing child configuration.',
+        'Runtime writes remain valid-write or invalid-reject; load remains valid-write or deterministic fallback.'
+      ],
+      bypasses: [
+        'A read-only request projects the current definition without staging or registry mutation.',
+        'Fields with project false do not enter getValue output.',
+        'Fields with persist false do not enter saved property data.',
+        'Any updater, validation, staging, or commit failure retains the exact prior schema and constructor.'
+      ],
+      allowedContributors: [
+        'property schema registry',
+        'config-mode property component definition registry',
+        'PropsManager active and replay-retained usage query',
+        'Base property validation and config-mode constructor builder'
+      ],
+      forbiddenContributors: [
+        'constructor-mode behavior introspection',
+        'app document migration policy',
+        'component or child relation mutation',
+        'render/UI fallback values or semantic field mapping'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/props-manager/src/registries/**',
+        'packages/props-manager/src/manager/props-manager.ts',
+        'packages/props-manager/src/components/base.ts',
+        'packages/props-manager/src/index.ts',
+        'packages/props-manager/src/__tests__/**',
+        'docs/ai/framework/packages/props-manager.md'
+      ],
+      specRefs: [
+        '#definition-model',
+        '#composition-and-atomicity',
+        '#product-cases'
+      ],
+      failureOwnerStepId: 'rebuild-declarative-property-type'
+    },
+    {
+      id: 'project-property-values',
+      order: 2,
+      laneId: 'property',
+      title: 'Project canonical property values',
+      ownerPackage: '@asyra/scene-tree',
+      purpose:
+        'Merge the canonical property getValue result into computed element data without interpreting app field semantics.',
+      inputs: [
+        'artifact:canonical-property-values',
+        'registered component-property relation and aliases'
+      ],
+      outputs: ['artifact:computed-element-data'],
+      conditions: [
+        'Computed setup and property subscriptions consume only the complete getValue result.',
+        'Normal Core changeComputedData and owner-aware property commits refresh the same canonical projection.',
+        'Removed fixed fields are not reconstructed in computed data.'
+      ],
+      bypasses: [
+        'A property field omitted from getValue because project is false produces no computed field.',
+        'A component without the property relation receives no value from that property type.'
+      ],
+      allowedContributors: [
+        'artifact:canonical-property-values',
+        '@asyra/scene-tree Computed property subscriptions',
+        'registered component-property relations'
+      ],
+      forbiddenContributors: [
+        'schema/default reconstruction inside Scene Tree',
+        'render strategy or UI compute functions',
+        'fallback values for removed or missing fields'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/scene-tree/src/components/computed.ts',
+        'packages/scene-tree/src/create-dynamic-props.ts',
+        'packages/scene-tree/src/__tests__/**',
+        'docs/ai/framework/packages/scene-tree.md'
+      ],
+      specRefs: [
+        '#app-consumer-flow',
+        '#ownership-and-boundaries',
+        '#product-cases'
+      ],
+      failureOwnerStepId: 'project-property-values'
+    },
+    {
+      id: 'consume-typed-render-data',
+      order: 1,
+      laneId: 'projection',
+      title: 'Consume typed render data',
+      ownerPackage: '@asyra/render',
+      purpose:
+        'Deliver app-declared computed fields to an engine-neutral render strategy without unsafe casts or semantic inference.',
+      inputs: [
+        'artifact:computed-element-data',
+        'artifact:app-render-strategy-registration'
+      ],
+      outputs: ['artifact:typed-render-consumption'],
+      conditions: [
+        'EngineNeutralRenderStrategy accepts an app-declared custom data shape while retaining required RenderElementData fields.',
+        'The registered strategy alone decides how C affects engine-neutral drawing.'
+      ],
+      bypasses: [
+        'If the app keeps the existing strategy, the framework does not infer whether it understands the redefined fields.',
+        'A field unused by render requires no render strategy change.'
+      ],
+      allowedContributors: [
+        'artifact:computed-element-data',
+        'app-registered engine-neutral render strategy',
+        '@asyra/render graphics abstractions'
+      ],
+      forbiddenContributors: [
+        'Pixi or concrete render-engine types',
+        'property registry reads from the render callback',
+        'automatic B-to-C draw behavior',
+        'fallback geometry for an unadapted strategy'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/render/src/types/render-strategy.ts',
+        'packages/render/src/types.ts',
+        'packages/render/src/index.ts',
+        'packages/render/src/__tests__/**',
+        'docs/ai/framework/packages/render.md'
+      ],
+      specRefs: [
+        '#app-consumer-flow',
+        '#ownership-and-boundaries',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'consume-typed-render-data'
+    },
+    {
+      id: 'derive-typed-ui-data',
+      order: 2,
+      laneId: 'projection',
+      title: 'Derive typed UI data',
+      ownerPackage: '@asyra/ui-context',
+      purpose:
+        'Let an optional app UI property compute from app-declared custom element fields without becoming model authority.',
+      inputs: [
+        'artifact:computed-element-data',
+        'artifact:app-ui-property-registration'
+      ],
+      outputs: ['artifact:derived-ui-value'],
+      conditions: [
+        'PropertyComputeContext exposes the app-declared element data type to the app compute callback.',
+        'The app registration explicitly owns aggregate, mixed, empty, and selection behavior for C.'
+      ],
+      bypasses: [
+        'No UI registration is required when C has no UI meaning.',
+        'Apps may bypass ui-context and derive their own UI state from framework subscriptions.'
+      ],
+      allowedContributors: [
+        'artifact:computed-element-data',
+        'app-defined UI property registration',
+        '@asyra/ui-context derived-state runtime'
+      ],
+      forbiddenContributors: [
+        'canonical property ownership',
+        'automatic UI controls, formatter, or B-to-C mapping',
+        'render or render-engine state'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/ui-context/src/property-registry.ts',
+        'packages/ui-context/src/ui-context.ts',
+        'packages/ui-context/src/index.ts',
+        'packages/ui-context/src/__tests__/**',
+        'docs/ai/framework/packages/ui-context.md'
+      ],
+      specRefs: [
+        '#app-consumer-flow',
+        '#ownership-and-boundaries',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'derive-typed-ui-data'
+    }
+  ]
+
+  const routes = [
+    {
+      id: 'request-property-definition',
+      from: 'compose-property-customization',
+      to: 'coordinate-property-redefinition',
+      kind: 'composition',
+      predicate:
+        'The app requests either a read-only definition view or a pre-start redefinition.',
+      producedArtifacts: ['artifact:property-definition-request']
+    },
+    {
+      id: 'read-owner-definition',
+      from: 'coordinate-property-redefinition',
+      to: 'rebuild-declarative-property-type',
+      kind: 'composition',
+      predicate:
+        'Core has resolved the property identity and requests the owner-normalized definition.',
+      producedArtifacts: ['artifact:definition-read-request']
+    },
+    {
+      id: 'return-current-definition',
+      from: 'rebuild-declarative-property-type',
+      to: 'coordinate-property-redefinition',
+      kind: 'data',
+      predicate: 'Props Manager can project a complete config-mode definition.',
+      producedArtifacts: ['artifact:current-property-definition']
+    },
+    {
+      id: 'return-definition-view',
+      from: 'coordinate-property-redefinition',
+      to: 'compose-property-customization',
+      kind: 'data',
+      predicate:
+        'The app requested getPropertyTypeDefinition or Core is supplying the updater input.',
+      producedArtifacts: ['artifact:property-definition-view']
+    },
+    {
+      id: 'request-atomic-rebuild',
+      from: 'coordinate-property-redefinition',
+      to: 'rebuild-declarative-property-type',
+      kind: 'composition',
+      predicate:
+        'The synchronous updater returned a same-identity complete next definition during open composition.',
+      producedArtifacts: ['artifact:definition-rebuild-request']
+    },
+    {
+      id: 'return-committed-definition',
+      from: 'rebuild-declarative-property-type',
+      to: 'coordinate-property-redefinition',
+      kind: 'data',
+      predicate:
+        'Schema and config-mode runtime committed atomically with preserved child configuration.',
+      producedArtifacts: ['artifact:committed-property-definition']
+    },
+    {
+      id: 'return-redefinition-result',
+      from: 'coordinate-property-redefinition',
+      to: 'compose-property-customization',
+      kind: 'data',
+      predicate:
+        'Core updated app owner metadata after the owner commit and detached the result.',
+      producedArtifacts: ['artifact:property-redefinition-result']
+    },
+    {
+      id: 'register-app-render-consumer',
+      from: 'compose-property-customization',
+      to: 'consume-typed-render-data',
+      kind: 'composition',
+      predicate: 'The redefined field changes a shape render strategy.',
+      producedArtifacts: ['artifact:app-render-strategy-registration']
+    },
+    {
+      id: 'register-app-ui-consumer',
+      from: 'compose-property-customization',
+      to: 'derive-typed-ui-data',
+      kind: 'composition',
+      predicate: 'The redefined field has app UI or aggregate meaning.',
+      producedArtifacts: ['artifact:app-ui-property-registration']
+    },
+    {
+      id: 'register-app-load-migration',
+      from: 'compose-property-customization',
+      kind: 'terminal',
+      predicate:
+        'Persisted app documents require a semantic old-field to new-field conversion before validation.',
+      producedArtifacts: ['artifact:app-load-migration']
+    },
+    {
+      id: 'project-canonical-values',
+      from: 'rebuild-declarative-property-type',
+      to: 'project-property-values',
+      kind: 'runtime',
+      predicate:
+        'A post-start property instance initializes or changes through the redefined canonical runtime.',
+      producedArtifacts: ['artifact:canonical-property-values']
+    },
+    {
+      id: 'deliver-render-data',
+      from: 'project-property-values',
+      to: 'consume-typed-render-data',
+      kind: 'data',
+      predicate: 'The element type has a registered render strategy.',
+      producedArtifacts: ['artifact:computed-element-data']
+    },
+    {
+      id: 'deliver-ui-compute-data',
+      from: 'project-property-values',
+      to: 'derive-typed-ui-data',
+      kind: 'data',
+      predicate: 'A registered UI property recomputes from the affected elements.',
+      producedArtifacts: ['artifact:computed-element-data']
+    },
+    {
+      id: 'publish-typed-render-consumption',
+      from: 'consume-typed-render-data',
+      kind: 'terminal',
+      predicate:
+        'The app render strategy consumes its declared custom field and emits engine-neutral drawing operations.',
+      producedArtifacts: ['artifact:typed-render-consumption']
+    },
+    {
+      id: 'publish-derived-ui-value',
+      from: 'derive-typed-ui-data',
+      kind: 'terminal',
+      predicate:
+        'The optional UI property publishes the app-owned derived value.',
+      producedArtifacts: ['artifact:derived-ui-value']
+    }
+  ]
+
+  const artifacts = [
+    {
+      id: 'artifact:property-definition-request',
+      title: 'Property definition read or redefine request',
+      ownerStepId: 'compose-property-customization',
+      channel: 'Core public facade call',
+      terminal: false,
+      consumerStepIds: ['coordinate-property-redefinition']
+    },
+    {
+      id: 'artifact:app-render-strategy-registration',
+      title: 'App-owned render strategy registration',
+      ownerStepId: 'compose-property-customization',
+      channel: 'Core render strategy facade',
+      terminal: false,
+      consumerStepIds: ['consume-typed-render-data']
+    },
+    {
+      id: 'artifact:app-ui-property-registration',
+      title: 'App-owned UI property registration',
+      ownerStepId: 'compose-property-customization',
+      channel: 'Core UI property facade',
+      terminal: false,
+      consumerStepIds: ['derive-typed-ui-data']
+    },
+    {
+      id: 'artifact:app-load-migration',
+      title: 'App-owned document migration',
+      ownerStepId: 'compose-property-customization',
+      channel: 'Core load hook pipeline',
+      terminal: true,
+      consumerStepIds: []
+    },
+    {
+      id: 'artifact:definition-read-request',
+      title: 'Owner definition read request',
+      ownerStepId: 'coordinate-property-redefinition',
+      channel: 'Core to Props Manager owner call',
+      terminal: false,
+      consumerStepIds: ['rebuild-declarative-property-type']
+    },
+    {
+      id: 'artifact:property-definition-view',
+      title: 'Detached app-facing property definition',
+      ownerStepId: 'coordinate-property-redefinition',
+      channel: 'Core getter or updater callback',
+      terminal: false,
+      consumerStepIds: ['compose-property-customization']
+    },
+    {
+      id: 'artifact:definition-rebuild-request',
+      title: 'Validated atomic rebuild request',
+      ownerStepId: 'coordinate-property-redefinition',
+      channel: 'Core to Props Manager owner call',
+      terminal: false,
+      consumerStepIds: ['rebuild-declarative-property-type']
+    },
+    {
+      id: 'artifact:property-redefinition-result',
+      title: 'Detached committed redefinition result',
+      ownerStepId: 'coordinate-property-redefinition',
+      channel: 'Core public facade return',
+      terminal: false,
+      consumerStepIds: ['compose-property-customization']
+    },
+    {
+      id: 'artifact:current-property-definition',
+      title: 'Normalized current property definition',
+      ownerStepId: 'rebuild-declarative-property-type',
+      channel: 'Props Manager definition owner response',
+      terminal: false,
+      consumerStepIds: ['coordinate-property-redefinition']
+    },
+    {
+      id: 'artifact:committed-property-definition',
+      title: 'Atomically committed property definition',
+      ownerStepId: 'rebuild-declarative-property-type',
+      channel: 'Props Manager definition owner response',
+      terminal: false,
+      consumerStepIds: ['coordinate-property-redefinition']
+    },
+    {
+      id: 'artifact:canonical-property-values',
+      title: 'Canonical projected property values',
+      ownerStepId: 'rebuild-declarative-property-type',
+      channel: 'Property component getValue and change subscription',
+      terminal: false,
+      consumerStepIds: ['project-property-values']
+    },
+    {
+      id: 'artifact:computed-element-data',
+      title: 'Computed element data with app custom fields',
+      ownerStepId: 'project-property-values',
+      channel: 'Scene Tree computed state and projection channels',
+      terminal: false,
+      consumerStepIds: ['consume-typed-render-data', 'derive-typed-ui-data']
+    },
+    {
+      id: 'artifact:typed-render-consumption',
+      title: 'Typed engine-neutral render callback consumption',
+      ownerStepId: 'consume-typed-render-data',
+      channel: 'registered render strategy callback',
+      terminal: true,
+      consumerStepIds: []
+    },
+    {
+      id: 'artifact:derived-ui-value',
+      title: 'Optional app-owned derived UI value',
+      ownerStepId: 'derive-typed-ui-data',
+      channel: 'ui-context observable',
+      terminal: true,
+      consumerStepIds: []
+    }
+  ]
+
+  const invariants = [
+    {
+      id: 'redefinition-is-atomic-and-pre-start',
+      statement:
+        'A config-mode property definition changes schema and runtime together only during open composition; every failure preserves the exact old definition and relations.',
+      stepIds: [
+        'coordinate-property-redefinition',
+        'rebuild-declarative-property-type'
+      ],
+      artifactIds: [
+        'artifact:definition-rebuild-request',
+        'artifact:committed-property-definition'
+      ],
+      specRefs: ['#composition-and-atomicity', '#product-cases']
+    },
+    {
+      id: 'semantic-consumers-remain-explicit',
+      statement:
+        'The framework never infers semantic equivalence or rewrites relations, render, UI, commands, or migration after an app field redefinition.',
+      stepIds: [
+        'compose-property-customization',
+        'coordinate-property-redefinition',
+        'consume-typed-render-data',
+        'derive-typed-ui-data'
+      ],
+      artifactIds: [
+        'artifact:app-render-strategy-registration',
+        'artifact:app-ui-property-registration',
+        'artifact:app-load-migration'
+      ],
+      specRefs: ['#product-contract', '#app-consumer-flow']
+    },
+    {
+      id: 'canonical-data-authority-is-preserved',
+      statement:
+        'Props Manager owns property validation and values, Scene Tree owns computed projection, and render/UI consume derived typed data without becoming authority.',
+      stepIds: [
+        'rebuild-declarative-property-type',
+        'project-property-values',
+        'consume-typed-render-data',
+        'derive-typed-ui-data'
+      ],
+      artifactIds: [
+        'artifact:canonical-property-values',
+        'artifact:computed-element-data'
+      ],
+      specRefs: ['#app-consumer-flow', '#ownership-and-boundaries']
+    }
+  ]
+
+  const acceptanceContracts = [
+    {
+      id: 'app-can-redefine-preset-fields',
+      title: 'App can redefine preset fields',
+      stepIds: [
+        'compose-property-customization',
+        'coordinate-property-redefinition',
+        'rebuild-declarative-property-type'
+      ],
+      specRefs: ['#public-api', '#product-cases'],
+      assertions: [
+        'An app can inspect and atomically add, remove, or replace config-mode fixed fields through its Core instance before startup without a preset deep import.'
+      ]
+    },
+    {
+      id: 'app-consumers-remain-typed-and-explicit',
+      title: 'App consumers remain typed and explicit',
+      stepIds: [
+        'compose-property-customization',
+        'project-property-values',
+        'consume-typed-render-data',
+        'derive-typed-ui-data'
+      ],
+      specRefs: ['#app-consumer-flow', '#definition-of-done'],
+      assertions: [
+        'App-declared fields reach property updates, render strategies, and optional UI compute callbacks without unsafe casts, while their semantic behavior remains app-owned.'
+      ]
+    },
+    {
+      id: 'failure-and-load-boundaries-remain-safe',
+      title: 'Failure and load boundaries remain safe',
+      stepIds: [
+        'compose-property-customization',
+        'coordinate-property-redefinition',
+        'rebuild-declarative-property-type'
+      ],
+      specRefs: ['#composition-and-atomicity', '#product-cases'],
+      assertions: [
+        'Failed redefinition preserves the old definition, runtime invalid writes reject, load fallback remains deterministic, and semantic document conversion stays app-owned.'
+      ]
+    }
+  ]
+
+  const data = {
+    schema: { id: 'asyra.flow-inspector', version: 2 },
+    target: {
+      id: 'property-type-redefinition',
+      kind: 'system',
+      title: 'Property Type Redefinition Inspector',
+      subtitle:
+        'Pre-start app composition from detached definition through atomic property rebuild and explicit typed render/UI consumers.'
+    },
+    authority: {
+      specPath,
+      inspectorPath,
+      semanticOwner: 'Declarative Property Type Redefinition product contract',
+      inspectorOwner: 'Property Type Redefinition Inspector data'
+    },
+    links: [
+      {
+        id: 'product-contract',
+        label: 'Product Contract',
+        href: './property-type-redefinition-plan.md',
+        kind: 'authority'
+      },
+      {
+        id: 'flow-inspector-contract',
+        label: 'Flow Inspector Contract',
+        href: './flow-inspector-dashboard-plan.md',
+        kind: 'framework'
+      }
+    ],
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  }
+
+  const freeze = (value) => {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
+      return value
+    }
+    Object.freeze(value)
+    Object.values(value).forEach(freeze)
+    return value
+  }
+
+  freeze(data)
+
+  if (typeof globalThis !== 'undefined') {
+    globalThis.FLOW_INSPECTOR_DATA = data
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = data
+  }
+})()

--- a/docs/ai/framework/plans/property-type-redefinition-flow-inspector.html
+++ b/docs/ai/framework/plans/property-type-redefinition-flow-inspector.html
@@ -1,0 +1,805 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Property Type Redefinition Inspector</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #101418;
+        --panel: #151b22;
+        --panel-2: #1d2530;
+        --line: #334155;
+        --text: #e5edf5;
+        --muted: #9caab8;
+        --accent: #59b7ff;
+        --accent-2: #f97373;
+        --warn: #f6c85f;
+        --ok: #7bd88f;
+        --card-w: 270px;
+        --card-h: 118px;
+        --gap-x: 220px;
+        --gap-y: 100px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--text);
+        background: var(--bg);
+        font: 14px/1.5 ui-sans-serif, system-ui, sans-serif;
+      }
+      .app {
+        display: grid;
+        grid-template-columns: minmax(980px, 1fr) 430px;
+        height: 100vh;
+        overflow: hidden;
+      }
+      .main {
+        min-width: 0;
+        overflow: auto;
+        padding: 24px;
+      }
+      .header {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 18px;
+      }
+      h1 {
+        margin: 0 0 6px;
+        font-size: 24px;
+      }
+      .subtitle,
+      .detail-summary {
+        color: var(--muted);
+      }
+      .header-links,
+      .filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 12px 0 18px;
+      }
+      .header-link,
+      .filter-button {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 6px 10px;
+        color: var(--accent);
+        background: var(--panel);
+      }
+      .filter-button.is-active {
+        border-color: var(--accent);
+      }
+      .guide-panel {
+        margin-bottom: 18px;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 12px 16px;
+        background: var(--panel);
+      }
+      .guide-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(240px, 1fr));
+        gap: 12px;
+      }
+      .guide-card,
+      .detail-section {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 12px;
+        background: var(--panel-2);
+      }
+      .flow {
+        position: relative;
+        min-width: 100%;
+        min-height: 720px;
+      }
+      .flow-svg {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+      }
+      .step-card {
+        position: absolute;
+        width: var(--card-w);
+        min-height: var(--card-h);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 14px;
+        color: var(--text);
+        background: var(--panel);
+        text-align: left;
+      }
+      .step-card.is-selected {
+        border-color: var(--accent);
+      }
+      .step-card h2 {
+        margin: 0 0 6px;
+        font-size: 15px;
+      }
+      .detail {
+        height: 100vh;
+        overflow: auto;
+        border-left: 1px solid var(--line);
+        padding: 24px;
+        background: #0f1720;
+      }
+      .detail-section {
+        margin-bottom: 16px;
+      }
+      .detail-section h3 {
+        margin: 0 0 8px;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+      code {
+        color: #dbeafe;
+      }
+      a {
+        color: var(--accent);
+      }
+      @media (max-width: 1050px) {
+        .app {
+          grid-template-columns: 1fr;
+          height: auto;
+          overflow: visible;
+        }
+        .detail {
+          height: auto;
+          border-top: 1px solid var(--line);
+          border-left: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <main class="main">
+        <div class="header">
+          <div>
+            <h1 id="inspector-title">Flow Inspector</h1>
+            <p id="inspector-subtitle" class="subtitle">
+              Loading target contract.
+            </p>
+            <div id="inspector-links" class="header-links"></div>
+          </div>
+        </div>
+        <div id="filters" class="filters"></div>
+        <details class="guide-panel">
+          <summary>Viewer controls and contract</summary>
+          <section class="guide-grid">
+            <article class="guide-card">
+              <h2>Viewer controls</h2>
+              <p>
+                Filter by owner lane and select a card to inspect its exact
+                inputs, outputs, boundaries, and failure owner.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h2>Target contract</h2>
+              <p id="target-contract-summary">Loading target contract.</p>
+            </article>
+          </section>
+        </details>
+        <section
+          id="flow"
+          class="flow"
+          aria-label="property type redefinition flow"
+        ></section>
+      </main>
+      <aside id="detail" class="detail" aria-label="step detail"></aside>
+    </div>
+    <script src="./property-type-redefinition-flow-inspector.data.cjs"></script>
+    <script data-flow-inspector-renderer>
+/* global console, document, window */
+
+;(function () {
+  'use strict'
+
+  const data = globalThis.FLOW_INSPECTOR_DATA
+  if (!data) {
+    throw new Error(
+      'Missing FLOW_INSPECTOR_DATA. Load the target data file before the shared viewer.'
+    )
+  }
+
+  const {
+    schema,
+    target,
+    authority,
+    links = [],
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  } = data
+
+  const requiredCollections = {
+    links,
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  }
+  const invalidCollections = Object.entries(requiredCollections)
+    .filter(([, value]) => !Array.isArray(value))
+    .map(([name]) => name)
+  if (invalidCollections.length) {
+    throw new Error(
+      `Flow Inspector target has invalid collections: ${invalidCollections.join(', ')}`
+    )
+  }
+  if (schema?.id !== 'asyra.flow-inspector' || schema.version !== 2) {
+    throw new Error('Flow Inspector requires schema asyra.flow-inspector/v2.')
+  }
+
+  const flow = document.getElementById('flow')
+  const detail = document.getElementById('detail')
+  const filters = document.getElementById('filters')
+  const title = document.getElementById('inspector-title')
+  const subtitle = document.getElementById('inspector-subtitle')
+  const headerLinks = document.getElementById('inspector-links')
+  const targetSummary = document.getElementById('target-contract-summary')
+
+  const requiredElements = {
+    flow,
+    detail,
+    filters,
+    title,
+    subtitle,
+    headerLinks,
+    targetSummary
+  }
+  const missingElements = Object.entries(requiredElements)
+    .filter(([, element]) => !element)
+    .map(([name]) => name)
+  if (missingElements.length) {
+    throw new Error(
+      `Flow Inspector shell is missing: ${missingElements.join(', ')}`
+    )
+  }
+
+  const escapeHtml = (value) =>
+    String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;')
+
+  const specLink = links.find((link) => link.kind === 'authority')
+
+  const formatItem = (value) => {
+    if (value && typeof value === 'object' && value.href && value.label) {
+      return `<a href="${escapeHtml(value.href)}">${escapeHtml(value.label)}</a>`
+    }
+    const text = String(value)
+    if (text.startsWith('#') && specLink) {
+      return `<a href="${escapeHtml(`${specLink.href}${text}`)}"><code>${escapeHtml(text)}</code></a>`
+    }
+    return escapeHtml(text).replace(/`([^`]+)`/g, '<code>$1</code>')
+  }
+
+  const section = (heading, items, className = '') => {
+    const values = items && items.length ? items : ['None']
+    return `
+      <section class="detail-section ${className}">
+        <h3>${escapeHtml(heading)}</h3>
+        <ul>${values.map((item) => `<li>${formatItem(item)}</li>`).join('')}</ul>
+      </section>`
+  }
+
+  const laneById = new Map(lanes.map((lane) => [lane.id, lane]))
+  const stepById = new Map(steps.map((step) => [step.id, step]))
+  const artifactById = new Map(
+    artifacts.map((artifact) => [artifact.id, artifact])
+  )
+  const stepsByLane = new Map(
+    lanes.map((lane) => [
+      lane.id,
+      steps
+        .filter((step) => step.laneId === lane.id)
+        .sort((left, right) => left.order - right.order)
+    ])
+  )
+
+  const layout = {
+    left: 28,
+    top: 68,
+    cardW: 270,
+    cardH: 118,
+    gapX: 220,
+    gapY: 100
+  }
+
+  let selectedId = steps[0]?.id ?? null
+  let selectedLaneId = 'All'
+
+  const isVisible = (step) =>
+    selectedLaneId === 'All' || step.laneId === selectedLaneId
+
+  const getStepLane = (step) =>
+    lanes.findIndex((lane) => lane.id === step.laneId)
+
+  const getStepRow = (step) =>
+    stepsByLane.get(step.laneId)?.findIndex((item) => item.id === step.id) ?? 0
+
+  const stepPosition = (step) => ({
+    x: layout.left + getStepLane(step) * (layout.cardW + layout.gapX),
+    y: layout.top + getStepRow(step) * (layout.cardH + layout.gapY)
+  })
+
+  const getFlowBounds = () => {
+    const visibleSteps = steps.filter(isVisible)
+    const laneIndexes = visibleSteps.map(getStepLane)
+    const rowIndexes = visibleSteps.map(getStepRow)
+    const maxLane = laneIndexes.length ? Math.max(...laneIndexes) : 0
+    const maxRow = rowIndexes.length ? Math.max(...rowIndexes) : 0
+    return {
+      width:
+        layout.left * 2 + (maxLane + 1) * layout.cardW + maxLane * layout.gapX,
+      height:
+        layout.top * 2 + (maxRow + 1) * layout.cardH + maxRow * layout.gapY
+    }
+  }
+
+  const toSvgPoint = (svg, x, y) => {
+    const point = svg.createSVGPoint()
+    point.x = x
+    point.y = y
+    const matrix = svg.getScreenCTM()
+    return matrix ? point.matrixTransform(matrix.inverse()) : { x, y }
+  }
+
+  const getEdgePath = (svg, fromCard, toCard, fromStep, toStep) => {
+    const fromBox = fromCard.getBoundingClientRect()
+    const toBox = toCard.getBoundingClientRect()
+    if (fromStep.laneId === toStep.laneId) {
+      const start = toSvgPoint(
+        svg,
+        fromBox.left + fromBox.width / 2,
+        fromBox.bottom
+      )
+      const end = toSvgPoint(svg, toBox.left + toBox.width / 2, toBox.top)
+      const midpointY = fromBox.bottom + (toBox.top - fromBox.bottom) * 0.5
+      const controlStart = toSvgPoint(
+        svg,
+        fromBox.left + fromBox.width / 2,
+        midpointY
+      )
+      const controlEnd = toSvgPoint(
+        svg,
+        toBox.left + toBox.width / 2,
+        midpointY
+      )
+      return `M ${start.x} ${start.y} C ${controlStart.x} ${controlStart.y}, ${controlEnd.x} ${controlEnd.y}, ${end.x} ${end.y}`
+    }
+
+    const direction = toBox.left >= fromBox.left ? 1 : -1
+    const startX = direction > 0 ? fromBox.right : fromBox.left
+    const startY = fromBox.top + fromBox.height / 2
+    const endX = direction > 0 ? toBox.left : toBox.right
+    const endY = toBox.top + toBox.height / 2
+    const distanceX = Math.abs(endX - startX)
+    const curve = Math.max(120, Math.min(distanceX * 0.46, layout.gapX * 0.92))
+    const start = toSvgPoint(svg, startX, startY)
+    const end = toSvgPoint(svg, endX, endY)
+    const controlStart = toSvgPoint(svg, startX + direction * curve, startY)
+    const controlEnd = toSvgPoint(svg, endX - direction * curve, endY)
+    return `M ${start.x} ${start.y} C ${controlStart.x} ${controlStart.y}, ${controlEnd.x} ${controlEnd.y}, ${end.x} ${end.y}`
+  }
+
+  const routeClass = (kind) => {
+    if (kind === 'bypass') return 'route-bypass'
+    if (kind === 'coexecute' || kind === 'fanout') return 'route-parallel'
+    return `route-${kind}`
+  }
+
+  const renderEdges = (svg) => {
+    svg.querySelectorAll('.edge-path').forEach((node) => node.remove())
+    routes.forEach((route) => {
+      if (!route.to) return
+      const from = stepById.get(route.from)
+      const to = stepById.get(route.to)
+      if (!from || !to || !isVisible(from) || !isVisible(to)) return
+      const fromCard = flow.querySelector(`[data-step-id="${route.from}"]`)
+      const toCard = flow.querySelector(`[data-step-id="${route.to}"]`)
+      if (!fromCard || !toCard) return
+
+      const path = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path'
+      )
+      path.setAttribute('d', getEdgePath(svg, fromCard, toCard, from, to))
+      path.setAttribute(
+        'class',
+        `edge-path ${routeClass(route.kind)}${route.from === selectedId || route.to === selectedId ? ' is-active' : ''}`
+      )
+      path.setAttribute('data-route-id', route.id)
+      path.setAttribute('marker-end', 'url(#arrow)')
+      const tooltip = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'title'
+      )
+      tooltip.textContent = `${route.id}: ${route.kind}; ${route.predicate}`
+      path.appendChild(tooltip)
+      svg.appendChild(path)
+    })
+  }
+
+  const routesForStep = (stepId, direction) =>
+    routes
+      .filter((route) => route[direction] === stepId)
+      .map(
+        (route) =>
+          `${route.id} [${route.kind}]: ${route.predicate}; ${route.from} -> ${route.to ?? 'terminal'}; artifacts ${route.producedArtifacts.join(', ')}`
+      )
+
+  const artifactsOwnedBy = (stepId) =>
+    artifacts
+      .filter((artifact) => artifact.ownerStepId === stepId)
+      .map(
+        (artifact) =>
+          `${artifact.id}: ${artifact.channel}; consumers ${artifact.consumerStepIds.join(', ') || 'terminal'}`
+      )
+
+  const artifactsConsumedBy = (stepId) =>
+    artifacts
+      .filter((artifact) => artifact.consumerStepIds.includes(stepId))
+      .map(
+        (artifact) =>
+          `${artifact.id}: owner ${artifact.ownerStepId}; ${artifact.channel}`
+      )
+
+  const invariantsForStep = (stepId) =>
+    invariants
+      .filter((invariant) => invariant.stepIds.includes(stepId))
+      .map(
+        (invariant) =>
+          `${invariant.id}: ${invariant.statement}; refs ${invariant.specRefs.join(', ')}`
+      )
+
+  const acceptanceForStep = (stepId) =>
+    acceptanceContracts
+      .filter((contract) => contract.stepIds.includes(stepId))
+      .map(
+        (contract) =>
+          `${contract.id}: ${contract.assertions.join('; ')}; refs ${contract.specRefs.join(', ')}`
+      )
+
+  const renderHeader = () => {
+    document.title = target.title
+    title.textContent = target.title
+    subtitle.textContent = target.subtitle
+    headerLinks.innerHTML = links
+      .map(
+        (link) =>
+          `<a class="header-link" href="${escapeHtml(link.href)}" data-link-kind="${escapeHtml(link.kind)}">${escapeHtml(link.label)}</a>`
+      )
+      .join('')
+    targetSummary.innerHTML = [
+      `Target: <code>${escapeHtml(target.kind)}:${escapeHtml(target.id)}</code>`,
+      `Schema: <code>${escapeHtml(schema.id)}/v${escapeHtml(schema.version)}</code>`,
+      `Semantic authority: <code>${escapeHtml(authority.specPath)}</code>`,
+      `Inspector data: <code>${escapeHtml(authority.inspectorPath)}</code>`
+    ].join('<br />')
+  }
+
+  const renderFilters = () => {
+    filters.innerHTML = ''
+    ;[{ id: 'All', title: 'All' }, ...lanes].forEach((lane) => {
+      const button = document.createElement('button')
+      button.className = `filter-button${lane.id === selectedLaneId ? ' is-active' : ''}`
+      button.type = 'button'
+      button.textContent = lane.title
+      button.addEventListener('click', () => {
+        selectedLaneId = lane.id
+        const selectedStep = stepById.get(selectedId)
+        if (selectedStep && !isVisible(selectedStep)) {
+          selectedId = steps.find(isVisible)?.id ?? steps[0]?.id ?? null
+        }
+        render()
+      })
+      filters.appendChild(button)
+    })
+  }
+
+  const renderDetail = () => {
+    const selected = stepById.get(selectedId) ?? steps[0]
+    if (!selected) {
+      detail.innerHTML = '<p>No steps are declared.</p>'
+      return
+    }
+    const lane = laneById.get(selected.laneId)
+    detail.innerHTML = `
+      <div class="detail-group">${escapeHtml(lane?.title ?? selected.laneId)}</div>
+      <div class="detail-heading">
+        <span class="step-number">Step ${escapeHtml(selected.order)}</span>
+        <h2>${escapeHtml(selected.title)}</h2>
+      </div>
+      <p class="detail-summary">${escapeHtml(selected.purpose)}</p>
+      ${section('Target links', links, 'rule-box')}
+      ${section('Owner package', [selected.ownerPackage], 'alignment-box')}
+      ${section('Inputs', selected.inputs)}
+      ${section('Outputs', selected.outputs)}
+      ${section('Conditions', selected.conditions, 'trace-box')}
+      ${section('Bypasses', selected.bypasses, 'trace-box')}
+      ${section('Allowed contributors', selected.allowedContributors, 'evidence-box')}
+      ${section('Forbidden contributors', selected.forbiddenContributors, 'risk-box')}
+      ${section('Cache dimensions', selected.cacheDimensions, 'trace-box')}
+      ${section('Implementation boundary', selected.implementationBoundary)}
+      ${section('Spec references', selected.specRefs, 'rule-box')}
+      ${section('Failure owner step', [selected.failureOwnerStepId], 'risk-box')}
+      ${section('Incoming routes', routesForStep(selected.id, 'to'), 'trace-box')}
+      ${section('Outgoing routes', routesForStep(selected.id, 'from'), 'trace-box')}
+      ${section('Owned artifacts', artifactsOwnedBy(selected.id), 'trace-box')}
+      ${section('Consumed artifacts', artifactsConsumedBy(selected.id), 'trace-box')}
+      ${section('Invariants', invariantsForStep(selected.id), 'evidence-box')}
+      ${section('Acceptance contracts', acceptanceForStep(selected.id), 'test-box')}`
+  }
+
+  const renderFlow = () => {
+    flow.innerHTML = ''
+    const bounds = getFlowBounds()
+    flow.style.minWidth = `${bounds.width}px`
+    flow.style.minHeight = `${bounds.height}px`
+
+    lanes.forEach((lane, laneIndex) => {
+      const label = document.createElement('div')
+      label.className = 'lane-label'
+      label.style.left = `${layout.left + laneIndex * (layout.cardW + layout.gapX)}px`
+      label.textContent = lane.title
+      flow.appendChild(label)
+    })
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('class', 'flow-svg')
+    svg.setAttribute('viewBox', `0 0 ${bounds.width} ${bounds.height}`)
+    svg.style.width = `${bounds.width}px`
+    svg.style.height = `${bounds.height}px`
+    svg.innerHTML = `
+      <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(148, 163, 184, 0.62)"></path>
+        </marker>
+      </defs>`
+    flow.appendChild(svg)
+
+    steps.filter(isVisible).forEach((step) => {
+      const position = stepPosition(step)
+      const lane = laneById.get(step.laneId)
+      const tags = step.tags ?? []
+      const card = document.createElement('button')
+      card.type = 'button'
+      card.className = [
+        'step-card',
+        step.id === selectedId ? 'is-selected' : '',
+        tags.includes('risk') ? 'is-risk' : '',
+        tags.includes('critical') ? 'is-critical' : '',
+        tags.includes('blocker') ? 'is-blocker' : ''
+      ]
+        .filter(Boolean)
+        .join(' ')
+      card.style.left = `${position.x}px`
+      card.style.top = `${position.y}px`
+      card.dataset.stepId = step.id
+      card.innerHTML = `
+        <div class="step-kicker">
+          <span class="step-number">Step ${escapeHtml(step.order)}</span>
+          <span>${escapeHtml(lane?.title ?? step.laneId)}</span>
+        </div>
+        <div class="step-title">${escapeHtml(step.title)}</div>
+        <div class="step-summary">${escapeHtml(step.purpose)}</div>
+        <div class="badge-row">
+          <span class="badge truth">${escapeHtml(step.ownerPackage)}</span>
+          ${tags
+            .slice(0, 2)
+            .map((tag) => `<span class="badge">${escapeHtml(tag)}</span>`)
+            .join('')}
+        </div>`
+      card.addEventListener('click', () => {
+        selectedId = step.id
+        render()
+      })
+      flow.appendChild(card)
+    })
+
+    renderEdges(svg)
+  }
+
+  const runStaticChecks = () => {
+    const errors = []
+    const uniqueIds = (label, items) => {
+      const seen = new Set()
+      items.forEach((item) => {
+        if (seen.has(item.id)) errors.push(`${label}:duplicate:${item.id}`)
+        seen.add(item.id)
+      })
+    }
+    uniqueIds('lane', lanes)
+    uniqueIds('step', steps)
+    uniqueIds('route', routes)
+    uniqueIds('artifact', artifacts)
+    uniqueIds('invariant', invariants)
+    uniqueIds('acceptance', acceptanceContracts)
+
+    if (!target?.id || !target?.kind || !target?.title) {
+      errors.push('target:incomplete')
+    }
+
+    const requiredStepFields = [
+      'id',
+      'order',
+      'laneId',
+      'title',
+      'ownerPackage',
+      'purpose',
+      'inputs',
+      'outputs',
+      'conditions',
+      'bypasses',
+      'allowedContributors',
+      'forbiddenContributors',
+      'cacheDimensions',
+      'implementationBoundary',
+      'specRefs',
+      'failureOwnerStepId'
+    ]
+    steps.forEach((step) => {
+      requiredStepFields.forEach((field) => {
+        if (step[field] === undefined)
+          errors.push(`${step.id}:missing:${field}`)
+      })
+      if (!laneById.has(step.laneId)) errors.push(`${step.id}:lane`)
+      if (!stepById.has(step.failureOwnerStepId)) {
+        errors.push(`${step.id}:failureOwnerStepId`)
+      }
+      step.inputs
+        .filter((input) => input.startsWith('artifact:'))
+        .forEach((artifactId) => {
+          if (!artifactById.has(artifactId)) {
+            errors.push(`${step.id}:input:${artifactId}`)
+          }
+        })
+      step.outputs.forEach((artifactId) => {
+        if (!artifactById.has(artifactId)) {
+          errors.push(`${step.id}:output:${artifactId}`)
+        }
+      })
+    })
+
+    routes.forEach((route) => {
+      if (!stepById.has(route.from)) errors.push(`${route.id}:from`)
+      if (route.to && !stepById.has(route.to)) errors.push(`${route.id}:to`)
+      route.producedArtifacts.forEach((artifactId) => {
+        const artifact = artifactById.get(artifactId)
+        if (!artifact) {
+          errors.push(`${route.id}:artifact:${artifactId}`)
+          return
+        }
+        if (artifact.ownerStepId !== route.from) {
+          errors.push(`${route.id}:artifact-owner:${artifactId}`)
+        }
+        if (route.to && !artifact.consumerStepIds.includes(route.to)) {
+          errors.push(`${route.id}:artifact-consumer:${artifactId}`)
+        }
+      })
+    })
+
+    artifacts.forEach((artifact) => {
+      const owner = stepById.get(artifact.ownerStepId)
+      if (!owner) {
+        errors.push(`${artifact.id}:owner`)
+      } else if (!owner.outputs.includes(artifact.id)) {
+        errors.push(`${artifact.id}:owner-output`)
+      }
+      artifact.consumerStepIds.forEach((stepId) => {
+        const consumer = stepById.get(stepId)
+        if (!consumer) {
+          errors.push(`${artifact.id}:consumer:${stepId}`)
+        } else if (!consumer.inputs.includes(artifact.id)) {
+          errors.push(`${artifact.id}:consumer-input:${stepId}`)
+        }
+      })
+      if (!artifact.terminal && !artifact.consumerStepIds.length) {
+        errors.push(`${artifact.id}:missing-consumer`)
+      }
+    })
+
+    invariants.forEach((invariant) => {
+      invariant.stepIds.forEach((stepId) => {
+        if (!stepById.has(stepId)) {
+          errors.push(`${invariant.id}:step:${stepId}`)
+        }
+      })
+      invariant.artifactIds.forEach((artifactId) => {
+        if (!artifactById.has(artifactId)) {
+          errors.push(`${invariant.id}:artifact:${artifactId}`)
+        }
+      })
+    })
+
+    acceptanceContracts.forEach((contract) => {
+      contract.stepIds.forEach((stepId) => {
+        if (!stepById.has(stepId)) {
+          errors.push(`${contract.id}:step:${stepId}`)
+        }
+      })
+    })
+
+    if (errors.length) {
+      console.error('Flow Inspector static check failed', {
+        target: target.id,
+        errors
+      })
+    } else {
+      console.info('Flow Inspector static check passed', {
+        target: target.id,
+        lanes: lanes.length,
+        steps: steps.length,
+        routes: routes.length,
+        artifacts: artifacts.length,
+        invariants: invariants.length,
+        acceptanceContracts: acceptanceContracts.length
+      })
+    }
+  }
+
+  const runLayoutChecks = () => {
+    const cards = [...flow.querySelectorAll('.step-card')].map((card) => {
+      const rect = card.getBoundingClientRect()
+      return {
+        id: card.dataset.stepId,
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom
+      }
+    })
+    const overlaps = []
+    cards.forEach((card, index) => {
+      cards.slice(index + 1).forEach((other) => {
+        const overlapX =
+          Math.min(card.right, other.right) - Math.max(card.left, other.left)
+        const overlapY =
+          Math.min(card.bottom, other.bottom) - Math.max(card.top, other.top)
+        if (overlapX > 8 && overlapY > 8) {
+          overlaps.push(`${card.id}:${other.id}`)
+        }
+      })
+    })
+    if (overlaps.length) {
+      console.error('Flow Inspector layout check failed', { overlaps })
+    } else {
+      console.info('Flow Inspector layout check passed', {
+        cards: cards.length
+      })
+    }
+  }
+
+  const render = () => {
+    renderHeader()
+    renderFilters()
+    renderFlow()
+    renderDetail()
+    runLayoutChecks()
+  }
+
+  runStaticChecks()
+  render()
+  window.addEventListener('resize', () => {
+    const svg = flow.querySelector('.flow-svg')
+    if (svg) renderEdges(svg)
+  })
+})()
+    </script>
+  </body>
+</html>

--- a/docs/ai/framework/plans/property-type-redefinition-plan.md
+++ b/docs/ai/framework/plans/property-type-redefinition-plan.md
@@ -1,0 +1,322 @@
+# Declarative Property Type Redefinition Plan
+
+## Status
+
+Accepted product and architecture plan. The APIs and runtime behavior described
+here are not implemented yet.
+
+## Product Contract
+
+App developers may customize the fixed fields of an existing declarative
+property type after optional preset installation and before the first
+`core.start()`. The framework exposes one high-level mutation,
+`redefinePropertyType()`, so an app does not manually coordinate a partially
+updated property schema, runtime defaults, persistence keys, projected value
+keys, or unit keys.
+
+Property redefinition changes how one property type stores, validates, and
+projects data. It does not infer that a removed field and an added field have
+the same product meaning. Component relations, child projections, render
+strategies, UI-context registrations, app commands, and document migration
+remain explicit app composition or app code.
+
+This is a bounded pre-start exception for complete declarative property-type
+definitions. It is not a general registry replace operation and does not alter
+the existing duplicate-registration contract.
+
+## Supported And Unsupported Behavior
+
+Supported:
+
+- inspect a detached normalized definition for a registered config-mode
+  property type;
+- add, remove, or replace fixed top-level fields in one complete definition;
+- atomically rebuild the corresponding schema and config-mode runtime while
+  preserving the property identity and its declared relations;
+- derive defaults, persistence, value projection, unit projection, and runtime
+  validation from the complete next field definition;
+- consume app-defined custom fields through typed Core update, render-strategy,
+  and UI aggregation APIs;
+- transfer the redefined property registration owner to the app while
+  preserving existing incoming and outgoing relations.
+
+Unsupported:
+
+- redefinition after the first `core.start()` call;
+- redefinition while active or replay-retained instances use the property type;
+- redefinition of constructor-mode property components whose behavior is not a
+  complete declarative config;
+- nested path mutation such as `stroke.fill.color`; an app replaces the whole
+  top-level `fill` field definition when that rare customization is required;
+- implicit child-relation, component-relation, render, UI-context, feature,
+  command, export, or migration changes;
+- semantic mapping from a removed field to an added field;
+- fallback product values that hide an unadapted consumer;
+- any render-engine or concrete-engine change.
+
+## Public API
+
+The planned Core facade adds one read-only companion and one mutation:
+
+```ts
+interface PropertyTypeFieldDefinition<T = DataTypes> {
+  readonly key: string
+  readonly kind: PropertyValueKind
+  readonly defaultValue: T
+  readonly validate?: (value: unknown) => boolean
+  readonly allowedUnits?: readonly PropertyUnitKind[]
+  readonly persist: boolean
+  readonly project: boolean
+  readonly unit: boolean
+}
+
+interface PropertyTypeDefinition<
+  TFields extends object = Record<string, DataTypes>
+> {
+  readonly type: string
+  readonly fields: readonly PropertyTypeFieldDefinition<
+    TFields[keyof TFields]
+  >[]
+  readonly allowDynamicKeys: boolean
+  readonly dynamicReservedKeys: readonly string[]
+}
+
+core.getPropertyTypeDefinition<TFields>(
+  type: string
+): Readonly<PropertyTypeDefinition<TFields>> | undefined
+
+core.redefinePropertyType<TFields>(
+  type: string,
+  update: (
+    current: Readonly<PropertyTypeDefinition<TFields>>
+  ) => PropertyTypeDefinition<TFields>
+): Readonly<PropertyTypeDefinition<TFields>>
+```
+
+The exact generic representation may be simplified during implementation only
+if these public guarantees remain true:
+
+- the returned current and next definitions are deeply detached from registry
+  state;
+- every fixed field has one key, kind, default, validation contract, and
+  explicit persist/project/unit policy;
+- the updater is synchronous and receives the complete editable field
+  definition;
+- the type identity cannot change;
+- the returned definition is the committed normalized result;
+- property-child relations remain queryable and editable only through
+  `get/define/removePropertyChildRelation` and are not embedded as a second
+  mutation path in `redefinePropertyType()`.
+
+`getPropertySchema()` remains a low-level schema query. The existing
+`registerPropertySchema()` and `definePropertyComponent()` APIs remain the
+ordinary low-level definition path for new or constructor-mode types.
+
+## Definition Model
+
+`@asyra/props-manager` projects a config-mode schema plus runtime config into
+one normalized `PropertyTypeDefinition`. A fixed field is valid only when its
+schema, default, persistence, projected value, and unit roles form one complete
+definition. Duplicate keys, invalid defaults, contradictory projection flags,
+reserved keys, or schema/runtime drift make the type ineligible for
+redefinition until corrected through the ordinary owner APIs.
+
+Removing a field removes it from the next schema, defaults, persistence,
+`getValue()`, and unit output together. Adding a field creates all selected
+roles together. The framework must never leave a field visible in only one of
+those representations.
+
+Dynamic keys remain controlled by `allowDynamicKeys` and
+`dynamicReservedKeys`; fixed-field redefinition does not reinterpret arbitrary
+dynamic data. Existing property-child configuration is preserved byte-for-byte
+by the atomic rebuild. If the child `toValue()` projection enumerates child
+fields, the app explicitly replaces that relation through the existing child
+relation APIs.
+
+## Composition And Atomicity
+
+The Core facade owns composition coordination:
+
+1. require open composition and a registered property identity;
+2. reject pending cleanup, constructor mode, active instances, and
+   replay-retained instances;
+3. request a detached normalized current definition from Props Manager;
+4. run the synchronous app updater against that detached value;
+5. require the same property type and validate the complete next definition;
+6. build the complete next schema and property constructor before registry
+   mutation;
+7. atomically swap schema and runtime, preserving child configuration and graph
+   relations;
+8. transfer registration owner metadata to the app and return a detached
+   committed definition.
+
+If the updater throws, validation fails, staging fails, or commit cannot
+complete, the previous schema, constructor, owner, and relations remain intact.
+No observer, render, UI, migration, or product fallback runs to repair a failed
+redefinition.
+
+Definition and usage failures use a stable Props Manager error contract.
+Composition-closed, pending-cleanup, and relation-validation failures retain
+their existing Core registration error contracts. Final startup relation
+validation additionally rejects fixed component aliases or property-child keys
+that no longer resolve to the redefined projected fields. Dynamic property
+types keep their explicit dynamic-key policy.
+
+## App Consumer Flow
+
+Preset uses the same Core facade subset available to apps. A normal app flow is:
+
+```ts
+applyPreset(core)
+
+core.redefinePropertyType<AStyleV2>('a-style', (current) => ({
+  ...current,
+  fields: [
+    ...current.fields.filter((field) => field.key !== 'b'),
+    {
+      key: 'c',
+      kind: 'number',
+      defaultValue: 10,
+      validate: (value): value is number =>
+        typeof value === 'number' && Number.isFinite(value),
+      persist: true,
+      project: true,
+      unit: false
+    }
+  ]
+}))
+
+core.unregisterRenderStrategy('a-shape')
+core.registerRenderStrategy('a-shape', renderAShapeWithC)
+
+core.unregisterUIProperty('aStyle')
+core.defineUIProperty('aStyle', createAStyleUIPropertyWithC())
+
+core.registerLoadHook(migrateAStyleBToC)
+await core.start(container, renderOptions)
+```
+
+The data path after composition remains canonical:
+
+```text
+Feature / app API
+-> core.changeComputedData(...) or updatePropertyById(...)
+-> Props Manager validation and property getValue()
+-> Scene Tree computed data
+-> registered render strategy and/or UI-context compute
+```
+
+App code can use a local custom-field interface in the normal typed APIs without
+unsafe casts. The typed surface must cover:
+
+- id-first `updatePropertyById()` calls for app-declared fields;
+- `EngineNeutralRenderStrategy` input data;
+- `PropertyComputeContext.elements` for app-defined UI aggregation.
+
+Existing builtin call sites remain source-compatible. This type work changes no
+runtime owner and adds no engine-specific data.
+
+The existing `defineUIProperty()` name is already the primary UI declaration
+API. Render replacement continues to use
+`unregisterRenderStrategy() -> registerRenderStrategy()`. Naming aliases or
+general `redefineRenderStrategy()` / `redefineUIProperty()` operations are out
+of scope.
+
+## Ownership And Boundaries
+
+- `@asyra/props-manager` owns normalized definition projection, schema/runtime
+  validation, usage guards, staging, atomic swap, rollback, and runtime/load
+  validation semantics.
+- `@asyra/core` owns the app-facing getter/redefinition facade, permanent
+  composition lock, graph owner update, preserved relation coordination, and
+  final structural relation validation.
+- `@asyra/scene-tree` continues to project property `getValue()` into computed
+  element data; it does not interpret custom field meaning.
+- `@asyra/render` supplies typed engine-neutral render-strategy input and does
+  not infer how a new field should draw.
+- `@asyra/ui-context` supplies typed app aggregation input and remains optional,
+  derived-only state.
+- `@asyra/preset` continues to install official defaults through the public
+  Core facade. It exposes no preset-specific redefinition object or private app
+  path.
+- App composition owns the updater, explicit relation/render/UI replacements,
+  domain commands, and deterministic document migration.
+- `@asyra/render-engine` and `@asyra/render-engine-pixi` are unchanged.
+
+## Product Cases
+
+1. Definition read: an app reads a deeply detached normalized Fill or Stroke
+   definition; mutating the returned data cannot change registries.
+2. Add field: adding C makes its validated default, save output, projected
+   value, typed app update, render input, and optional UI aggregation available
+   through the canonical flow.
+3. Remove field: removing B removes it from validation/default/save/value/unit
+   roles together; a later runtime write to B is rejected rather than mapped to
+   C.
+4. Replace field meaning: the app removes B, adds C, and explicitly replaces
+   affected render/UI/domain consumers through ordinary APIs; the framework
+   does not claim semantic equivalence.
+5. Nested boundary: an app customizing `stroke.fill` replaces that complete
+   top-level field definition or redefines an app-owned Fill type; no nested
+   property-path API is introduced.
+6. Relation preservation: redefinition preserves existing graph relations;
+   stale fixed aliases or child keys block startup until the app uses the
+   existing relation APIs.
+7. Failure atomicity: missing, constructor-mode, in-use, replay-retained,
+   pending-cleanup, invalid, updater-throw, and closed-composition cases leave
+   the old definition and relations unchanged.
+8. Load boundary: a missing or invalid C uses the normal load fallback, while a
+   semantic B-to-C conversion occurs only in an app migration before package
+   validation.
+9. App/preset parity: an app performs the complete customization through Core
+   public APIs without a preset deep import or Props Manager singleton access.
+10. Typed consumers: app-declared custom fields compile in id-first updates,
+    render strategies, and UI compute callbacks without unsafe casts.
+
+## Definition Of Done
+
+- The thin product contract and dedicated Inspector agree on every owner,
+  route, bypass, forbidden contributor, product case, and failure owner.
+- Props Manager formal tests prove detached reads, normalized definition
+  parity, active/replay usage guards, atomic commit, rollback, and load/runtime
+  validation.
+- Core formal tests prove open-composition enforcement, app ownership transfer,
+  relation preservation, final structural validation, and no partial graph or
+  registry mutation.
+- Scene Tree, Render, and UI-context tests prove canonical custom-field
+  projection and typed app consumption without changing data authority.
+- Preset integration tests prove that official config-mode types can be read and
+  redefined through the same Core facade available to apps.
+- Golden paths document add, remove, nested top-level replacement, explicit
+  render/UI replacement, and app-owned migration.
+- No general registry replace operation, nested path API, automatic consumer
+  rewrite, render-engine change, fallback field mapping, or app deep import is
+  introduced.
+- Inspector contract tests, affected package tests/builds, root tests, lint,
+  dependency-boundary gates, and focused diff review pass.
+
+## Inspector Authority
+
+- Inspector data:
+  `docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs`
+- Direct-open Inspector:
+  `docs/ai/framework/plans/property-type-redefinition-flow-inspector.html`
+- Contract gate:
+  `docs/ai/framework/plans/property-type-redefinition-flow-inspector.contract.test.cjs`
+
+The product contract owns public behavior. The Inspector owns package and data
+flow boundaries. Formal tests own executable evidence.
+
+## Implementation Segments
+
+Each segment begins with a fresh Inspector Step Execution Card and advances one
+owner step at a time:
+
+1. Props Manager normalized definition projection and atomic declarative
+   rebuild, test-first.
+2. Core facade, composition/ownership coordination, and final structural
+   relation validation, test-first.
+3. Scene Tree canonical custom-field projection verification.
+4. Render and UI-context typed app-consumer surfaces, one package owner at a
+   time.
+5. Preset/Core integration, golden paths, API/package docs, and full gates.

--- a/tools/flow-inspector/embed-viewer.cjs
+++ b/tools/flow-inspector/embed-viewer.cjs
@@ -25,6 +25,10 @@ const targetEntries = [
   path.join(
     projectRoot,
     'docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.html'
+  ),
+  path.join(
+    projectRoot,
+    'docs/ai/framework/plans/property-type-redefinition-flow-inspector.html'
   )
 ]
 

--- a/tools/flow-inspector/viewer-entry.test.cjs
+++ b/tools/flow-inspector/viewer-entry.test.cjs
@@ -140,6 +140,15 @@ const targets = [
     ),
     dataScript: './canvas-pipeline-debugger-flow-inspector.data.cjs',
     filterLaneTitle: 'Diagnostic Projection'
+  },
+  {
+    id: 'property-type-redefinition',
+    entryPath: path.join(
+      projectRoot,
+      'docs/ai/framework/plans/property-type-redefinition-flow-inspector.html'
+    ),
+    dataScript: './property-type-redefinition-flow-inspector.data.cjs',
+    filterLaneTitle: 'Property Runtime'
   }
 ]
 


### PR DESCRIPTION
## Summary

- add the accepted declarative property type redefinition product and architecture plan
- define the pre-start Core and Props Manager ownership boundary without general replace or nested mutation semantics
- add the dedicated Property Type Redefinition Inspector, contract gate, and shared viewer registration
- synchronize framework API, architecture, package, routing, and golden-path documentation

## Validation

- node --test docs/ai/framework/plans/*flow-inspector.contract.test.cjs tools/flow-inspector/viewer-entry.test.cjs (90 passed)
- yarn lint:ci (0 errors; existing warnings only)
- git diff --check

## Scope

Documentation and Inspector tooling only. The planned runtime APIs remain explicitly marked as not implemented.