### PR TITLE
docs(framework): confirm migration gate closeout

### DIFF
--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -1596,3 +1596,34 @@ unregister -> app migration -> core.start()` as the public app route.
   - `docs/ai/framework/plans/app-level-migration-flow-inspector.data.cjs`
 - Related Commit(s):
   - pending local contract-correction commit
+
+## 2026-07-19 - Confirm app-level migration Gate 1 closeout
+
+- Context:
+  - PR #90 merged the app-level migration formalization and its corrected
+    connected-dispatch semantics into `main` at `19bbe2c51`.
+  - The completed plan record, dedicated Inspector, public contracts, reusable
+    example, and formal tests now describe the same app-owned version-chain and
+    framework-owned load orchestration boundary.
+  - The user explicitly authorized final closeout after that merge.
+- Decision:
+  - Confirm Framework Release Gate 1 as closed without creating a second plan
+    record or moving schema-history ownership into framework packages.
+  - Retain the completed plan at its canonical completed path and keep Gate 1
+    absent from `PLANS.md`.
+  - Keep Framework Release Gate 2 as the next gate. This closeout does not start
+    its implementation; its product contract and dedicated Inspector must pass
+    readiness first.
+- Consequences:
+  - The final Gate 1 contract is the single synchronous direct/provider load
+    flow shipped by PR #90: raw input, the app-owned connected migration
+    dispatcher and any later hooks, mandatory package validation/fallback,
+    atomic canonical apply, then observational diagnostics.
+  - No production behavior changes are required by this closeout record.
+  - This closeout does not authorize merge, release, tag, or publication.
+- Related Plan:
+  - `docs/ai/framework/plans/completed/props-manager-app-level-migration-plan.md`
+  - `docs/ai/framework/plans/app-level-migration-flow-inspector.data.cjs`
+  - `docs/ai/framework/PLANS.md`
+- Related Commit(s):
+  - `19bbe2c51` (`feat(framework): formalize connected app migrations`, PR #90)

--- a/docs/ai/framework/plans/completed/load-and-migration.md
+++ b/docs/ai/framework/plans/completed/load-and-migration.md
@@ -9,7 +9,8 @@
 
 ## 2. App-level migration pipeline formalization
 
-- Completed on July 19, 2026 as Framework Release Gate 1.
+- Completed on July 19, 2026 as Framework Release Gate 1; final closeout was
+  confirmed after the connected-dispatch contract shipped in PR #90.
 - Apps own one connected linear migration chain, its domain transforms, and one
   conditional dispatcher. The dispatcher follows matching current-version
   transitions and passes an unmatched version through unchanged. Core retains

--- a/docs/ai/framework/plans/completed/props-manager-app-level-migration-plan.md
+++ b/docs/ai/framework/plans/completed/props-manager-app-level-migration-plan.md
@@ -2,7 +2,8 @@
 
 ## Completion
 
-- Status: completed on July 19, 2026; Framework Release Gate 1 is closed.
+- Status: completed on July 19, 2026; Framework Release Gate 1 closeout was
+  confirmed after PR #90 merged into `main` at `19bbe2c51`.
 - Final decision: retain the single Core load pipeline and app-owned schema
   history. Core owns synchronous hook orchestration, package validation/fallback
   coordination, canonical apply, and observational diagnostics only.
@@ -10,11 +11,12 @@
   input parity, hook result/failure semantics, owner-issued validation artifacts,
   instance isolation, and diagnostics containment were closed without adding a
   second migration state owner or framework-owned app version branches.
-- Post-closeout contract correction: one app-owned migration registry now
-  validates its complete batch as a single connected linear chain and registers
-  one conditional dispatcher through `core.registerLoadHook(...)`. A document
-  version with no matching migration terminates app migration normally and
-  continues to package validation; Core still owns no app target-version policy.
+- Final contract correction: PR #90 formalized one app-owned migration registry
+  that validates its complete batch as a single connected linear chain and
+  registers one conditional dispatcher through `core.registerLoadHook(...)`.
+  A document version with no matching migration terminates app migration
+  normally and continues to package validation; Core still owns no app
+  target-version policy.
 - Exit criteria: the dedicated Inspector, reusable typed example, focused and
   root tests, dependency validation, lint, production build, and two independent
   final reviews passed with no P0/P1/P2 findings.


### PR DESCRIPTION
## Summary

- confirm Framework Release Gate 1 closeout after PR #90 merged
- retain the canonical completed plan and keep Gate 1 absent from PLANS.md
- append the final closeout decision without changing production migration behavior or starting Gate 2

## Validation

- Inspector contract: 11/11
- migration example and type contract: 18/18
- root test tasks: 16/16
- dependency validation: 19 workspaces
- lint: 0 errors, 45 existing warnings
- production build: 18/18
- git diff --check
- self review and independent review: CLEAN, no P0/P1/P2/P3 findings

No merge, tag, release, or publication was performed.