### PR TITLE
docs(framework): close Canvas Pipeline Debugger plan

### DIFF
--- a/docs/ai/framework/PLANS.md
+++ b/docs/ai/framework/PLANS.md
@@ -6,15 +6,7 @@ This file tracks framework planning topics and points to detailed references.
 
 ## Near-Term Plans
 
-1. Canvas Pipeline Debugger
-
-- Add an optional DEV-runtime surface for app developers to inspect canonical
-  Render input, layer evaluation, and engine-neutral pre-handoff evidence.
-- Do not inspect pixels, hit testing, concrete-engine results, or reconstruct
-  missing output from debug geometry.
-- Reference: `docs/ai/framework/plans/canvas-pipeline-debugger-plan.md`
-
-2. Declarative property type redefinition
+1. Declarative property type redefinition
 
 - Let app developers inspect and atomically redefine one config-mode property
   type after preset composition and before `core.start()`.
@@ -25,7 +17,7 @@ This file tracks framework planning topics and points to detailed references.
   normal property update, render strategy, or UI aggregation paths.
 - Reference: `docs/ai/framework/plans/property-type-redefinition-plan.md`
 
-3. Render delta update pipeline
+2. Render delta update pipeline
 
 - Apply data-channel deltas directly in render update flow to avoid full computed-data rehydrate.
 - Use render-side cached snapshots + key-based invalidation for heavy geometry.

