### PR TITLE
Framework: define release gate roadmap

### DIFF
--- a/docs/ai/framework/ARCHITECTURE.md
+++ b/docs/ai/framework/ARCHITECTURE.md
@@ -124,7 +124,11 @@ Canonical shorthand:
 - Core observes only its injected Factory instance, serializes persistence after
   committed action/undo/redo outcomes, and reports persistence separately from
   runtime commit.
-- Scene-tree owns entity graph.
+- Scene-tree owns entity graph. In Release Gate 3 it remains the canonical owner
+  for parent membership, child order, cycle prevention, and
+  group/reparent/subtree invariants; Preset will own the optional official Group
+  defaults and basic operation adapters, while apps own Group interaction and
+  UI policy. These complete operations are planned, not current behavior.
 - Props-manager owns property component values and schema validation.
 - System-context owns app/system mode flags.
 - Render owns state-to-engine adaptation, layer/strategy orchestration, handle
@@ -239,7 +243,23 @@ applyPreset(core, { profile?, defaults? })
 - These guarantees are local application semantics. They do not lock external
   processes or remote clients and do not provide database serializability.
 - Yjs provider/room/auth, awareness/presence, remote origin and deduplication,
-  reconnect, convergence, and collaborative conflict policy remain deferred.
+  reconnect, convergence, and collaborative conflict policy are not implemented
+  yet and are required by Framework Release Gate 2. Runtime activation remains
+  optional for non-collaborative apps.
+
+## Framework Release Sequence
+
+The first public framework release is gated, in order, by:
+
+1. app-level migration pipeline formalization and closeout;
+2. optional-at-runtime Yjs network collaboration and conflict-policy foundation;
+3. canonical Group hierarchy behaviors plus Preset basic operations;
+4. optional AI agent runtime with replaceable provider and app-owned actions;
+5. framework release-readiness audit and closeout.
+
+Auto-layout, its unit/UI aggregation family, and production `3D`/`HYBRID`
+remain post-release Roadmap capabilities. Detailed scope and status are owned by
+`PLANS.md`; this sequence does not claim that an unclosed gate is implemented.
 
 ## Package Deep Dives
 

--- a/docs/ai/framework/CONSTRAINTS.md
+++ b/docs/ai/framework/CONSTRAINTS.md
@@ -38,6 +38,9 @@
 
 - Not implemented yet.
 - Unit conversion hooks are preparatory only.
+- Auto-layout and its unit/UI aggregation family are post-release Roadmap work,
+  not part of the first framework release gate sequence.
+- See `plans/auto-layout-behavior-engine-plan.md`.
 
 2. Engine portability
 
@@ -80,8 +83,31 @@
 - A network provider, room/auth lifecycle, awareness/presence, remote canonical
   apply pipeline, offline/server persistence, dedupe/origin handling, and full
   collaboration conflict policy are not implemented yet.
+- These capabilities are required by Framework Release Gate 2 but remain
+  optional to activate at app runtime.
 - See `plans/yjs-network-collaboration-plan.md` and
   `plans/collaborative-conflict-policies-plan.md`.
+
+9. Group hierarchy operations
+
+- Preset `CONTAINERS` currently installs the official Group component and
+  hierarchy projection, while Scene Tree owns parent ids and child order.
+- Atomic public group, ungroup, reparent/reorder, and subtree lifecycle behavior
+  is not complete yet.
+- These data/pipeline behaviors are required by Framework Release Gate 3; Group
+  UI, selection policy, shortcuts, hover, and click behavior remain app-owned.
+- See `plans/group-component-and-hierarchy-behaviors-plan.md`.
+
+10. AI agent runtime
+
+- No reusable AI action-planning runtime or production-capable provider adapter
+  is implemented yet.
+- The AI runtime is required by Framework Release Gate 4 but remains optional to
+  install and activate; apps that omit it must create no model-provider,
+  network, secret, or AI lifecycle side effect.
+- App-owned registered actions and ordinary transaction/validation/state paths
+  remain authoritative; model output is never canonical scene state.
+- See `plans/ai-agent-runtime-plan.md`.
 
 ## Documentation Rule
 

--- a/docs/ai/framework/PLANS.md
+++ b/docs/ai/framework/PLANS.md
@@ -4,35 +4,65 @@ Never record completed plans here.
 
 This file tracks framework planning topics and points to detailed references.
 
-## Deferred Plans
+## Framework Release Gates
 
-1. Auto-layout behavior engine.
+Complete and close these plans in order before the first public Asyra Framework
+release. A release gate may begin implementation only after its product contract
+and matching Inspector owner flow satisfy
+`docs/ai/framework/rules/inspector-contract-readiness.md`.
 
-- Reference: `docs/ai/framework/plans/unit-conversion-and-ui-aggregation-plan.md`
+1. App-level migration pipeline formalization and closeout
 
-2. App-level migration pipeline formalization
-
-- Versioned hook chain and migration templates.
+- Audit the existing ordered load-hook pipeline, formalize version-step and
+  failure semantics, add the reusable app migration example/template, and close
+  any remaining contract or test gap.
 - Reference: `docs/ai/framework/plans/props-manager-app-level-migration-plan.md`
 
-3. AI agent runtime
+2. Yjs network collaboration and conflict-policy foundation
 
-- Optional reusable package for natural-language planning, structured action validation, transaction-bounded execution, provider replacement, and app-owned domain actions.
+- Ship optional-at-runtime, provider-replaceable CRDT collaboration as part of
+  the framework release: instance/provider ownership, room/auth boundary,
+  remote canonical apply, origin/dedupe, awareness, persistence interfaces,
+  reconnect/convergence, local-only undo, and deterministic framework conflict
+  handling.
+- Apps that do not need collaboration remain free to omit provider/runtime
+  activation.
+- References:
+  - `docs/ai/framework/plans/yjs-network-collaboration-plan.md`
+  - `docs/ai/framework/plans/collaborative-conflict-policies-plan.md`
+
+3. Group component and hierarchy behaviors
+
+- Complete canonical Scene Tree group, ungroup, reparent/reorder, subtree,
+  validation, replay, collaboration, load/save, and Render projection behavior.
+- Preset `CONTAINERS` provides the official Group component and basic
+  ID-driven operations; selection choice, shortcuts, hover/click behavior, and
+  UI presentation remain app-owned.
+- Reference:
+  `docs/ai/framework/plans/group-component-and-hierarchy-behaviors-plan.md`
+
+4. AI agent runtime
+
+- Ship an optional reusable package for natural-language planning, structured
+  action validation, permission/confirmation policy, transaction-bounded
+  execution, provider replacement, safe secret boundaries, and app-owned domain
+  actions.
+- AI activation remains opt-in and model output never becomes canonical scene
+  state or bypasses Feature System, ordinary app/Core APIs, validation,
+  undo/redo, persistence, collaboration, or Render derivation.
 - Reference: `docs/ai/framework/plans/ai-agent-runtime-plan.md`
 
