### PR TITLE
docs(framework): close property type redefinition plan

### DIFF
--- a/docs/ai/framework/API_SURFACES.md
+++ b/docs/ai/framework/API_SURFACES.md
@@ -57,7 +57,7 @@ Lifecycle and integration:
     explicitly allowed dynamic aliases retain their dynamic-key policy
   - this is not a general registry replace path and does not rewrite relations,
     render strategies, UI properties, commands, or migrations
-  - authority: `plans/property-type-redefinition-plan.md`
+  - authority: `plans/completed/property-type-redefinition-plan.md`
 - component relation APIs:
   - `defineComponent(definition: ComponentDefinition): void`
   - `unregisterComponent(type, options?): boolean | UnregisterComponentResult`

--- a/docs/ai/framework/ARCHITECTURE.md
+++ b/docs/ai/framework/ARCHITECTURE.md
@@ -201,11 +201,11 @@ applyPreset(core, { profile?, defaults? })
 - There is no semantic-equivalence or replace operation. A full implementation
   change is `unregister default -> define custom`; a non-equivalent structural
   change is `remove old relation -> define new relation`.
-- A bounded pre-start declarative property-type redefinition API is planned in
-  `plans/property-type-redefinition-plan.md`. It will atomically rebuild one
+- The bounded pre-start declarative property-type redefinition API defined in
+  `plans/completed/property-type-redefinition-plan.md` atomically rebuilds one
   config-mode schema/runtime definition without inferring semantic equivalence
-  or adding a general registry replace operation. Until implemented, the
-  current unregister-then-define contract remains authoritative.
+  or adding a general registry replace operation. Constructor-mode types keep
+  the existing unregister-then-define contract.
 - The first `core.start()` closes composition permanently before renderer side
   effects and validates declared relations. Registration composition is not a
   runtime mutation or migration mechanism.

--- a/docs/ai/framework/PLANS.md
+++ b/docs/ai/framework/PLANS.md
@@ -6,18 +6,7 @@ This file tracks framework planning topics and points to detailed references.
 
 ## Near-Term Plans
 
-1. Declarative property type redefinition
-
-- Let app developers inspect and atomically redefine one config-mode property
-  type after preset composition and before `core.start()`.
-- Keep relation, render strategy, UI-context, and migration changes explicit
-  through existing Core APIs; do not infer that removed and added fields are
-  semantically equivalent.
-- Provide typed custom-field consumption without requiring app casts in the
-  normal property update, render strategy, or UI aggregation paths.
-- Reference: `docs/ai/framework/plans/property-type-redefinition-plan.md`
-
-2. Render delta update pipeline
+1. Render delta update pipeline
 
 - Apply data-channel deltas directly in render update flow to avoid full computed-data rehydrate.
 - Use render-side cached snapshots + key-based invalidation for heavy geometry.

--- a/docs/ai/framework/REQUEST_ROUTING.md
+++ b/docs/ai/framework/REQUEST_ROUTING.md
@@ -43,8 +43,8 @@ Use this file to route a new framework request to the right docs first.
   - `packages/core.md`
   - `packages/props-manager.md`
   - `rules/extension-patterns.md`
-  - planned config-mode field customization:
-    `plans/property-type-redefinition-plan.md`
+  - config-mode field customization:
+    `plans/completed/property-type-redefinition-plan.md`
 
 - render engine abstraction and custom render layers
   - `packages/render.md`