--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -1311,3 +1311,39 @@ unregister -> app migration -> core.start()` as the public app route.
   - `3a2a6c654` (`fix(core): preserve configured provider failures`)
   - `6f76b8aab` (`fix(preset): isolate selectable default prerequisites`)
   - `8a29217b8` (`docs(framework): align preset provider terminology`)
+
+## 2026-07-18 - Canvas Pipeline Debugger completed
+
+- Context:
+  - PR #83 merged the optional Canvas Pipeline Debugger, its dedicated
+    Inspector, formal Render/Core/app coverage, Asyra Design DEV wiring, and
+    production-bundle exclusion to `main`.
+  - PR validation passed. A synchronized live-app closeout review additionally
+    confirmed that a focused element becomes `observed`, exposes canonical
+    workspace/canvas projection, renders a readable debugger-only outline after
+    ordinary selection is cleared, and retains no debugger fault.
+- Decision:
+  - Treat the Canvas Pipeline Debugger plan as implementation complete and
+    archive its product contract at the completed canonical path.
+  - Keep the debugger optional, disabled by default, deterministic,
+    instance-bound, and engine-neutral. Observation stops before the concrete
+    engine call and never claims pixel, hit-test, engine-result, or product-data
+    authority.
+  - Keep the app-facing API limited to
+    `@asyra/core/canvas-pipeline-debugger`; Render support remains an optional
+    non-app-facing subpath and Pixi remains confined to its concrete engine
+    package.
+- Consequences:
+  - Canvas Pipeline Debugger is removed from active framework plans. Its
+    Inspector data, contract test, and direct-open viewer remain the executable
+    architecture authority and now resolve the completed product contract.
+  - Scene Tree and Props Manager do not gain separate debuggers without a future
+    concrete runtime-observability requirement.
+  - Debugger data remains transient and cannot become persistence, undo/redo,
+    collaboration, export, interaction, or canonical render input.
+- Related Plan:
+  - `docs/ai/framework/plans/completed/canvas-pipeline-debugger-plan.md`
+- Related Commit(s):
+  - `fbc216ab2b219c9e950e6dfabad102b2a396b981` (`feat(render): add canvas pipeline debugger`)
+  - `77026a8d79a22bcb8ed22d3ff8f6a99f660343ec` (PR #83 merge commit)
+  - [PR #83](https://github.com/karote00/asyra/pull/83)

--- a/docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.contract.test.cjs
@@ -29,7 +29,7 @@ test('product contract and dedicated Inspector remain resolvable authorities', (
 
   assert.equal(
     data.authority.specPath,
-    'docs/ai/framework/plans/canvas-pipeline-debugger-plan.md'
+    'docs/ai/framework/plans/completed/canvas-pipeline-debugger-plan.md'
   )
   assert.equal(
     data.authority.inspectorPath,
@@ -131,7 +131,7 @@ test('overlay remains non-interactive and cleanup is debugger-owned', () => {
 
 test('overlay faults enter the session read model before cleanup', () => {
   const spec = fs.readFileSync(
-    path.resolve(__dirname, 'canvas-pipeline-debugger-plan.md'),
+    path.resolve(__dirname, 'completed/canvas-pipeline-debugger-plan.md'),
     'utf8'
   )
   const session = step('control-debug-session')
@@ -171,7 +171,7 @@ test('overlay faults enter the session read model before cleanup', () => {
 
 test('Inspector names bounded product cases and definition of done', () => {
   const spec = fs.readFileSync(
-    path.resolve(__dirname, 'canvas-pipeline-debugger-plan.md'),
+    path.resolve(__dirname, 'completed/canvas-pipeline-debugger-plan.md'),
     'utf8'
   )
   const acceptance = data.acceptanceContracts

--- a/docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.data.cjs
@@ -2,7 +2,7 @@
   'use strict'
 
   const specPath =
-    'docs/ai/framework/plans/canvas-pipeline-debugger-plan.md'
+    'docs/ai/framework/plans/completed/canvas-pipeline-debugger-plan.md'
   const inspectorPath =
     'docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.data.cjs'
 
@@ -527,7 +527,7 @@
       {
         id: 'product-contract',
         label: 'Product Contract',
-        href: './canvas-pipeline-debugger-plan.md',
+        href: './completed/canvas-pipeline-debugger-plan.md',
         kind: 'framework'
       },
       {

--- a/docs/ai/framework/plans/completed/canvas-pipeline-debugger-plan.md
+++ b/docs/ai/framework/plans/completed/canvas-pipeline-debugger-plan.md
@@ -1,5 +1,39 @@
 # Canvas Pipeline Debugger Plan
 
+## Status and Authority
+
+Completed on 2026-07-18. PR #83 merged the optional Canvas Pipeline Debugger
+to `main` at merge commit
+`77026a8d79a22bcb8ed22d3ff8f6a99f660343ec`.
+
+The debugger remains a development-runtime diagnostic surface only. It stops
+at deterministic, engine-neutral pre-handoff evidence and does not claim pixel,
+hit-test, concrete-engine, or product-data authority.
+
+The exact owner flow remains defined by
+`docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.data.cjs`.
+
+## Completion Record
+
+- Final decision: keep one optional, disabled-by-default Core facade for app
+  developers to inspect canonical Render inputs, layer evaluation, bounded
+  trace data, and focused expected-geometry projection during DEV runtime.
+- Implementation summary: Render owns instance-bound observation and detached
+  pre-engine evidence; the optional Render subpath owns deterministic trace and
+  non-interactive overlay projection; Core owns session lifecycle; Asyra Design
+  owns DEV-only loading, console exposure, HMR disposal, and production bypass.
+- Compatibility summary: the Core and Render roots remain free of debugger
+  exports, engine boundaries remain unchanged, and no debugger data enters
+  persistence, undo/redo, collaboration, export, hit testing, or canonical
+  product rendering.
+- Exit criteria: PR #83 validation passed; package, app, root, lint, build,
+  dependency, Inspector, production-exclusion, and diff gates passed; bounded
+  reviews found no unresolved concrete issue; synchronized live-app review
+  confirmed an observed focused projection and readable debugger-only overlay
+  with no retained fault.
+- Canonical executable architecture contract:
+  `docs/ai/framework/plans/canvas-pipeline-debugger-flow-inspector.data.cjs`.
+
 ## Product Contract
 
 Canvas Pipeline Debugger is an optional framework diagnostic surface for app


### PR DESCRIPTION
## Summary

- move the completed Canvas Pipeline Debugger product contract to the framework completed plans directory
- remove the debugger from active PLANS and renumber the remaining near-term work
- update the dedicated Inspector authority and contract test to resolve the completed product contract
- append the 2026-07-18 framework decision-history closeout entry

## Completion evidence

- implementation PR #83 is merged and its validate and Vercel checks passed
- all framework Inspector semantic and shared viewer tests passed: 90 tests
- yarn lint:ci passed with 0 errors; existing no-console warnings remain
- git diff --check and the closeout path/reference matrix passed
- synchronized Asyra Design live-runtime review passed at 1440x900 and 100% zoom: rect-1 was observed with canonical workspace/canvas projection, the debugger-only outline remained readable after ordinary selection was cleared, and snapshot fault was null

## Scope

Documentation and Inspector authority closeout only. No runtime implementation, public API, engine behavior, or debugger E2E harness is changed.