-4. Unit-aware property model (auto-layout-oriented)
+5. Framework Release Readiness Audit and Closeout
 
-- Support value+unit semantics in schema/aggregates.
-- Keep auto-layout implementation out of this phase.
-- Reference: `docs/ai/framework/plans/unit-conversion-and-ui-aggregation-plan.md`
+- Freeze and audit the supported public surface, package artifacts, dependency
+  boundaries, clean-consumer installation, generated templates, release
+  documentation, and full formal gate matrix without publishing automatically.
+- Reference:
+  `docs/ai/framework/plans/framework-release-readiness-and-closeout-plan.md`
 
-5. UI aggregate helpers (lowest priority, auto-layout-related)
+## Post-Release Roadmap
 
-- Mixed values and mixed units (`MIX`) helpers.
-- App-level registration remains first-class.
-- Reference: `docs/ai/framework/plans/unit-conversion-and-ui-aggregation-plan.md`
-
-6. Official 2D/3D/hybrid preset profiles
+1. Official 2D/3D/hybrid preset profiles
 
 - Publish a render-mode profile only after its concrete engine and canonical
   feature/property/schema/render/input default modules exist and pass the engine
@@ -42,14 +72,20 @@ This file tracks framework planning topics and points to detailed references.
 - Do not expose empty, placeholder, or capability-incomplete profiles.
 - Reference: `docs/ai/framework/plans/preset-2d-3d-init-profile-plan.md`
 
-7. Yjs network collaboration (final collaboration architecture phase)
+2. Auto-layout behavior engine (lowest-priority roadmap family)
 
-- Add provider/room/auth lifecycle, remote canonical apply, origin/dedupe,
-  awareness, offline/server persistence, and reconnect/convergence contracts.
-- Depends on stable local transaction atomicity, state ownership, replay, and
-  selective instance boundaries.
-- Reference: `docs/ai/framework/plans/yjs-network-collaboration-plan.md`
+- Advanced optional Preset behavior for design tools; it is not a first-release
+  framework requirement.
+- Reference: `docs/ai/framework/plans/auto-layout-behavior-engine-plan.md`
 
-8. Advanced collaborative conflict policies (Yjs collaboration sub-plan)
+3. Unit-aware property model (auto-layout-oriented)
 
-- Reference: `docs/ai/framework/plans/collaborative-conflict-policies-plan.md`
+- Support value+unit semantics in schema/aggregates.
+- Keep auto-layout implementation out of this phase.
+- Reference: `docs/ai/framework/plans/unit-conversion-and-ui-aggregation-plan.md`
+
+4. UI aggregate helpers (lowest priority, auto-layout-related)
+
+- Mixed values and mixed units (`MIX`) helpers.
+- App-level registration remains first-class.
+- Reference: `docs/ai/framework/plans/unit-conversion-and-ui-aggregation-plan.md`

--- a/docs/ai/framework/REQUEST_ROUTING.md
+++ b/docs/ai/framework/REQUEST_ROUTING.md
@@ -39,6 +39,23 @@ Use this file to route a new framework request to the right docs first.
   - `plans/yjs-network-collaboration-plan.md`
   - `plans/collaborative-conflict-policies-plan.md`
 
+- group/ungroup/reparent/reorder/subtree hierarchy behavior
+  - `packages/scene-tree.md`
+  - `packages/preset.md`
+  - `packages/factory.md`
+  - `plans/group-component-and-hierarchy-behaviors-plan.md`
+
+- AI intent/action planning/provider/permission/transaction execution
+  - `FRAMEWORK_ESSENTIALS.md`
+  - `packages/feature-system.md`
+  - `packages/factory.md`
+  - `plans/ai-agent-runtime-plan.md`
+
+- auto-layout/unit-aware layout/UI aggregation Roadmap
+  - `CONSTRAINTS.md`
+  - `plans/auto-layout-behavior-engine-plan.md`
+  - `plans/unit-conversion-and-ui-aggregation-plan.md`
+
 - component/property/schema registration
   - `packages/core.md`
   - `packages/props-manager.md`
@@ -63,8 +80,16 @@ Use this file to route a new framework request to the right docs first.
   - `rules/load-validation-and-migration.md`
   - `packages/props-manager.md`
   - `PLANS.md`
+  - `plans/props-manager-app-level-migration-plan.md`
   - `plans/completed/*` (for completed migration/validation history)
   - `decisions/releases/*` (for release-scoped rationale history)
+
+- framework release readiness/package publication closeout
+  - `PLANS.md`
+  - `plans/framework-release-readiness-and-closeout-plan.md`
+  - `rules/generated-artifacts.md`
+  - `rules/pre-release-legacy-removal.md`
+  - `decisions/releases/README.md`
 
 - deprecated package behavior/removal timeline
   - `rules/deprecation-lifecycle.md`