--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -1347,3 +1347,49 @@ unregister -> app migration -> core.start()` as the public app route.
   - `fbc216ab2b219c9e950e6dfabad102b2a396b981` (`feat(render): add canvas pipeline debugger`)
   - `77026a8d79a22bcb8ed22d3ff8f6a99f660343ec` (PR #83 merge commit)
   - [PR #83](https://github.com/karote00/asyra/pull/83)
+
+## 2026-07-19 - Declarative Property Type Redefinition completed
+
+- Context:
+  - PR #86 contains the complete pre-start property redefinition contract,
+    implementation, formal package coverage, executable Inspector authority,
+    golden paths, and synchronized framework/app documentation.
+  - Bounded sub-agent and independent reviews were resolved, and the product
+    owner verified through an uncommitted Asyra Design example that Fill fields
+    can be changed and Dimension fields added with explicit typed UI/data
+    consumers and no render coupling.
+- Decision:
+  - Treat Declarative Property Type Redefinition as implementation complete and
+    archive its product contract at the completed canonical path.
+  - Keep `getPropertyTypeDefinition()` and `redefinePropertyType()` as the only
+    high-level Core route for complete config-mode field customization after
+    optional preset composition and before the first `core.start()`.
+  - Keep semantic consumers explicit and owner-local: relations, render
+    strategies, UI properties, commands, and migrations are never rewritten or
+    inferred from removed/added fields.
+- Consequences:
+  - Props Manager remains the sole schema/runtime rebuild owner; Core coordinates
+    composition, owner transfer, relation preservation, and final structural
+    validation without adding general registry replace semantics.
+  - Official preset types and app types use the same public Core API, while
+    constructor-mode types retain unregister/define composition.
+  - Custom fields remain typed through id-first property updates, engine-neutral
+    render strategies, and UI compute elements; render-engine/Pixi and load
+    migration ownership remain unchanged.
+  - The plan is removed from active framework plans. Its Inspector data,
+    contract test, and viewer remain executable architecture authorities and now
+    resolve the completed product contract.
+  - PR #86 remains open for owner review; this closeout does not claim merge or
+    release completion.
+- Related Plan:
+  - `docs/ai/framework/plans/completed/property-type-redefinition-plan.md`
+- Related Commit(s):
+  - `341ddee24` (`feat(props-manager): add atomic property type definition owner`)
+  - `a57a3640c` (`feat(core): coordinate declarative property redefinition`)
+  - `a2c06ec4c` (`test(scene-tree): verify canonical custom field projection`)
+  - `8b21fef07` (`feat(render): type app-defined strategy data`)
+  - `b009d20c5` (`feat(ui-context): type app-defined compute data`)
+  - `4b66ba0c9` (`test(preset): verify public property redefinition flow`)
+  - `ff5f8a1ee` (`fix(props-manager): distinguish object and array values`)
+  - `779d6a427` (`fix(preset): align fill definitions for redefinition`)
+  - [PR #86](https://github.com/karote00/asyra/pull/86)

--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -1379,8 +1379,9 @@ unregister -> app migration -> core.start()` as the public app route.
   - The plan is removed from active framework plans. Its Inspector data,
     contract test, and viewer remain executable architecture authorities and now
     resolve the completed product contract.
-  - PR #86 remains open for owner review; this closeout does not claim merge or
-    release completion.
+  - PR #86 merged to `main` at
+    `91cee525af34ebb9f2fa717610663d61b245589a`; this closeout records the merged
+    plan state but does not claim release completion.
 - Related Plan:
   - `docs/ai/framework/plans/completed/property-type-redefinition-plan.md`
 - Related Commit(s):
@@ -1392,4 +1393,5 @@ unregister -> app migration -> core.start()` as the public app route.
   - `4b66ba0c9` (`test(preset): verify public property redefinition flow`)
   - `ff5f8a1ee` (`fix(props-manager): distinguish object and array values`)
   - `779d6a427` (`fix(preset): align fill definitions for redefinition`)
+  - `91cee525a` (`Framework: declarative property type redefinition (#86)`)
   - [PR #86](https://github.com/karote00/asyra/pull/86)

--- a/docs/ai/framework/plans/completed/property-type-redefinition-plan.md
+++ b/docs/ai/framework/plans/completed/property-type-redefinition-plan.md
@@ -1,9 +1,37 @@
 # Declarative Property Type Redefinition Plan
 
-## Status
+## Status and Authority
 
-Accepted product and architecture plan. The APIs and runtime behavior described
-here are not implemented yet.
+Completed on 2026-07-19 after implementation review and direct Asyra Design
+verification by the product owner. The implementation is complete on
+`codex/property-type-redefinition-implementation` and published for review in
+PR #86. This closeout archives the accepted product contract before merge by
+explicit owner direction; it does not claim that PR #86 has merged or shipped.
+
+The exact owner flow remains defined by
+`docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs`.
+
+## Completion Record
+
+- Final decision: apps may inspect and atomically redefine one complete
+  config-mode property type through Core after optional preset composition and
+  before the first `core.start()`; constructor-mode types keep their existing
+  unregister/define path.
+- Implementation summary: Props Manager owns normalized detached definitions,
+  validation, usage guards, and atomic schema/runtime rebuild; Core owns the
+  public facade, composition lock, relation preservation, structural startup
+  validation, and app ownership transfer; Scene Tree, Render, and UI Context
+  retain typed downstream projection boundaries.
+- Compatibility summary: official preset types use the same Core route as app
+  types, builtin call sites remain source-compatible, render-engine/Pixi
+  boundaries are unchanged, and load migration remains app-owned before
+  package validation.
+- Exit criteria: all Inspector segments, affected package/app and root gates,
+  lint, build, dependency boundaries, bounded sub-agent and independent
+  reviews, regression repairs, and direct product-owner app verification passed
+  with no unresolved P0/P1/P2 finding.
+- Canonical executable architecture contract:
+  `docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs`.
 
 ## Product Contract
 
@@ -323,11 +351,11 @@ flow boundaries. Formal tests own executable evidence.
 Each segment begins with a fresh Inspector Step Execution Card and advances one
 owner step at a time:
 
-1. Props Manager normalized definition projection and atomic declarative
+1. [x] Props Manager normalized definition projection and atomic declarative
    rebuild, test-first.
-2. Core facade, composition/ownership coordination, and final structural
+2. [x] Core facade, composition/ownership coordination, and final structural
    relation validation, test-first.
-3. Scene Tree canonical custom-field projection verification.
-4. Render and UI-context typed app-consumer surfaces, one package owner at a
+3. [x] Scene Tree canonical custom-field projection verification.
+4. [x] Render and UI-context typed app-consumer surfaces, one package owner at a
    time.
-5. Preset/Core integration, golden paths, API/package docs, and full gates.
+5. [x] Preset/Core integration, golden paths, API/package docs, and full gates.

--- a/docs/ai/framework/plans/completed/property-type-redefinition-plan.md
+++ b/docs/ai/framework/plans/completed/property-type-redefinition-plan.md
@@ -4,9 +4,9 @@
 
 Completed on 2026-07-19 after implementation review and direct Asyra Design
 verification by the product owner. The implementation is complete on
-`codex/property-type-redefinition-implementation` and published for review in
-PR #86. This closeout archives the accepted product contract before merge by
-explicit owner direction; it does not claim that PR #86 has merged or shipped.
+`codex/property-type-redefinition-implementation` and merged to `main` through
+PR #86 at `91cee525af34ebb9f2fa717610663d61b245589a`. This closeout archives the
+accepted product contract after merge; it does not claim a shipped release.
 
 The exact owner flow remains defined by
 `docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs`.

--- a/docs/ai/framework/plans/property-type-redefinition-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/property-type-redefinition-flow-inspector.contract.test.cjs
@@ -36,7 +36,7 @@ test('plan and dedicated Inspector remain resolvable authorities', () => {
 
   assert.equal(
     data.authority.specPath,
-    'docs/ai/framework/plans/property-type-redefinition-plan.md'
+    'docs/ai/framework/plans/completed/property-type-redefinition-plan.md'
   )
   assert.equal(
     data.authority.inspectorPath,
@@ -201,7 +201,7 @@ test('routes preserve owner boundaries for definition read, rebuild, and consume
 
 test('product contract names bounded cases and rejects scope expansion', () => {
   const spec = fs.readFileSync(
-    path.resolve(__dirname, 'property-type-redefinition-plan.md'),
+    path.resolve(__dirname, 'completed/property-type-redefinition-plan.md'),
     'utf8'
   )
   const acceptance = data.acceptanceContracts

--- a/docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs
@@ -2,7 +2,7 @@
   'use strict'
 
   const specPath =
-    'docs/ai/framework/plans/property-type-redefinition-plan.md'
+    'docs/ai/framework/plans/completed/property-type-redefinition-plan.md'
   const inspectorPath =
     'docs/ai/framework/plans/property-type-redefinition-flow-inspector.data.cjs'
 
@@ -706,7 +706,7 @@
       {
         id: 'product-contract',
         label: 'Product Contract',
-        href: './property-type-redefinition-plan.md',
+        href: './completed/property-type-redefinition-plan.md',
         kind: 'authority'
       },
       {


### PR DESCRIPTION
## Summary

- archive the completed Declarative Property Type Redefinition plan
- remove it from active framework plans and promote Render Delta Update Pipeline
- update canonical API, architecture, routing, Inspector, and decision references
- record that implementation PR #86 merged to main

## Validation

- `node --test docs/ai/framework/plans/property-type-redefinition-flow-inspector.contract.test.cjs` (8/8 passed)
- completed plan and canonical references verified
- stale active-plan references: none
- `git diff --check origin/main...HEAD` passed