--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -1446,3 +1446,62 @@ unregister -> app migration -> core.start()` as the public app route.
   - `2465a6663` (`fix(render): retain failed hierarchy handoffs`)
   - `7009b471d` (`fix(render): rollback failed reparent handoffs`)
   - [PR #88](https://github.com/karote00/asyra/pull/88)
+
+## 2026-07-19 - Define first framework release gate sequence
+
+- Context:
+  - The Render Delta Update Pipeline closeout left no Near-Term framework plan,
+    while the remaining Deferred list mixed release prerequisites with optional
+    future capabilities.
+  - Most design-oriented canvas tools require a CRDT collaboration foundation
+    even though individual apps may choose not to activate collaboration.
+  - The first release is also expected to provide a safe opt-in AI action
+    runtime without turning any model provider or app-domain agent into a Core
+    dependency.
+  - Preset already installs an official Group component, but Scene Tree, Factory,
+    collaboration, Preset operations, load/save, and Render do not yet expose one
+    complete atomic group/ungroup/reparent/subtree contract.
+  - This supersedes the 2026-02-28 priority decisions that kept app migration and
+    Yjs collaboration in the deferred queue; it does not rewrite those historical
+    entries.
+- Decision:
+  - Require five ordered gates before the first public Asyra Framework release:
+    app-level migration formalization/closeout, optional-at-runtime Yjs network
+    collaboration and conflict policy, Group hierarchy behavior with Preset
+    basic operations, optional AI agent runtime with a replaceable production
+    provider boundary, and framework release-readiness audit/closeout.
+  - Keep Scene Tree as canonical hierarchy owner, Factory/Yjs as transaction and
+    shared-delivery infrastructure, Preset as official Group default/basic
+    operation owner, Render as derived hierarchy projection, and apps as owners
+    of selection, commands, hover/click behavior, and UI presentation.
+  - Keep Auto-layout and its unit/UI aggregation family at the lowest
+    post-release priority. Keep production 3D/Hybrid profile activation on the
+    post-release Roadmap.
+- Consequences:
+  - Collaboration ships in the framework release but remains explicitly
+    opt-in, so non-collaborative apps incur no provider, room, awareness, network,
+    or lifecycle activation.
+  - Group work extends the existing component/container baseline instead of
+    registering a duplicate Group or placing design-tool UI policy in framework
+    packages.
+  - AI ships as an optional package/runtime: app-owned registered actions and
+    Feature System lifecycle plus ordinary transaction, validation,
+    collaboration, canonical state, and Render paths remain authoritative,
+    while apps that omit AI activate no provider, model network, secret, or AI
+    lifecycle behavior.
+  - Each gate remains queued rather than implementation-ready until its thin
+    product contract and exact Inspector owner flow pass readiness review.
+  - The final gate audits packed artifacts, public APIs, clean-consumer use,
+    generated templates, formal gates, and release records; it does not itself
+    authorize push, merge, tag, or publication.
+- Related Plan:
+  - `docs/ai/framework/PLANS.md`
+  - `docs/ai/framework/plans/props-manager-app-level-migration-plan.md`
+  - `docs/ai/framework/plans/yjs-network-collaboration-plan.md`
+  - `docs/ai/framework/plans/collaborative-conflict-policies-plan.md`
+  - `docs/ai/framework/plans/group-component-and-hierarchy-behaviors-plan.md`
+  - `docs/ai/framework/plans/ai-agent-runtime-plan.md`
+  - `docs/ai/framework/plans/framework-release-readiness-and-closeout-plan.md`
+  - `docs/ai/framework/plans/auto-layout-behavior-engine-plan.md`
+- Related Commit(s):
+  - pending

--- a/docs/ai/framework/packages/factory.md
+++ b/docs/ai/framework/packages/factory.md
@@ -186,12 +186,19 @@ infrastructure.
   their nested transaction calls back to that same instance; they do not touch
   the default Factory history or statuses.
 
-## Deferred Contracts
+## Release-Blocking Planned Contracts
 
-- Yjs network collaboration:
+- Yjs network collaboration is required before the first framework release but
+  remains optional to activate at app runtime:
   `../plans/yjs-network-collaboration-plan.md`
-- advanced domain conflict policy:
+- deterministic framework conflict policy and app extension points are part of
+  that same release gate:
   `../plans/collaborative-conflict-policies-plan.md`
+
+These contracts are not implemented by the current local shared-channel
+infrastructure. Until the release gate closes, Factory must not be described as
+providing provider/room/auth, remote canonical apply, awareness, reconnect, or
+network convergence.
 
 ## Validation Checklist
 

--- a/docs/ai/framework/packages/preset.md
+++ b/docs/ai/framework/packages/preset.md
@@ -150,6 +150,25 @@ no extension object, deep-import path, field mapping, or replace registry.
 Constructor-mode types and complete capability replacement retain the explicit
 unregister-then-define route.
 
+## Release-Blocking Group Operations
+
+`CONTAINERS` already installs the official invisible Group component and its
+Render projection. Before the first framework release it must also provide the
+basic ID-driven group/ungroup adapters defined by
+`../plans/group-component-and-hierarchy-behaviors-plan.md`.
+
+- The adapters use public Core/Scene Tree/property boundaries and never mutate
+  hierarchy or computed data directly.
+- Preset owns default 2D coordinate normalization and direct-child Group bounds
+  for the supported basic operation contract.
+- Preset does not choose selected ids, register shortcuts or app commands,
+  define post-operation selection, or own hover/click/hit/UI behavior.
+- Apps may replace the official Group capability through the ordinary
+  pre-start composition route without patching Preset internals.
+
+These operation adapters and complete atomic hierarchy semantics are planned,
+not current runtime behavior.
+
 ## Validation Checklist
 
 - imports are side-effect free;

--- a/docs/ai/framework/packages/scene-tree.md
+++ b/docs/ai/framework/packages/scene-tree.md
@@ -77,6 +77,26 @@ owner refresh. It does not reconstruct removed or non-projected fields from
 schema/defaults, interpret custom field meaning, or become a second schema
 owner.
 
+## Release-Blocking Group Hierarchy Contract
+
+Scene Tree currently owns container membership and sibling order, but the first
+framework release additionally requires one atomic public contract for group,
+ungroup, reparent/reorder, and subtree lifecycle behavior.
+
+- Scene Tree owns validation, exact before/after parent/index evidence, cycle
+  prevention, one-parent membership, deterministic order, and subtree
+  restoration for every registered `isContainer` component.
+- The Core-facing operation boundary is ID-based; apps and Preset must not need
+  internal Group instances or mutate `parentId`/`children` directly.
+- A hierarchy move preserves entity identity and is not modeled as deleting and
+  recreating a different entity.
+- Preset owns only official Group defaults and basic coordinate/bounds adapters;
+  app interaction and UI policy remain outside Scene Tree.
+
+This target is not implemented yet. Its supported cases and release gate are
+defined by
+`../plans/group-component-and-hierarchy-behaviors-plan.md`.
+
 ## Validation Checklist
 
 - Entity creation updates graph + computed data consistently.

--- a/docs/ai/framework/plans/ai-agent-runtime-plan.md
+++ b/docs/ai/framework/plans/ai-agent-runtime-plan.md
@@ -1,5 +1,22 @@
 # AI Agent Runtime Plan
 
+## Status
+
+Framework Release Gate 4: required after the Group hierarchy gate closes and
+before the final release-readiness audit.
+
+The package ships in the first public framework release but remains optional to
+install and activate at app runtime. Before implementation begins, create the
+matching Inspector owner flow for app intent/context, provider request/result,
+Feature System lifecycle, plan validation, permission/confirmation, transaction
+execution, canonical state mutation, collaboration routing, audit output,
+failure, and cleanup.
+
+Release inclusion requires at least one production-capable provider adapter or
+generic provider integration through the replaceable boundary. The exact first
+adapter is decided by the Inspector without making that provider mandatory for
+apps or exposing browser-held secrets by default.
+
 ## Context
 
 Asyra is a canvas-tool framework, not a model provider. AI support should
@@ -34,6 +51,9 @@ End-state:
 - apps can opt into AI without making AI a core framework dependency
 - natural-language intent becomes structured action plans
 - action plans are validated before execution
+- the app invokes planning/execution inside an app-owned Feature System
+  execution or session; the AI runtime does not become another intent lifecycle
+  owner
 - accepted plans execute through app-owned APIs and transaction runners
 - one accepted AI plan maps to one intended undo commit by default
 - collaboration-compatible apps can route AI-originated changes through the same
@@ -49,6 +69,7 @@ Out of scope for this framework plan:
 - allowing arbitrary code execution from model output
 - allowing AI to bypass Asyra transaction, validation, persistence, or
   collaboration paths
+- creating another execute/session/cancel runtime beside Feature System
 - requiring apps to use AI at all
 - requiring browser clients to hold secret API keys directly
 
@@ -91,6 +112,11 @@ Responsibilities:
 - error handling for invalid action plans, validation failures, partial execution
   prevention, and retry planning
 - optional audit/explanation output describing what the AI planned and executed
+
+The runtime is invoked by an app-owned feature and consumes that feature's
+cancellation/lifecycle signal. It may coordinate provider planning, validation,
+and the accepted action sequence, but Feature System remains the sole owner of
+execute/session/cancel decisions and operation serialization.
 
 The package should not own app-domain actions. For example, the runtime may know
 that an action named `create_shape` exists after the app registers it, but it
@@ -186,7 +212,8 @@ framework default.
 
 Canonical AI action flow:
 
-1. User submits a natural-language request.
+1. An app-owned feature receives the user's natural-language request and invokes
+   the AI runtime with its lifecycle/cancellation context.
 2. App context provider summarizes current state and constraints.
 3. Runtime sends request, context, and available action definitions to the
    provider.
@@ -194,7 +221,8 @@ Canonical AI action flow:
 5. Runtime validates the plan.
 6. Runtime optionally returns a preview for user confirmation.
 7. Runtime executes all accepted actions through app-provided executors inside
-   one transaction runner call.
+   one transaction runner call while the app feature remains the lifecycle
+   owner.
 8. Render updates as derived output from state changes.
 9. If the app uses shared mutation channels, collaborators receive the same state
    changes through the normal collaborative path.
@@ -253,7 +281,7 @@ The runtime should support useful behavior without requiring web search or
 generated media. Apps can add those capabilities as separate registered actions
 or provider extensions.
 
-## Future Implementation Test Plan
+## Implementation Test Plan
 
 Action registry tests:
 - registers actions
@@ -285,10 +313,44 @@ Integration tests:
 - undo reverts the full AI action batch
 - shared/collaborative mutation path receives AI-originated changes when enabled
 
+Release-boundary tests:
+- importing and starting an app without AI activation creates no provider,
+  network request, model configuration, secret read, or AI runtime side effect
+- the production-capable adapter passes structured-output, malformed-result,
+  provider-failure, redaction, abort, timeout, and cleanup cases
+- all planned actions validate before the first mutation and a rejected plan
+  applies no canonical prefix
+- one accepted plan creates one intended undo commit unless the approved plan
+  explicitly declares bounded transaction groups
+- AI-originated shared changes use the same origin/dedupe/conflict/remote apply
+  path as ordinary app actions when collaboration is enabled
+- model output cannot call unregistered actions, internal package APIs, Render
+  objects, arbitrary code, or app-private state
+- provider planning and action execution honor the owning Feature System abort,
+  timeout, and cleanup lifecycle without introducing another session queue
+
+## Release-Gate Definition of Done
+
+- the product contract and Inspector agree on every owner, input/output,
+  Feature System lifecycle, permission, transaction, provider, collaboration,
+  failure, and cleanup route;
+- the reusable runtime package and first production-capable adapter are built,
+  typed, documented, and independently replaceable;
+- registry, validation, permission, confirmation, preflight, execution,
+  rollback/no-partial-mutation, audit, redaction, abort, timeout, and instance
+  isolation tests pass;
+- one reference-app integration proves app-owned actions, complete undo,
+  optional collaboration delivery, and provider replacement through public APIs;
+- non-AI consumers retain unchanged startup, bundle/runtime ownership, and no
+  provider or secret side effect;
+- public package/API/security/example/Golden Path docs and release decisions
+  agree;
+- the plan is archived and the final release-readiness gate may begin.
+
 ## Assumptions
 
 - The package name is `@asyra/ai-agent-runtime`.
-- The plan remains in Deferred Plans until implementation priority changes.
+- This is Framework Release Gate 4 and begins only after Gates 1-3 close.
 - This is a docs-only planning record; no package scaffolding or runtime
   implementation is included yet.
 - The framework package remains app-agnostic and optional.

--- a/docs/ai/framework/plans/auto-layout-behavior-engine-plan.md
+++ b/docs/ai/framework/plans/auto-layout-behavior-engine-plan.md
@@ -1,0 +1,74 @@
+# Auto-Layout Behavior Engine Plan
+
+## Status
+
+Post-release Roadmap, lowest-priority family.
+
+Auto-layout is an advanced optional Preset capability for design-tool products.
+It is not required for the first Asyra Framework release and must not become a
+Core, Scene Tree, Render, or app UI assumption.
+
+Before implementation begins, write the thin supported behavior contract and
+matching Inspector owner flow. This record intentionally does not settle layout
+algorithms while the work remains deferred.
+
+## Goal
+
+Provide official Preset-owned auto-layout defaults that orchestrate generic
+framework property, hierarchy, transaction, and projection APIs without making
+the framework kernel design-tool-specific.
+
+## Ownership Direction
+
+- Scene Tree remains the canonical entity hierarchy owner and does not decide
+  layout policy.
+- Props Manager owns validated property values and unit-aware schemas, not
+  layout algorithms.
+- Preset owns the optional official auto-layout behavior, default property
+  definitions, observers/features, and deterministic recomputation route.
+- Render consumes completed computed geometry and never performs canonical
+  layout.
+- Apps own panels, controls, handles, previews, authoring UX, and replacement or
+  extension of Preset layout behavior.
+
+## Prerequisite Roadmap Work
+
+- deterministic value/unit conversion with parent/layout context;
+- unit-aware property model;
+- mixed-value and mixed-unit UI aggregation helpers where useful;
+- stable Group hierarchy behavior from Framework Release Gate 3;
+- profiling and exact layout equivalence evidence before retaining caches.
+
+The unit and UI helper work is tracked by
+`unit-conversion-and-ui-aggregation-plan.md` and remains preparatory; it does not
+by itself implement an auto-layout engine.
+
+## Deferred Scope Direction
+
+When this Roadmap family is picked up, its product contract must decide at least:
+
+- supported container/layout modes and axis behavior;
+- padding, gap, alignment, distribution, sizing, min/max, and nested-layout
+  semantics;
+- fixed, content-sized, fill, percentage, mixed-unit, empty, invalid, and
+  overflow cases;
+- child order and Group/container interaction;
+- transaction, undo/redo, load/save, collaboration, and instance behavior;
+- Preset extension/replacement boundaries and app-owned UI behavior;
+- Render/hit/export equivalence for completed computed geometry.
+
+## Non-Goals While Deferred
+
+- no placeholder or partial auto-layout profile in Preset;
+- no Core or Scene Tree branch that assumes design-tool layout semantics;
+- no UI-only calculation as canonical data authority;
+- no Render fallback geometry, fixture-specific layout, or cache-driven product
+  correction;
+- no change to the first framework release scope.
+
+## Pickup Condition
+
+Begin only after all framework release gates close and product priority selects
+Auto-layout over the other post-release Roadmap families. At pickup, replace
+this direction record with an implementation-ready product contract and exact
+Inspector before editing production code.

--- a/docs/ai/framework/plans/collaborative-conflict-policies-plan.md
+++ b/docs/ai/framework/plans/collaborative-conflict-policies-plan.md
@@ -2,11 +2,12 @@
 
 ## Parent Plan and Status
 
-This is a deferred sub-plan of
+This is a required sub-plan of Framework Release Gate 2:
 `docs/ai/framework/plans/yjs-network-collaboration-plan.md`.
 
 It must not be implemented before local transaction atomicity, remote canonical
 apply, origin/dedupe handling, and collaboration provider boundaries are stable.
+It does not make app-specific conflict UX a framework responsibility.
 
 ## Goal
 
@@ -38,3 +39,30 @@ Out of scope:
 2. Add policy invocation points in transaction/apply pipeline.
 3. Add default no-op policy set in preset.
 4. Add tests for deterministic outcomes under concurrent edits.
+
+## Release Scope
+
+- Provide a replaceable policy registration/invocation contract at the remote
+  canonical apply boundary.
+- Ship deterministic framework-owned defaults for invariants the framework
+  itself owns, including entity existence, hierarchy membership/order, property
+  validation, and unsupported-operation rejection.
+- Permit apps to register domain policies for app-owned geometry, topology,
+  locks, permissions, and workflow semantics without patching Yjs transport or
+  canonical state owners.
+- Keep awareness, selection presentation, merge dialogs, conflict indicators,
+  and manual resolution UI outside the framework policy owner.
+- A conflict policy may resolve, repair, or reject before canonical commit; it
+  must not patch Render/UI output or create a second state authority.
+
+## Definition of Done
+
+- the matching Yjs Inspector names the policy input, owner, output, rejection,
+  repair, bypass, and downstream canonical-apply routes;
+- duplicate, reordered, concurrent, unauthorized, unsupported, and repaired
+  operations converge or reject deterministically without echo;
+- local undo excludes remote-origin work and rollback compensation re-enters the
+  same conflict/origin pipeline;
+- framework defaults and app extension points have formal instance-isolation
+  and convergence tests;
+- the parent Yjs gate and this sub-plan close together before Release Gate 3.

--- a/docs/ai/framework/plans/framework-release-readiness-and-closeout-plan.md
+++ b/docs/ai/framework/plans/framework-release-readiness-and-closeout-plan.md
@@ -1,0 +1,166 @@
+# Framework Release Readiness Audit and Closeout Plan
+
+## Status
+
+Framework Release Gate 5: queued after the migration, Yjs collaboration, Group
+hierarchy, and AI agent runtime plans are completed and closed.
+
+This gate audits and closes release readiness. It does not authorize a push,
+merge, tag, registry publish, deployment, or release by itself. Those remain
+explicit user-owned remote operations.
+
+Before execution begins, create a release-readiness Inspector that assigns one
+owner to every source, package artifact, generated template, clean-consumer,
+test, documentation, versioning, and release-decision step. The Inspector must
+identify failures without creating another product or package authority.
+
+## Goal
+
+Prove that the documented first-release framework scope can be built, packed,
+installed, imported, initialized, exercised, and understood by a consumer from
+published artifacts alone.
+
+The target release includes:
+
+- deterministic local feature, transaction, validation, persistence, render,
+  preset, and extension contracts already marked complete;
+- the closed app-level migration contract;
+- optional-at-runtime Yjs network collaboration and conflict-policy foundation;
+- the official Preset Group component and basic hierarchy operations;
+- the optional AI agent runtime and its first production-capable replaceable
+  provider adapter;
+- the supported `2D` and `CUSTOM` profile behavior.
+
+Auto-layout, unit-aware aggregation, and production `3D`/`HYBRID` remain
+explicit post-release Roadmap work and must not appear as available release
+capabilities.
+
+## Audit Scope
+
+### 1. Plan and contract closure
+
+- Every preceding release gate is archived under `plans/completed/*` with its
+  final Inspector authority and decision entry.
+- `docs/ai/framework/PLANS.md`, constraints, architecture, package docs, API
+  surfaces, Golden Paths, examples, and release decisions describe the same
+  supported and unsupported behavior.
+- No active plan, TODO, placeholder, unavailable profile, or known P0/P1/P2
+  contract finding is misrepresented as completed capability.
+
+### 2. Public API and package boundary
+
+- Freeze the intended public package names, root/subpath exports, types,
+  runtime entrypoints, peer dependencies, and compatibility/deprecation state.
+- Audit framework, preset, reference app, examples, tests, and generated
+  templates for forbidden deep imports or package-internal dependencies.
+- Remove pre-release legacy product branches instead of publishing competing
+  behavior; keep only documented load migration, diagnostics, or released
+  deprecation paths.
+- Confirm optional collaboration and concrete-engine packages do not introduce
+  mandatory runtime side effects for consumers that omit them.
+- Confirm optional AI packages/adapters do not introduce mandatory model,
+  network, secret, or provider side effects for consumers that omit them.
+
+### 3. Package artifacts and metadata
+
+- Validate each published package's name, version, license, files, entrypoints,
+  exports, type declarations, source maps when intended, dependency classes,
+  and package-manager compatibility.
+- Pack every release package into a reviewable project-local artifact area and
+  verify that required files are present and repository-only/test/secret files
+  are absent.
+- Confirm internal package dependency versions resolve from packed artifacts
+  and do not depend on workspace-only paths or undeclared hoisting.
+
+### 4. Clean-consumer verification
+
+- Install only the packed artifacts into a clean project-local consumer fixture
+  using the documented supported Node, package-manager, TypeScript, React, and
+  browser/runtime ranges.
+- Compile public imports and documented subpath imports without monorepo path
+  aliases.
+- Run a minimal headless Core flow and a minimal Preset `2D` flow.
+- Exercise save/load migration, one transaction with undo/redo, Group
+  group/ungroup hierarchy, and opt-in two-peer collaboration/convergence through
+  public APIs only.
+- Exercise one opt-in AI plan through registered app actions, validation,
+  confirmation/permission, an app-owned Feature System lifecycle, one undo
+  commit, and the shared path when collaboration is enabled.
+- Prove that an app which does not activate collaboration performs no provider,
+  room, awareness, or network startup.
+- Prove that an app which does not activate AI performs no model-provider,
+  secret, AI network, or AI runtime startup.
+
+The durable consumer fixture belongs in the repository if it becomes a formal
+release test. Transient packed artifacts must remain in an ignored project-local
+path and must not be committed.
+
+### 5. Generated templates and examples
+
+- Regenerate `create-app/*` only through the official release/template script.
+- Verify generated consumers contain the current public imports, migration
+  example, preset composition, Group operation route, and optional
+  collaboration/AI setup without app-internal framework access.
+- Run the generated template's documented install, build, test, and startup
+  smoke path.
+
+### 6. Formal quality gates
+
+- affected package tests and builds;
+- root tests and production build;
+- lint and dependency-boundary validation;
+- Inspector contract tests for every release flow;
+- exact app E2E for startup, load, undo/redo, hierarchy, collaboration, Render,
+  AI action execution, cleanup, and instance isolation;
+- performance budgets owned by completed plans;
+- synchronized visual review for supported rendered product cases;
+- primary and independent review with no unresolved P0/P1/P2 finding.
+
+### 7. Release records and handoff
+
+- Produce a bounded readiness result listing passed gates and exact blockers;
+  do not create self-referential readiness matrices or closure packets beyond
+  the Inspector and executable evidence required by project rules.
+- Confirm semantic version, changelog/release notes, migration/deprecation notes,
+  license/attribution, security/contact information, and supported-environment
+  documentation.
+- Prepare the versioned framework decision snapshot according to
+  `docs/ai/framework/decisions/releases/README.md` at the actual release cut.
+- Keep repository commit/push/PR preparation separate from tag and registry
+  publication authority.
+
+## Stop and Failure Conditions
+
+The framework is not release-ready when any of the following remains:
+
+- a preceding release gate is incomplete or its Inspector/product contract
+  conflicts with implementation;
+- packed artifacts cannot build and run outside the monorepo;
+- public docs require an internal/deep import or an undeclared dependency;
+- generated templates are stale or require manual post-generation repair;
+- optional Yjs activation changes non-collaborative runtime behavior;
+- optional AI activation changes non-AI runtime behavior or leaks provider
+  configuration/secrets;
+- Group hierarchy can orphan, duplicate, cycle, partially apply, diverge across
+  peers, or leave stale Render ownership;
+- a pre-release legacy/fallback product route remains reachable;
+- a required gate fails or any P0/P1/P2 review finding is unresolved.
+
+Failures stay owned by their first incorrect package, contract, artifact, or
+release step. The audit must not approve downstream documentation or packaging
+work around an upstream product failure.
+
+## Definition of Done
+
+- every Inspector route and release artifact resolves to one current owner;
+- all release package tarballs pass metadata, content, type, import, and clean
+  consumer verification;
+- the generated app/template and Asyra Design exercise the supported public
+  routes without framework-internal imports;
+- formal quality, collaboration, hierarchy, cleanup, performance, and visual
+  gates pass with no unresolved P0/P1/P2 finding;
+- supported/unsupported capability statements and release records are exact;
+- the audit records either `READY` with reproducible evidence or `BLOCKED` with
+  exact owner failures;
+- after a `READY` result, this plan is closed and the user may separately
+  authorize version commit, push, merge, tag, and publication operations.

--- a/docs/ai/framework/plans/group-component-and-hierarchy-behaviors-plan.md
+++ b/docs/ai/framework/plans/group-component-and-hierarchy-behaviors-plan.md
@@ -1,0 +1,196 @@
+# Group Component and Hierarchy Behaviors Plan
+
+## Status
+
+Framework Release Gate 3: queued after Yjs network collaboration and its
+conflict-policy foundation close.
+
+This plan is a product contract for data and pipeline behavior, not a Group UI
+specification. Before implementation begins, create a matching Inspector owner
+flow for Scene Tree validation/mutation, Factory transaction and collaboration
+delivery, Preset operations, load/save, and Render hierarchy projection.
+
+## Current Baseline
+
+- Scene Tree already owns parent ids, child arrays, container registration,
+  sibling order, and add/remove parent/index replay evidence.
+- Preset `CONTAINERS` already installs the official `GROUP` component, its
+  invisible default Render strategy, and the Scene Tree-to-Render projection.
+- Render already consumes canonical parent/index hierarchy information.
+- The framework does not yet expose one complete atomic contract for grouping,
+  ungrouping, reparenting/reordering, subtree removal, and their failure,
+  replay, collaboration, and load invariants.
+
+The implementation task extends this baseline. It must not register a duplicate
+Group component or model a hierarchy move as deletion plus creation of a new
+entity identity.
+
+## Goal
+
+Provide stable, UI-independent hierarchy behavior that lets a preset-based
+design tool create and manipulate groups through public framework boundaries.
+
+The release result must support:
+
+- creating one Group around valid sibling elements;
+- ungrouping one Group into its parent;
+- moving or reordering existing elements and nested groups without changing
+  their identities;
+- deterministic nested-container and subtree behavior;
+- exact rollback, undo/redo, save/load, CRDT convergence, and Render hierarchy
+  projection;
+- app-owned invocation, selection decisions, shortcuts, hover/click behavior,
+  and presentation.
+
+## Ownership
+
+### Scene Tree
+
+- sole canonical owner of parent membership, child order, cycle prevention,
+  subtree membership, and hierarchy mutation validation;
+- exposes ID-based hierarchy operations through the Core facade rather than
+  requiring apps to hold internal Group instances;
+- validates the complete operation before the first canonical mutation;
+- preserves existing element identity and exact before/after parent/index
+  evidence for replay and collaboration.
+
+Scene Tree must remain generic to every registered `isContainer` component. It
+must not hardcode Preset Group UI or design-tool selection policy.
+
+### Factory and collaboration pipeline
+
+- one user-visible group, ungroup, move, or reorder request is one intended
+  transaction and undo commit;
+- rollback and undo/redo restore exact membership, sibling order, identities,
+  and canonical data;
+- shared delivery preserves transaction grouping and hierarchy provenance;
+- after Release Gate 2, remote apply validates and commits the same canonical
+  hierarchy operation without echo or partial peer-visible state.
+
+### Preset
+
+- `CONTAINERS` remains the owner of the official Group component/defaults;
+- provides basic ID-driven group and ungroup operation adapters through public
+  Core/Scene Tree and property APIs;
+- owns the default 2D coordinate normalization needed to preserve world-space
+  appearance when elements enter or leave the invisible Group container;
+- keeps Group geometry consistent with its direct children for the supported
+  basic translation/bounds contract.
+
+Preset must not inspect app selection, bind shortcuts, choose the active Group,
+create hover/click policy, install product UI, or bypass canonical Scene Tree
+mutation APIs.
+
+### Render and app
+
+- Render projects the committed canonical hierarchy and keeps existing element
+  identity/engine ownership through reparent or reorder handoff;
+- the app decides which ids to operate on, which feature/command triggers the
+  request, post-operation selection, UI tree presentation, hover/click targets,
+  menus, shortcuts, and product-specific interaction policy.
+
+## Supported Product Contract
+
+### Group
+
+- Input ids are non-empty, unique, existing, non-workspace siblings with one
+  common parent.
+- Canonical sibling order, not caller input order, determines child order.
+- The Group is inserted at the first selected sibling position and the selected
+  elements become its children in their previous relative order.
+- Nested groups are allowed.
+- Preset establishes the default Group bounds/position and converts child
+  coordinates so visible world-space output does not jump.
+- Direct-child membership or geometry changes rederive the default Group bounds
+  through one canonical Preset-owned path; rebasing must not create a visible
+  jump, recursive mutation loop, or second geometry authority.
+
+### Ungroup
+
+- The target is one existing Preset Group with a valid container parent.
+- Direct children move into the Group's parent at the Group's sibling slot and
+  retain their relative order and identities.
+- Preset converts child coordinates back to the parent coordinate space so
+  visible world-space output does not jump.
+- The empty Group is then removed. Ungrouping an already-empty Group
+  deterministically removes that Group and makes no child mutation.
+
+### Reparent and reorder
+
+- Move/reorder accepts existing ids, a valid target container id, and a bounded
+  target index.
+- A move preserves entity identity and cannot make an element its own parent,
+  place a container under its descendant, duplicate membership, orphan an
+  element, or create a cycle.
+- Moving multiple siblings preserves their canonical relative order.
+- Same-parent reorder and cross-parent reparent share one validated hierarchy
+  mutation contract; the exact public request/result names are finalized by the
+  Inspector before implementation.
+
+### Subtree and lifecycle
+
+- Removing a non-empty Group removes its complete owned subtree unless the
+  caller explicitly chose the separate ungroup operation.
+- Subtree removal and restoration are deterministic, bounded, and reversible;
+  descendants cannot remain registered with a missing parent.
+- Save/load preserves one parent per non-workspace element, exact child order,
+  nested groups, and Group data.
+- Load rejects or normalizes malformed hierarchy only at the documented load
+  validation boundary; runtime mutations never silently repair invalid input.
+- Destroy, reload, re-registration, and instance teardown release observers and
+  projections without sharing hierarchy state across Core instances.
+
+## Unsupported and App-Owned Behavior
+
+- selection and post-operation selection policy;
+- keyboard shortcuts, context menus, toolbar actions, and command routing;
+- hover, clickability, hit-area presentation, outlines, handles, breadcrumbs,
+  layers-panel UI, and accessibility UI;
+- app-specific naming, locking policy, permissions, snapping, layout, and
+  constraint systems;
+- Group resize/scaling of descendants, auto-layout, clipping/masking, Boolean
+  operations, symbols/components, and arbitrary cross-parent multi-selection
+  grouping in this release gate.
+
+Unsupported behavior must fail explicitly or remain absent. It must not be
+simulated through Render-only output, app-specific fallback state, or duplicate
+hierarchy ownership.
+
+## Product Cases
+
+- group contiguous and non-contiguous siblings while preserving canonical
+  order and world-space appearance;
+- group a nested Group with another sibling;
+- ungroup normal and empty Groups deterministically;
+- reorder within one parent and reparent across two valid containers;
+- reject missing ids, duplicate ids, mixed parents for group, invalid target,
+  workspace movement, self-parenting, descendant cycles, and invalid index
+  before mutation;
+- delete and undo a multi-level subtree with exact identities/order restored;
+- rollback a mid-operation failure with no partial parent/child/property state;
+- undo/redo and save/load reproduce the exact hierarchy and Group geometry;
+- two collaboration peers converge on group, ungroup, reorder, subtree delete,
+  duplicate delivery, and concurrent hierarchy conflict cases;
+- Render reparent/reorder performs one abstract hierarchy handoff for the same
+  canonical element identity and never leaves a duplicate visual or stale
+  parent;
+- separate Core instances remain isolated;
+- apps can invoke the operations without importing Scene Tree internals or
+  receiving any framework-owned UI behavior.
+
+## Definition of Done
+
+- the product contract and exact Inspector owner flow agree and every route,
+  artifact, failure owner, and implementation boundary resolves;
+- Scene Tree formal tests cover hierarchy validation, atomicity, ordering,
+  subtree lifecycle, replay, load, and instance isolation;
+- Factory/Yjs tests prove one transaction, exact inverse, remote canonical
+  apply, dedupe, conflict resolution, and convergence;
+- Preset tests prove component installation, operation adapters, coordinate and
+  bounds behavior, cleanup, and app override boundaries;
+- Render/engine integration tests prove identity-safe hierarchy handoff and
+  canonical order without a patch/fallback output path;
+- package, monorepo, dependency, lint, build, app integration, and synchronized
+  visual gates pass for the supported cases;
+- framework/package/API/Golden Path docs and release decisions are synchronized;
+- the plan is archived and Release Gate 4 may begin.

--- a/docs/ai/framework/plans/props-manager-app-level-migration-plan.md
+++ b/docs/ai/framework/plans/props-manager-app-level-migration-plan.md
@@ -1,5 +1,20 @@
 # Framework App-Level Migration Plan
 
+## Status
+
+Framework Release Gate 1: queued for formalization audit and closeout.
+
+This gate must not invent replacement runtime behavior merely to create work.
+Core already exposes ordered `registerLoadHook(...)` execution before package
+validation for both persistence load and `core.load(...)`. The task first audits
+that implementation, its formal tests, examples, and public documentation
+against this product contract. If the contract is already satisfied, the
+correct outcome is documentation/test completion and plan closeout.
+
+Before implementation or closeout work begins, add or update the matching
+Inspector owner flow for raw input, ordered app migration, package validation,
+canonical apply, diagnostics, and failure ownership.
+
 ## Scope
 
 Define how app-level users migrate document formats using framework hooks, across all core packages.
@@ -65,6 +80,53 @@ Define how app-level users migrate document formats using framework hooks, acros
 2. Optional analyze hook
 - input: migrated + validation diagnostics
 - output: logging/telemetry side effects only
+
+## Required Formalization
+
+- Define how an app identifies the document version before the first hook and
+  how each successful hook advances exactly one declared version step.
+- Preserve registration order deterministically and run the same hook chain for
+  persistence-provider load and direct `core.load(...)`.
+- Define empty-chain, already-current, missing-version, unsupported-version,
+  thrown-hook, invalid-result, and asynchronous-hook behavior explicitly.
+- A migration failure must stop before package validation or canonical state
+  apply and must not expose a partially migrated runtime document.
+- Package validation remains mandatory after migration; an app hook cannot
+  declare invalid package data safe or bypass fallback/reject semantics.
+- Provide one reusable app-owned `vN -> vN+1` migration example or template
+  without embedding app schema history in framework packages.
+- Keep optional diagnostics observational and unable to change the migration,
+  validation, or apply outcome.
+
+Exact version-envelope and error/result types remain pending until the matching
+Inspector maps the existing Core implementation and public compatibility cost.
+Do not add a second migration pipeline when the current ordered hook surface can
+satisfy the contract.
+
+## Product Cases
+
+- no persisted document: startup does not invoke migration;
+- already-current document: canonical validation and apply proceed without a
+  semantic rewrite;
+- `v1 -> v2 -> v3`: hooks run once in registration/version order and validation
+  observes only the complete `v3` result;
+- direct `core.load(...)` and provider-backed load use identical ordering;
+- thrown hook, unsupported version, or invalid hook result applies no canonical
+  prefix and surfaces one deterministic failure;
+- migrated but package-invalid data still follows package fallback/reject rules;
+- separate Core instances do not share app migration registrations.
+
+## Release-Gate Definition of Done
+
+- the Inspector defines one owner for every migration, validation, apply, and
+  diagnostic step and all routes/artifacts resolve;
+- existing Core behavior is either formally proven or corrected without a
+  parallel legacy path;
+- version-step, ordering, failure atomicity, validation, direct-load,
+  provider-load, diagnostics, and instance-isolation cases pass;
+- public API, Core/package docs, Golden Path, reusable example/template, and
+  release decision history agree;
+- the completed plan is archived and Release Gate 2 may begin.
 
 ## Non-goals (for this phase)
 

--- a/docs/ai/framework/plans/yjs-network-collaboration-plan.md
+++ b/docs/ai/framework/plans/yjs-network-collaboration-plan.md
@@ -2,8 +2,20 @@
 
 ## Status
 
-Deferred final collaboration architecture phase. This is a docs-only planning
-record and does not claim that network collaboration is currently implemented.
+Framework Release Gate 2: required after the app-level migration pipeline
+formalization and closeout.
+
+Network collaboration remains unimplemented today, but it is no longer a
+post-release deferred capability. The first public Asyra Framework release must
+ship the provider-replaceable CRDT foundation and the supported conflict-policy
+contract in this plan. Runtime activation remains optional: a canvas tool that
+does not need collaboration must not create a Y.Doc, provider, room, awareness
+runtime, network connection, or collaboration bundle side effect.
+
+Before implementation begins, create the matching Inspector owner flow and
+prove every prerequisite below against current formal contracts. A missing or
+unstable prerequisite is repaired inside this release gate before downstream
+network work advances.
 
 ## Context
 
@@ -22,7 +34,8 @@ The framework does not yet provide a complete network collaboration system.
 
 ## Prerequisites
 
-Do not begin implementation until these contracts are stable:
+Do not advance from the Release Gate 2 readiness segment until these contracts
+are stable:
 
 - authoritative state ownership
 - transaction atomicity and rollback
@@ -347,11 +360,16 @@ Conflict and permissions:
 - undo/rollback/origin behavior is deterministic
 - apps can supply authentication, authorization, persistence, and domain policy
   without patching framework internals
+- non-collaborative apps retain the current local transaction, persistence,
+  render, and package-loading behavior without collaboration activation
+- the framework release includes the tested collaboration packages/contracts;
+  provider connection and room participation remain explicit app composition
 
 ## Assumptions
 
-- This is the final collaboration architecture phase, intentionally deferred
-  until local kernel contracts stabilize.
+- This is the second required framework release gate; it starts only after Gate
+  1 closes and its local-kernel prerequisites pass the Inspector readiness
+  review.
 - Existing shared-channel infrastructure is reused where it preserves the target
   ownership and apply rules.
 - Exact package/API shape remains open until implementation planning starts.


### PR DESCRIPTION
## Summary

- define five ordered gates before the first public Asyra Framework release: migration closeout, Yjs collaboration, Group hierarchy behavior, AI agent runtime, and release readiness closeout
- keep Yjs and AI included in the release while preserving explicit opt-in runtime activation
- define Scene Tree, Factory/Yjs, Preset, Render, Feature System, and app ownership boundaries for Group and AI behavior
- add detailed Group hierarchy, release readiness, and Auto-layout Roadmap plans
- synchronize architecture, constraints, package ownership, request routing, and unreleased decision history

## Scope notes

- Group UI, selection, hover/click behavior, shortcuts, and presentation remain app-owned
- Auto-layout remains the lowest-priority post-release Preset Roadmap family
- each release gate remains queued until its independent Inspector contract passes readiness review

## Validation

- 108 current documentation references resolved
- release-roadmap contract assertions passed 10/10
- git diff check passed
- yarn lint:ci passed with 0 errors and 45 existing warnings

This PR changes framework planning and documentation contracts only; it does not implement the queued runtime capabilities or publish a release.
