### PR TITLE
feat(asyra-design): restore remote subtrees from exact snapshots

### DIFF
--- a/apps/asyra-design/e2e/collaboration.spec.ts
+++ b/apps/asyra-design/e2e/collaboration.spec.ts
@@ -89,6 +89,77 @@ const getCanonicalSnapshot = (page: Page) =>
       .sort((left, right) => left.id.localeCompare(right.id))
   })
 
+const getCanonicalHierarchyGeometry = (page: Page) =>
+  page.evaluate(() => {
+    const sceneTree = window.__Core__?.deps?.sceneTree
+    const elements = sceneTree?.getAllElements?.()
+    if (!(elements instanceof Map)) return []
+
+    const getFiniteNumber = (
+      value: unknown,
+      elementId: string,
+      key: string
+    ): number => {
+      const result = Number(value)
+      if (!Number.isFinite(result)) {
+        throw new Error(
+          `Element "${elementId}" has non-finite computed "${key}"`
+        )
+      }
+      return result
+    }
+
+    const getWorldPosition = (elementId: string) => {
+      let currentId = elementId
+      let x = 0
+      let y = 0
+      const visited = new Set<string>()
+
+      while (currentId) {
+        if (visited.has(currentId)) {
+          throw new Error(`Hierarchy cycle reaches "${currentId}"`)
+        }
+        visited.add(currentId)
+        const element = sceneTree?.getElementById?.(currentId)
+        if (!element) {
+          throw new Error(`Missing hierarchy element "${currentId}"`)
+        }
+        if (element.get?.('type') === 'workspace') {
+          break
+        }
+        const computed = element.getAllComputedData?.() ?? {}
+        x += getFiniteNumber(computed.x, currentId, 'x')
+        y += getFiniteNumber(computed.y, currentId, 'y')
+        currentId = String(element.get?.('parentId') ?? '')
+      }
+
+      return { x, y }
+    }
+
+    return Array.from(elements.entries())
+      .filter(([, element]) => element.get?.('type') !== 'workspace')
+      .map(([id, element]) => {
+        const computed = element.getAllComputedData?.() ?? {}
+        const type = String(element.get?.('type') ?? '')
+        const children =
+          type === 'group' ? element.get?.('children') : undefined
+        return {
+          id,
+          type,
+          parentId: String(element.get?.('parentId') ?? ''),
+          children: Array.isArray(children) ? [...children] : undefined,
+          local: {
+            x: getFiniteNumber(computed.x, id, 'x'),
+            y: getFiniteNumber(computed.y, id, 'y'),
+            width: getFiniteNumber(computed.width, id, 'width'),
+            height: getFiniteNumber(computed.height, id, 'height')
+          },
+          world: getWorldPosition(id)
+        }
+      })
+      .sort((left, right) => left.id.localeCompare(right.id))
+  })
+
 const getCollaborationDiagnostics = (page: Page) =>
   page.evaluate(() => ({
     status: window.__AsyraCollaboration__?.getStatus() ?? 'missing',
@@ -559,6 +630,84 @@ test('remote undo restores an exact nested Group with and without local tombston
     expect(await getUndoDepth(noTombstonePeer)).toBe(noTombstoneUndoDepth)
   } finally {
     await Promise.all([senderContext.close(), tombstoneContext.close()])
+  }
+})
+
+test('remote Group redo preserves exact hierarchy and world geometry', async ({
+  browser
+}, testInfo) => {
+  const fileId = `group-redo-${Date.now()}-${testInfo.workerIndex}`
+  const firstContext = await browser.newContext()
+  const secondContext = await browser.newContext()
+  const first = await firstContext.newPage()
+  const second = await secondContext.newPage()
+
+  try {
+    await Promise.all([
+      first.goto(collaborationUrl(fileId)),
+      second.goto(collaborationUrl(fileId))
+    ])
+    await Promise.all([waitForAppReady(first), waitForAppReady(second)])
+    await Promise.all([
+      waitForCollaboration(first),
+      waitForCollaboration(second)
+    ])
+
+    await createRectangle(first, 0.3, 0.35)
+    await createRectangle(first, 0.62, 0.55)
+    await expect.poll(() => getElementCount(second)).toBe(2)
+
+    const rectangleIds = (await getCanonicalSnapshot(first)).map(({ id }) => id)
+    const ungroupedGeometry = await getCanonicalHierarchyGeometry(first)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(ungroupedGeometry)
+
+    const groupId = await groupLayerIds(first, rectangleIds)
+    await expect.poll(() => getElementCount(second)).toBe(3)
+    const groupedGeometry = await getCanonicalHierarchyGeometry(first)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(groupedGeometry)
+
+    await undo(first)
+    await expect.poll(() => getElementCount(first)).toBe(2)
+    await expect.poll(() => getElementCount(second)).toBe(2)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(first))
+      .toEqual(ungroupedGeometry)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(ungroupedGeometry)
+
+    await redo(first)
+    await expect.poll(() => getElementCount(first)).toBe(3)
+    await expect.poll(() => getElementCount(second)).toBe(3)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(first))
+      .toEqual(groupedGeometry)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(groupedGeometry)
+
+    const remoteGroup = (await getCanonicalHierarchyGeometry(second)).find(
+      ({ id }) => id === groupId
+    )
+    expect(remoteGroup).toEqual(
+      groupedGeometry.find(({ id }) => id === groupId)
+    )
+    await Promise.all([
+      first.screenshot({
+        path: testInfo.outputPath('group-redo-source.png'),
+        fullPage: true
+      }),
+      second.screenshot({
+        path: testInfo.outputPath('group-redo-peer.png'),
+        fullPage: true
+      })
+    ])
+  } finally {
+    await Promise.all([firstContext.close(), secondContext.close()])
   }
 })
 

--- a/apps/asyra-design/e2e/collaboration.spec.ts
+++ b/apps/asyra-design/e2e/collaboration.spec.ts
@@ -4,6 +4,7 @@ import {
   createVectorPath,
   dragSelectedElementBy,
   getCanvasPosition,
+  getContentsPanel,
   getElementCount,
   getSelectedElementClientCenter,
   redo,
@@ -13,6 +14,55 @@ import {
 
 const collaborationUrl = (fileId: string) =>
   `/?fileId=${encodeURIComponent(fileId)}`
+
+const layerRow = (page: Page, elementId: string) =>
+  page.getByTestId(`element-item-${elementId}`)
+
+const getLayerIds = (page: Page): Promise<string[]> =>
+  getContentsPanel(page)
+    .locator('[data-layer-element="true"]')
+    .evaluateAll((rows) =>
+      rows.map(
+        (row) =>
+          row.getAttribute('data-testid')?.replace('element-item-', '') ?? ''
+      )
+    )
+
+const getSelectedIds = (page: Page): Promise<string[]> =>
+  page.evaluate(
+    () => window.__Core__?.deps.selection.getElementSelectionIds() ?? []
+  )
+
+const groupLayerIds = async (
+  page: Page,
+  elementIds: readonly string[]
+): Promise<string> => {
+  const contentsPanel = getContentsPanel(page)
+  const panelBounds = await contentsPanel.boundingBox()
+  if (!panelBounds) {
+    throw new Error('Layers panel bounds are unavailable')
+  }
+  await page.mouse.click(
+    panelBounds.x + panelBounds.width / 2,
+    panelBounds.y + panelBounds.height - 50
+  )
+  await expect.poll(() => getSelectedIds(page)).toEqual([])
+
+  await layerRow(page, elementIds[0]).click()
+  await page.keyboard.down('Shift')
+  try {
+    for (const elementId of elementIds.slice(1)) {
+      await layerRow(page, elementId).click()
+    }
+  } finally {
+    await page.keyboard.up('Shift')
+  }
+  const groupButton = page.getByTestId('layers-group-button')
+  await expect(groupButton).toBeEnabled()
+  await groupButton.click()
+  await expect.poll(() => getSelectedIds(page)).toHaveLength(1)
+  return (await getSelectedIds(page))[0]
+}
 
 const waitForCollaboration = async (page: Page) => {
   await expect
@@ -53,6 +103,66 @@ const getCanonicalRenderVisibility = (page: Page, elementId: string) =>
     (id) =>
       window.__Core__?.deps?.render?.getElementById?.(id)?.visible ?? null,
     elementId
+  )
+
+const getOwnerSave = (page: Page) =>
+  page.evaluate(() => ({
+    sceneTree: window.__Core__.deps.sceneTree.save(),
+    props: window.__Core__.deps.props.save()
+  }))
+
+const getUndoDepth = (page: Page) =>
+  page.evaluate(
+    () =>
+      (
+        window.__Core__.deps.factory.transact as unknown as {
+          undoStack?: unknown[]
+        }
+      ).undoStack?.length ?? 0
+  )
+
+const capturePublicationOutcomes = (page: Page) =>
+  page.evaluate(() => {
+    const runtime = globalThis as typeof globalThis & {
+      __remoteRestoreOutcomes?: unknown[]
+    }
+    runtime.__remoteRestoreOutcomes = []
+    const handle = window.__AsyraCollaboration__ as
+      | (NonNullable<Window['__AsyraCollaboration__']> & {
+          observePublicationOutcomes(
+            subscriber: (outcome: {
+              direction: string
+              status: string
+              publicationId: string
+              error?: unknown
+            }) => void
+          ): () => void
+        })
+      | undefined
+    handle?.observePublicationOutcomes((outcome) => {
+      runtime.__remoteRestoreOutcomes?.push({
+        ...outcome,
+        ...(outcome.error instanceof Error
+          ? {
+              error: {
+                name: outcome.error.name,
+                message: outcome.error.message,
+                stack: outcome.error.stack
+              }
+            }
+          : {})
+      })
+    })
+  })
+
+const getPublicationOutcomes = (page: Page) =>
+  page.evaluate(
+    () =>
+      (
+        globalThis as typeof globalThis & {
+          __remoteRestoreOutcomes?: unknown[]
+        }
+      ).__remoteRestoreOutcomes ?? []
   )
 
 const getVectorTopologySummary = (page: Page) =>
@@ -232,6 +342,223 @@ test('two real Asyra Design windows converge while connected and reconnect live-
       secondContext.close(),
       isolatedContext.close()
     ])
+  }
+})
+
+test('remote undo restores an exact nested Group with and without local tombstones', async ({
+  browser
+}, testInfo) => {
+  test.setTimeout(120_000)
+  const fileId = `restore-${Date.now()}-${testInfo.workerIndex}`
+  const senderContext = await browser.newContext()
+  const tombstoneContext = await browser.newContext()
+  const sender = await senderContext.newPage()
+  const tombstonePeer = await tombstoneContext.newPage()
+  let noTombstonePeer: Page | undefined
+
+  try {
+    await Promise.all([
+      sender.goto(collaborationUrl(fileId)),
+      tombstonePeer.goto(collaborationUrl(fileId))
+    ])
+    await Promise.all([waitForAppReady(sender), waitForAppReady(tombstonePeer)])
+    await Promise.all([
+      waitForCollaboration(sender),
+      waitForCollaboration(tombstonePeer)
+    ])
+
+    await createRectangle(sender, 0.28, 0.32)
+    await createRectangle(sender, 0.48, 0.45)
+    await createRectangle(sender, 0.68, 0.58)
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(3)
+    const rectangleIds = (await getCanonicalSnapshot(sender)).map(
+      ({ id }) => id
+    )
+    const innerGroupId = await groupLayerIds(sender, rectangleIds.slice(0, 2))
+    await sender.getByTestId(`layers-group-toggle-${innerGroupId}`).click()
+    const outerGroupId = await groupLayerIds(sender, [
+      rectangleIds[2],
+      innerGroupId
+    ])
+    await sender.getByTestId(`layers-group-toggle-${innerGroupId}`).click()
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(5)
+    await expect
+      .poll(() => getOwnerSave(tombstonePeer))
+      .toEqual(await getOwnerSave(sender))
+
+    const expectedOwnerSave = await getOwnerSave(sender)
+    const expectedLayerIds = await getLayerIds(sender)
+    const expectedElementIds = (await getCanonicalSnapshot(sender)).map(
+      ({ id }) => id
+    )
+
+    await layerRow(sender, outerGroupId).click()
+    await sender.keyboard.press('Delete')
+    await expect.poll(() => getElementCount(sender)).toBe(0)
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(0)
+    await expect
+      .poll(() =>
+        tombstonePeer.evaluate((expectedSceneCount) => {
+          const sceneTree = window.__Core__.deps.sceneTree as unknown as {
+            _deletedMap?: Map<string, unknown>
+          }
+          const props = window.__Core__.deps.props as unknown as {
+            _deletedMap?: Map<string, unknown>
+          }
+          return (
+            sceneTree._deletedMap?.size === expectedSceneCount &&
+            (props._deletedMap?.size ?? 0) > 0
+          )
+        }, expectedElementIds.length)
+      )
+      .toBe(true)
+
+    await expect
+      .poll(() =>
+        sender.evaluate(
+          ({ storageKey, removedGroupId }) => {
+            const raw = localStorage.getItem(storageKey)
+            if (!raw) return false
+            const saved = JSON.parse(raw) as {
+              sceneTree?: { elements?: Record<string, unknown> }
+            }
+            return !saved.sceneTree?.elements?.[removedGroupId]
+          },
+          {
+            storageKey: `FILE:${fileId}`,
+            removedGroupId: outerGroupId
+          }
+        )
+      )
+      .toBe(true)
+
+    noTombstonePeer = await senderContext.newPage()
+    await noTombstonePeer.goto(collaborationUrl(fileId))
+    await waitForAppReady(noTombstonePeer)
+    await waitForCollaboration(noTombstonePeer)
+    expect(await getElementCount(noTombstonePeer)).toBe(0)
+    expect(
+      await noTombstonePeer.evaluate(() => {
+        const sceneTree = window.__Core__.deps.sceneTree as unknown as {
+          _deletedMap?: Map<string, unknown>
+        }
+        const props = window.__Core__.deps.props as unknown as {
+          _deletedMap?: Map<string, unknown>
+        }
+        return {
+          scene: sceneTree._deletedMap?.size ?? 0,
+          props: props._deletedMap?.size ?? 0
+        }
+      })
+    ).toEqual({ scene: 0, props: 0 })
+
+    await noTombstonePeer.evaluate(() => {
+      const runtime = globalThis as typeof globalThis & {
+        __remoteRestorePublications?: unknown[]
+        __remoteRestoreCommits?: unknown[]
+      }
+      runtime.__remoteRestorePublications = []
+      runtime.__remoteRestoreCommits = []
+      window.__Core__.deps.factory.subscribeToSharedPublication((publication) =>
+        runtime.__remoteRestorePublications?.push(publication)
+      )
+      window.__Core__.deps.factory.subscribeToTransactionStatus((status) => {
+        if (status.origin === 'remote' && status.status === 'committed') {
+          runtime.__remoteRestoreCommits?.push(status)
+        }
+      })
+    })
+    const noTombstoneUndoDepth = await getUndoDepth(noTombstonePeer)
+    await Promise.all([
+      capturePublicationOutcomes(tombstonePeer),
+      capturePublicationOutcomes(noTombstonePeer)
+    ])
+
+    await undo(sender)
+    await expect
+      .poll(async () => (await getPublicationOutcomes(tombstonePeer)).length)
+      .toBeGreaterThan(0)
+    const remoteOutcomes = {
+      tombstone: await getPublicationOutcomes(tombstonePeer),
+      noTombstone: await getPublicationOutcomes(noTombstonePeer)
+    }
+    const processFailures = Object.values(remoteOutcomes)
+      .flat()
+      .filter(
+        (outcome) =>
+          typeof outcome === 'object' &&
+          outcome !== null &&
+          'status' in outcome &&
+          outcome.status === 'process-failed'
+      )
+    if (processFailures.length > 0) {
+      throw new Error(
+        `Remote restore processing failed:\n${JSON.stringify(
+          remoteOutcomes,
+          null,
+          2
+        )}`
+      )
+    }
+
+    try {
+      await expect
+        .poll(() => getOwnerSave(tombstonePeer))
+        .toEqual(expectedOwnerSave)
+    } catch (error) {
+      await testInfo.attach('remote-restore-outcomes.json', {
+        body: JSON.stringify(
+          {
+            tombstone: await getPublicationOutcomes(tombstonePeer),
+            noTombstone: await getPublicationOutcomes(noTombstonePeer)
+          },
+          null,
+          2
+        ),
+        contentType: 'application/json'
+      })
+      throw error
+    }
+    await expect
+      .poll(() => getOwnerSave(noTombstonePeer as Page))
+      .toEqual(expectedOwnerSave)
+    await expect
+      .poll(() => getLayerIds(tombstonePeer))
+      .toEqual(expectedLayerIds)
+    await expect
+      .poll(() => getLayerIds(noTombstonePeer as Page))
+      .toEqual(expectedLayerIds)
+    await expect
+      .poll(() => getCanonicalSnapshot(noTombstonePeer as Page))
+      .toEqual(await getCanonicalSnapshot(sender))
+
+    expect(await getUndoDepth(noTombstonePeer)).toBe(noTombstoneUndoDepth)
+    expect(
+      await noTombstonePeer.evaluate(() => {
+        const runtime = globalThis as typeof globalThis & {
+          __remoteRestorePublications?: unknown[]
+          __remoteRestoreCommits?: unknown[]
+        }
+        return {
+          publications: runtime.__remoteRestorePublications?.length ?? -1,
+          commits: runtime.__remoteRestoreCommits?.length ?? -1
+        }
+      })
+    ).toEqual({ publications: 0, commits: 1 })
+
+    for (const elementId of expectedElementIds) {
+      expect(
+        await getCanonicalRenderVisibility(noTombstonePeer, elementId)
+      ).not.toBeNull()
+    }
+
+    await redo(sender)
+    await expect.poll(() => getElementCount(sender)).toBe(0)
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(0)
+    await expect.poll(() => getElementCount(noTombstonePeer as Page)).toBe(0)
+    expect(await getUndoDepth(noTombstonePeer)).toBe(noTombstoneUndoDepth)
+  } finally {
+    await Promise.all([senderContext.close(), tombstoneContext.close()])
   }
 })
 

--- a/apps/asyra-design/e2e/group-interaction.spec.ts
+++ b/apps/asyra-design/e2e/group-interaction.spec.ts
@@ -89,6 +89,172 @@ const getWorldPositions = (
   }, elementIds)
 
 test.describe('Asyra Design Group interaction MVP', () => {
+  test('undoes and redoes a basic two-rectangle Group without losing either rectangle', async ({
+    page
+  }) => {
+    await page.goto('/')
+    await waitForAppReady(page)
+    await resetCanvas(page)
+
+    await createRectangle(page, 0.35, 0.42)
+    await createRectangle(page, 0.65, 0.58)
+
+    const initialIds = await getLayerIds(page)
+    expect(initialIds).toHaveLength(2)
+    const initialWorldPositions = await getWorldPositions(page, initialIds)
+    const initialHierarchy = await page.evaluate((elementIds) => {
+      const sceneTree = window.__Core__.deps.sceneTree
+      const workspaceId = String(sceneTree.workspace)
+      const workspace = sceneTree.getElementById(workspaceId)
+      return {
+        workspaceId,
+        workspaceChildren: [
+          ...((workspace?.get('children') as string[] | undefined) ?? [])
+        ],
+        parentIds: elementIds.map((elementId) =>
+          String(sceneTree.getElementById(elementId)?.get('parentId') ?? '')
+        )
+      }
+    }, initialIds)
+    expect(initialHierarchy.workspaceChildren).toEqual(initialIds)
+    expect(initialHierarchy.parentIds).toEqual(
+      initialIds.map(() => initialHierarchy.workspaceId)
+    )
+    await page.evaluate((elementIds) => {
+      const core = window.__Core__
+      ;(
+        window as typeof window & {
+          __BasicGroupUndoIdentity?: {
+            sceneElements: unknown[]
+            renderElements: unknown[]
+          }
+        }
+      ).__BasicGroupUndoIdentity = {
+        sceneElements: elementIds.map((elementId) =>
+          core.deps.sceneTree.getElementById(elementId)
+        ),
+        renderElements: elementIds.map((elementId) =>
+          core.deps.render.getElementById(elementId)
+        )
+      }
+    }, initialIds)
+
+    const groupId = await groupLayerIds(page, initialIds)
+    expect(groupId).not.toBe(initialIds[0])
+    expect(groupId).not.toBe(initialIds[1])
+    await expect
+      .poll(() =>
+        page.evaluate(
+          ({ createdGroupId, childIds }) => {
+            const sceneTree = window.__Core__.deps.sceneTree
+            const group = sceneTree.getElementById(createdGroupId)
+            return {
+              groupExists: Boolean(group),
+              groupChildren: [
+                ...((group?.get('children') as string[] | undefined) ?? [])
+              ],
+              childParentIds: childIds.map((childId) =>
+                String(sceneTree.getElementById(childId)?.get('parentId') ?? '')
+              )
+            }
+          },
+          { createdGroupId: groupId, childIds: initialIds }
+        )
+      )
+      .toEqual({
+        groupExists: true,
+        groupChildren: initialIds,
+        childParentIds: initialIds.map(() => groupId)
+      })
+
+    await undo(page)
+
+    await expect.poll(() => getLayerIds(page)).toEqual(initialIds)
+    await expect.poll(() => getSelectedIds(page)).toEqual(initialIds)
+    const undoHierarchy = await page.evaluate(
+      ({ createdGroupId, elementIds, workspaceId }) => {
+        const sceneTree = window.__Core__.deps.sceneTree
+        const workspace = sceneTree.getElementById(workspaceId)
+        return {
+          groupExists: Boolean(sceneTree.getElementById(createdGroupId)),
+          elementExists: elementIds.map((elementId) =>
+            Boolean(sceneTree.getElementById(elementId))
+          ),
+          workspaceChildren: [
+            ...((workspace?.get('children') as string[] | undefined) ?? [])
+          ],
+          parentIds: elementIds.map((elementId) =>
+            String(sceneTree.getElementById(elementId)?.get('parentId') ?? '')
+          )
+        }
+      },
+      {
+        createdGroupId: groupId,
+        elementIds: initialIds,
+        workspaceId: initialHierarchy.workspaceId
+      }
+    )
+    expect(undoHierarchy).toEqual({
+      groupExists: false,
+      elementExists: initialIds.map(() => true),
+      workspaceChildren: initialHierarchy.workspaceChildren,
+      parentIds: initialHierarchy.parentIds
+    })
+    expect(await getWorldPositions(page, initialIds)).toEqual(
+      initialWorldPositions
+    )
+    const undoIdentity = await page.evaluate((elementIds) => {
+      const core = window.__Core__
+      const initial = (
+        window as typeof window & {
+          __BasicGroupUndoIdentity?: {
+            sceneElements: unknown[]
+            renderElements: unknown[]
+          }
+        }
+      ).__BasicGroupUndoIdentity
+      if (!initial) {
+        throw new Error('Missing basic Group undo identity evidence')
+      }
+      return {
+        scene: elementIds.map(
+          (elementId, index) =>
+            core.deps.sceneTree.getElementById(elementId) ===
+            initial.sceneElements[index]
+        ),
+        render: elementIds.map(
+          (elementId, index) =>
+            core.deps.render.getElementById(elementId) ===
+            initial.renderElements[index]
+        ),
+        renderParentIds: elementIds.map(
+          (elementId) =>
+            core.deps.render.getElementById(elementId)?.parent?.label ?? null
+        )
+      }
+    }, initialIds)
+    expect(undoIdentity).toEqual({
+      scene: initialIds.map(() => true),
+      render: initialIds.map(() => true),
+      renderParentIds: initialIds.map(() => initialHierarchy.workspaceId)
+    })
+
+    await redo(page)
+
+    await expect.poll(() => getSelectedIds(page)).toEqual([groupId])
+    await expect(layerRow(page, groupId)).toBeVisible()
+    expect(await getWorldPositions(page, initialIds)).toEqual(
+      initialWorldPositions
+    )
+    await page.evaluate(() => {
+      delete (
+        window as typeof window & {
+          __BasicGroupUndoIdentity?: unknown
+        }
+      ).__BasicGroupUndoIdentity
+    })
+  })
+
   test('creates in the hierarchy-target Group or explicit workspace root from mouse down', async ({
     page
   }) => {

--- a/apps/asyra-design/src/collaboration/lifecycle.ts
+++ b/apps/asyra-design/src/collaboration/lifecycle.ts
@@ -1,7 +1,7 @@
 import { createCollaboration, type Collaboration } from '@asyra/collaboration'
 import { publishEvent } from '@asyra/reactive-events'
 import { idCounter } from '@asyra/utils'
-import { factory } from '../contexts'
+import core, { factory } from '../contexts'
 import type { CollaborationMode } from '../render-app/collaboration-mode'
 import { createDocumentCollaborationFactory } from './factory-adapter'
 import { createAsyraDesignPublicationProcessor } from './operations'
@@ -38,7 +38,9 @@ const start = async (
   })
   const processRemotePublication = createAsyraDesignPublicationProcessor(
     factory.runRemoteTransaction.bind(factory),
-    (event) => factory.applyRemoteEvent(event, publishEvent)
+    (event) => factory.applyRemoteEvent(event, publishEvent),
+    undefined,
+    core
   )
   const collaboration = createCollaboration({
     documentId: mode.fileId,

--- a/apps/asyra-design/src/collaboration/lifecycle.ts
+++ b/apps/asyra-design/src/collaboration/lifecycle.ts
@@ -14,14 +14,20 @@ let startPromise:
 
 const createHandle = (
   instance: Collaboration
-): NonNullable<Window['__AsyraCollaboration__']> => ({
-  identity: instance.identity,
-  getStatus: () => instance.provider?.getStatus() ?? 'offline',
-  disconnect: () => instance.disconnect(),
-  reconnect: () => instance.reconnect(),
-  whenIdle: () => instance.whenIdle(),
-  dispose: () => instance.dispose()
-})
+): NonNullable<Window['__AsyraCollaboration__']> => {
+  const handle = {
+    identity: instance.identity,
+    getStatus: () => instance.provider?.getStatus() ?? 'offline',
+    disconnect: () => instance.disconnect(),
+    reconnect: () => instance.reconnect(),
+    whenIdle: () => instance.whenIdle(),
+    observePublicationOutcomes: (
+      subscriber: Parameters<Collaboration['observePublicationOutcomes']>[0]
+    ) => instance.observePublicationOutcomes(subscriber),
+    dispose: () => instance.dispose()
+  }
+  return handle
+}
 
 const start = async (
   mode: CollaborationMode

--- a/apps/asyra-design/src/collaboration/operations.ts
+++ b/apps/asyra-design/src/collaboration/operations.ts
@@ -1,8 +1,14 @@
 import type { SharedDelivery, SharedPublication } from '@asyra/factory'
 import { EventTypes, type AllEvent } from '@asyra/reactive-events'
 import {
+  type ElementPropertyOwnerRelation,
+  type EVENT_OPTIONS,
   PROPS_ACTIONS,
+  type PropsRestorePlan,
+  type PropsRestoreSnapshot,
   SCENE_TREE_ACTIONS,
+  type SceneTreeRestorePlan,
+  type SceneTreeRestoreSnapshot,
   SharedDataChannelNames,
   isRecord
 } from '@asyra/utils'
@@ -13,6 +19,28 @@ type RunRemoteTransaction = <T>(mutate: () => T) => T
 export type DecideRemotePublication = (
   publication: SharedPublication
 ) => SharedPublication | false
+export interface RemoteRestoreOwnerFacades {
+  preflightRestoreSubtree: (
+    snapshot: SceneTreeRestoreSnapshot
+  ) => SceneTreeRestorePlan
+  preflightRestoreProperties: (
+    snapshot: PropsRestoreSnapshot,
+    ownerRelations: readonly ElementPropertyOwnerRelation[]
+  ) => PropsRestorePlan
+  applyRestoreProperties: (
+    plan: PropsRestorePlan,
+    options?: EVENT_OPTIONS
+  ) => readonly string[]
+  applyRestoreSubtree: (
+    plan: SceneTreeRestorePlan,
+    options?: EVENT_OPTIONS
+  ) => unknown
+}
+
+interface ClassifiedRemoteRestore {
+  sceneSnapshot: SceneTreeRestoreSnapshot
+  propsSnapshot: PropsRestoreSnapshot
+}
 
 const owns = (value: object, key: string): boolean =>
   Object.prototype.hasOwnProperty.call(value, key)
@@ -141,6 +169,8 @@ const isSubtreeChange = (value: unknown): value is Record<string, unknown> => {
     !isRecord(value) ||
     value.eventName !== EventTypes.CHANGE_SUBTREE ||
     !isNonBlankString(value.elementId) ||
+    !Array.isArray(value.rootParentChildrenAfter) ||
+    !value.rootParentChildrenAfter.every(isNonBlankString) ||
     !Array.isArray(value.removed) ||
     value.removed.length === 0 ||
     !value.removed.every(isSubtreeEntry)
@@ -240,6 +270,59 @@ const isSupportedPayload = (delivery: SharedDelivery): boolean => {
   return false
 }
 
+const classifyRemoteRestore = (
+  publication: SharedPublication
+): ClassifiedRemoteRestore | undefined => {
+  const restoreDeliveries = publication.deliveries.filter(
+    (delivery) =>
+      delivery.channel === SharedDataChannelNames.SCENE_TREE &&
+      delivery.eventName === EventTypes.CHANGE_SUBTREE &&
+      isRecord(delivery.payload) &&
+      delivery.payload.action === SCENE_TREE_ACTIONS.RESTORE_SUBTREE
+  )
+  if (restoreDeliveries.length === 0) {
+    return
+  }
+  const restoreDelivery = restoreDeliveries[0] as SharedDelivery
+  const restoreIndex = publication.deliveries.indexOf(restoreDelivery)
+  const propertyDeliveries = publication.deliveries.slice(0, restoreIndex)
+  const validRestoreEnvelope =
+    restoreDeliveries.length === 1 &&
+    restoreIndex === publication.deliveries.length - 1 &&
+    propertyDeliveries.every(
+      (delivery) =>
+        delivery.channel === SharedDataChannelNames.PROPS &&
+        delivery.eventName === EventTypes.ADD_PROPERTY &&
+        isAddRemoveProperties(
+          delivery.payload,
+          PROPS_ACTIONS.ADD_PROPERTY,
+          EventTypes.ADD_PROPERTY
+        )
+    )
+  if (!validRestoreEnvelope || !isSubtreeChange(restoreDelivery.payload)) {
+    throw new Error(
+      '[asyra-design collaboration] invalid subtree restore publication'
+    )
+  }
+
+  const payload = restoreDelivery.payload
+  return {
+    sceneSnapshot: {
+      elementId: payload.elementId as string,
+      removed: payload.removed as SceneTreeRestoreSnapshot['removed'],
+      rootParentChildrenAfter:
+        payload.rootParentChildrenAfter as readonly string[]
+    },
+    propsSnapshot: {
+      components: propertyDeliveries.flatMap(
+        (delivery) =>
+          (delivery.payload as { data: PropsRestoreSnapshot['components'] })
+            .data
+      )
+    }
+  }
+}
+
 const toEvent = (delivery: SharedDelivery): AllEvent => {
   if (!isSupportedPayload(delivery)) {
     throw new Error(
@@ -254,15 +337,42 @@ export const createAsyraDesignPublicationProcessor =
     runRemoteTransaction: RunRemoteTransaction,
     process: ProcessOperation,
     decideRemotePublication: DecideRemotePublication = (publication) =>
-      publication
+      publication,
+    restoreOwners?: RemoteRestoreOwnerFacades
   ): ((publication: SharedPublication) => void) =>
   (publication) => {
     publication.deliveries.forEach(toEvent)
+    const inboundRestore = classifyRemoteRestore(publication)
     const acceptedPublication = decideRemotePublication(publication)
     if (acceptedPublication === false) {
       return
     }
     const events = acceptedPublication.deliveries.map(toEvent)
+    const acceptedRestore = classifyRemoteRestore(acceptedPublication)
+    if (Boolean(inboundRestore) !== Boolean(acceptedRestore)) {
+      throw new Error(
+        '[asyra-design collaboration] invalid subtree restore publication'
+      )
+    }
+    if (acceptedRestore) {
+      if (!restoreOwners) {
+        throw new Error(
+          '[asyra-design collaboration] subtree restore owner facades are required'
+        )
+      }
+      const scenePlan = restoreOwners.preflightRestoreSubtree(
+        acceptedRestore.sceneSnapshot
+      )
+      const propsPlan = restoreOwners.preflightRestoreProperties(
+        acceptedRestore.propsSnapshot,
+        scenePlan.propertyOwnerRelations
+      )
+      runRemoteTransaction(() => {
+        restoreOwners.applyRestoreProperties(propsPlan)
+        restoreOwners.applyRestoreSubtree(scenePlan)
+      })
+      return
+    }
     runRemoteTransaction(() => {
       events.forEach((event) => process(event))
     })

--- a/apps/asyra-design/src/contents/__tests__/layer-hierarchy.test.ts
+++ b/apps/asyra-design/src/contents/__tests__/layer-hierarchy.test.ts
@@ -62,6 +62,29 @@ describe('canonical Layers hierarchy projection', () => {
     ).toEqual(['root', 'sibling'])
   })
 
+  it('projects restored normal and empty Groups from canonical stable identities', () => {
+    const restoredMap = {
+      restored: element('restored', 'workspace', EntityTypes.GROUP),
+      child: element('child', 'restored'),
+      empty: element('empty', 'workspace', EntityTypes.GROUP)
+    }
+
+    expect(
+      projectVisibleLayerRows(
+        ['restored', 'child', 'empty'],
+        restoredMap,
+        new Set()
+      )
+    ).toEqual({
+      rows: [
+        { id: 'restored', depth: 0, isGroup: true, isExpanded: true },
+        { id: 'child', depth: 1, isGroup: false, isExpanded: false },
+        { id: 'empty', depth: 0, isGroup: true, isExpanded: true }
+      ],
+      error: null
+    })
+  })
+
   it('rejects duplicate, missing, misordered, and cyclic projections', () => {
     expect(
       projectVisibleLayerRows(['root', 'root'], elementDataMap, new Set())

--- a/apps/asyra-design/src/init/__tests__/collaboration-lifecycle.test.ts
+++ b/apps/asyra-design/src/init/__tests__/collaboration-lifecycle.test.ts
@@ -30,6 +30,9 @@ beforeEach(async () => {
   vi.restoreAllMocks()
   idCounter.clear()
   harness.collaboration.updateAwareness.mockReset()
+  harness.collaboration.observePublicationOutcomes
+    .mockReset()
+    .mockReturnValue(vi.fn())
   harness.collaboration.start.mockReset().mockResolvedValue(undefined)
   harness.collaboration.dispose.mockReset().mockResolvedValue(undefined)
   delete window.__AsyraCollaboration__
@@ -68,4 +71,27 @@ it('starts the real app collaboration composition without an Awareness preview r
   expect(idCounter.current(IDTypes.ELEMENT)).toBe('el-actor-lifecycle-0')
   expect(harness.collaboration.updateAwareness).not.toHaveBeenCalled()
   expect(window.__AsyraCollaboration__).toBeDefined()
+})
+
+it('exposes remote publication outcomes through the local collaboration handle', async () => {
+  vi.spyOn(collaborationModule, 'createCollaboration').mockReturnValue(
+    harness.collaboration as never
+  )
+  const handle = await startCollaboration({
+    fileId: 'file-lifecycle',
+    actorId: 'actor-lifecycle',
+    endpoint: 'ws://127.0.0.1:4101/asyra-design-collaboration'
+  })
+  const subscriber = vi.fn()
+
+  const unsubscribe = (
+    handle as typeof handle & {
+      observePublicationOutcomes(callback: typeof subscriber): () => void
+    }
+  ).observePublicationOutcomes(subscriber)
+
+  expect(harness.collaboration.observePublicationOutcomes).toHaveBeenCalledWith(
+    subscriber
+  )
+  expect(unsubscribe).toEqual(expect.any(Function))
 })

--- a/apps/asyra-design/src/init/__tests__/collaboration-operations.test.ts
+++ b/apps/asyra-design/src/init/__tests__/collaboration-operations.test.ts
@@ -3,7 +3,9 @@ import { EventTypes } from '@asyra/reactive-events'
 import {
   PROPS_ACTIONS,
   SCENE_TREE_ACTIONS,
-  SharedDataChannelNames
+  SharedDataChannelNames,
+  type PropsRestorePlan,
+  type SceneTreeRestorePlan
 } from '@asyra/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createAsyraDesignPublicationProcessor } from '../../collaboration/operations'
@@ -80,6 +82,7 @@ const validDeliveries = (): readonly SharedDelivery[] => [
     undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
     eventName: EventTypes.CHANGE_SUBTREE,
     elementId: 'group-a',
+    rootParentChildrenAfter: [],
     removed: [
       {
         elementId: 'rect-a',
@@ -120,7 +123,258 @@ const validDeliveries = (): readonly SharedDelivery[] => [
   })
 ]
 
+const restoreDeliveries = (): readonly SharedDelivery[] => [
+  delivery(SharedDataChannelNames.PROPS, EventTypes.ADD_PROPERTY, {
+    action: PROPS_ACTIONS.ADD_PROPERTY,
+    undoType: EventTypes.REMOVE_PROPERTY,
+    undoAction: PROPS_ACTIONS.REMOVE_PROPERTY,
+    eventName: EventTypes.ADD_PROPERTY,
+    data: [
+      {
+        id: 'position-group-a',
+        type: 'position',
+        x: 12,
+        y: 24
+      }
+    ]
+  }),
+  delivery(SharedDataChannelNames.SCENE_TREE, EventTypes.CHANGE_SUBTREE, {
+    action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+    undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
+    eventName: EventTypes.CHANGE_SUBTREE,
+    elementId: 'group-a',
+    rootParentChildrenAfter: [],
+    removed: [
+      {
+        elementId: 'group-a',
+        parentId: 'workspace-a',
+        index: 0,
+        data: {
+          id: 'group-a',
+          type: 'group',
+          parentId: 'workspace-a',
+          children: [],
+          props: { position: 'position-group-a' }
+        }
+      }
+    ]
+  })
+]
+
+const createRestoreOwners = () => {
+  const scenePlan = Object.freeze({
+    kind: 'scene-tree-restore-plan',
+    elementId: 'group-a',
+    entries: Object.freeze([
+      Object.freeze({
+        elementId: 'group-a',
+        strategy: 'materialize' as const
+      })
+    ]),
+    propertyOwnerRelations: Object.freeze([
+      Object.freeze({
+        ownerElementId: 'group-a',
+        ownerElementType: 'group',
+        ownerPropertyName: 'position',
+        componentId: 'position-group-a'
+      })
+    ])
+  }) satisfies SceneTreeRestorePlan
+  const propsPlan = Object.freeze({
+    kind: 'props-restore-plan',
+    entries: Object.freeze([
+      Object.freeze({
+        componentId: 'position-group-a',
+        strategy: 'materialize' as const
+      })
+    ]),
+    ownerRelations: scenePlan.propertyOwnerRelations
+  }) satisfies PropsRestorePlan
+
+  return {
+    scenePlan,
+    propsPlan,
+    owners: {
+      preflightRestoreSubtree: vi.fn(() => scenePlan),
+      preflightRestoreProperties: vi.fn(() => propsPlan),
+      applyRestoreProperties: vi.fn(() => Object.freeze(['position-group-a'])),
+      applyRestoreSubtree: vi.fn()
+    }
+  }
+}
+
 describe('Asyra Design app-owned collaboration processing', () => {
+  it('preflights one complete restore before applying Props then Scene in one remote transaction', () => {
+    const callOrder: string[] = []
+    const runRemoteTransaction = vi.fn((mutate: () => void) => {
+      callOrder.push('transaction')
+      mutate()
+    })
+    const process = vi.fn()
+    const { scenePlan, propsPlan, owners } = createRestoreOwners()
+    owners.preflightRestoreSubtree.mockImplementation((snapshot) => {
+      callOrder.push('preflight-scene')
+      expect(snapshot).toEqual(
+        expect.objectContaining({
+          elementId: 'group-a',
+          rootParentChildrenAfter: []
+        })
+      )
+      return scenePlan
+    })
+    owners.preflightRestoreProperties.mockImplementation(
+      (snapshot, ownerRelations) => {
+        callOrder.push('preflight-props')
+        expect(snapshot).toEqual({
+          components: [
+            {
+              id: 'position-group-a',
+              type: 'position',
+              x: 12,
+              y: 24
+            }
+          ]
+        })
+        expect(ownerRelations).toBe(scenePlan.propertyOwnerRelations)
+        return propsPlan
+      }
+    )
+    owners.applyRestoreProperties.mockImplementation(() => {
+      callOrder.push('apply-props')
+      return Object.freeze(['position-group-a'])
+    })
+    owners.applyRestoreSubtree.mockImplementation(() => {
+      callOrder.push('apply-scene')
+      return {
+        elementId: 'group-a',
+        removed: [],
+        rootParentChildrenAfter: []
+      }
+    })
+    const processPublication = createAsyraDesignPublicationProcessor(
+      runRemoteTransaction,
+      process,
+      (item) => item,
+      owners
+    )
+
+    processPublication(publication(restoreDeliveries(), 'restore-group-a'))
+
+    expect(callOrder).toEqual([
+      'preflight-scene',
+      'preflight-props',
+      'transaction',
+      'apply-props',
+      'apply-scene'
+    ])
+    expect(owners.applyRestoreProperties).toHaveBeenCalledWith(propsPlan)
+    expect(owners.applyRestoreSubtree).toHaveBeenCalledWith(scenePlan)
+    expect(process).not.toHaveBeenCalled()
+  })
+
+  it('rejects mixed or out-of-order restore deliveries before owner preflight', () => {
+    const cases = [
+      [
+        ...(restoreDeliveries() as SharedDelivery[]),
+        validDeliveries()[0] as SharedDelivery
+      ],
+      [...restoreDeliveries()].reverse()
+    ]
+
+    cases.forEach((deliveries, index) => {
+      const runRemoteTransaction = vi.fn((mutate: () => void) => mutate())
+      const process = vi.fn()
+      const { owners } = createRestoreOwners()
+      const processPublication = createAsyraDesignPublicationProcessor(
+        runRemoteTransaction,
+        process,
+        (item) => item,
+        owners
+      )
+
+      expect(() =>
+        processPublication(publication(deliveries, `invalid-restore-${index}`))
+      ).toThrow('invalid subtree restore publication')
+      expect(owners.preflightRestoreSubtree).not.toHaveBeenCalled()
+      expect(owners.preflightRestoreProperties).not.toHaveBeenCalled()
+      expect(runRemoteTransaction).not.toHaveBeenCalled()
+      expect(process).not.toHaveBeenCalled()
+    })
+  })
+
+  it('rejects restore evidence without detached root-parent order before policy or mutation', () => {
+    const [propsDelivery, sceneDelivery] = restoreDeliveries()
+    const malformedScene = {
+      ...sceneDelivery,
+      payload: {
+        ...(sceneDelivery?.payload as Record<string, unknown>)
+      }
+    } as SharedDelivery
+    delete (malformedScene.payload as Record<string, unknown>)
+      .rootParentChildrenAfter
+    const decide = vi.fn((item: SharedPublication) => item)
+    const runRemoteTransaction = vi.fn((mutate: () => void) => mutate())
+    const { owners } = createRestoreOwners()
+    const processPublication = createAsyraDesignPublicationProcessor(
+      runRemoteTransaction,
+      vi.fn(),
+      decide,
+      owners
+    )
+
+    expect(() =>
+      processPublication(
+        publication(
+          [propsDelivery as SharedDelivery, malformedScene],
+          'malformed-root-order'
+        )
+      )
+    ).toThrow('unsupported collaboration delivery')
+    expect(decide).not.toHaveBeenCalled()
+    expect(owners.preflightRestoreSubtree).not.toHaveBeenCalled()
+    expect(runRemoteTransaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects restore policy or owner preflight failure before the remote transaction', () => {
+    const rejectedOwners = createRestoreOwners().owners
+    const rejectedTransaction = vi.fn((mutate: () => void) => mutate())
+    const rejectPublication = createAsyraDesignPublicationProcessor(
+      rejectedTransaction,
+      vi.fn(),
+      () => false,
+      rejectedOwners
+    )
+
+    rejectPublication(
+      publication(restoreDeliveries(), 'unauthorized-restore-group-a')
+    )
+
+    expect(rejectedOwners.preflightRestoreSubtree).not.toHaveBeenCalled()
+    expect(rejectedOwners.preflightRestoreProperties).not.toHaveBeenCalled()
+    expect(rejectedTransaction).not.toHaveBeenCalled()
+
+    const staleOwners = createRestoreOwners().owners
+    staleOwners.preflightRestoreProperties.mockImplementation(() => {
+      throw new Error('stale property owner evidence')
+    })
+    const staleTransaction = vi.fn((mutate: () => void) => mutate())
+    const rejectStale = createAsyraDesignPublicationProcessor(
+      staleTransaction,
+      vi.fn(),
+      (item) => item,
+      staleOwners
+    )
+
+    expect(() =>
+      rejectStale(publication(restoreDeliveries(), 'stale-restore-group-a'))
+    ).toThrow('stale property owner evidence')
+    expect(staleOwners.preflightRestoreSubtree).toHaveBeenCalledOnce()
+    expect(staleOwners.preflightRestoreProperties).toHaveBeenCalledOnce()
+    expect(staleOwners.applyRestoreProperties).not.toHaveBeenCalled()
+    expect(staleOwners.applyRestoreSubtree).not.toHaveBeenCalled()
+    expect(staleTransaction).not.toHaveBeenCalled()
+  })
+
   it('validates all supported Scene Tree and Props routes before one remote transaction', () => {
     const runRemoteTransaction = vi.fn((mutate: () => void) => mutate())
     const process = vi.fn(() => true)

--- a/create-app/asyra-design/template/e2e/collaboration.spec.ts
+++ b/create-app/asyra-design/template/e2e/collaboration.spec.ts
@@ -89,6 +89,77 @@ const getCanonicalSnapshot = (page: Page) =>
       .sort((left, right) => left.id.localeCompare(right.id))
   })
 
+const getCanonicalHierarchyGeometry = (page: Page) =>
+  page.evaluate(() => {
+    const sceneTree = window.__Core__?.deps?.sceneTree
+    const elements = sceneTree?.getAllElements?.()
+    if (!(elements instanceof Map)) return []
+
+    const getFiniteNumber = (
+      value: unknown,
+      elementId: string,
+      key: string
+    ): number => {
+      const result = Number(value)
+      if (!Number.isFinite(result)) {
+        throw new Error(
+          `Element "${elementId}" has non-finite computed "${key}"`
+        )
+      }
+      return result
+    }
+
+    const getWorldPosition = (elementId: string) => {
+      let currentId = elementId
+      let x = 0
+      let y = 0
+      const visited = new Set<string>()
+
+      while (currentId) {
+        if (visited.has(currentId)) {
+          throw new Error(`Hierarchy cycle reaches "${currentId}"`)
+        }
+        visited.add(currentId)
+        const element = sceneTree?.getElementById?.(currentId)
+        if (!element) {
+          throw new Error(`Missing hierarchy element "${currentId}"`)
+        }
+        if (element.get?.('type') === 'workspace') {
+          break
+        }
+        const computed = element.getAllComputedData?.() ?? {}
+        x += getFiniteNumber(computed.x, currentId, 'x')
+        y += getFiniteNumber(computed.y, currentId, 'y')
+        currentId = String(element.get?.('parentId') ?? '')
+      }
+
+      return { x, y }
+    }
+
+    return Array.from(elements.entries())
+      .filter(([, element]) => element.get?.('type') !== 'workspace')
+      .map(([id, element]) => {
+        const computed = element.getAllComputedData?.() ?? {}
+        const type = String(element.get?.('type') ?? '')
+        const children =
+          type === 'group' ? element.get?.('children') : undefined
+        return {
+          id,
+          type,
+          parentId: String(element.get?.('parentId') ?? ''),
+          children: Array.isArray(children) ? [...children] : undefined,
+          local: {
+            x: getFiniteNumber(computed.x, id, 'x'),
+            y: getFiniteNumber(computed.y, id, 'y'),
+            width: getFiniteNumber(computed.width, id, 'width'),
+            height: getFiniteNumber(computed.height, id, 'height')
+          },
+          world: getWorldPosition(id)
+        }
+      })
+      .sort((left, right) => left.id.localeCompare(right.id))
+  })
+
 const getCollaborationDiagnostics = (page: Page) =>
   page.evaluate(() => ({
     status: window.__AsyraCollaboration__?.getStatus() ?? 'missing',
@@ -559,6 +630,84 @@ test('remote undo restores an exact nested Group with and without local tombston
     expect(await getUndoDepth(noTombstonePeer)).toBe(noTombstoneUndoDepth)
   } finally {
     await Promise.all([senderContext.close(), tombstoneContext.close()])
+  }
+})
+
+test('remote Group redo preserves exact hierarchy and world geometry', async ({
+  browser
+}, testInfo) => {
+  const fileId = `group-redo-${Date.now()}-${testInfo.workerIndex}`
+  const firstContext = await browser.newContext()
+  const secondContext = await browser.newContext()
+  const first = await firstContext.newPage()
+  const second = await secondContext.newPage()
+
+  try {
+    await Promise.all([
+      first.goto(collaborationUrl(fileId)),
+      second.goto(collaborationUrl(fileId))
+    ])
+    await Promise.all([waitForAppReady(first), waitForAppReady(second)])
+    await Promise.all([
+      waitForCollaboration(first),
+      waitForCollaboration(second)
+    ])
+
+    await createRectangle(first, 0.3, 0.35)
+    await createRectangle(first, 0.62, 0.55)
+    await expect.poll(() => getElementCount(second)).toBe(2)
+
+    const rectangleIds = (await getCanonicalSnapshot(first)).map(({ id }) => id)
+    const ungroupedGeometry = await getCanonicalHierarchyGeometry(first)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(ungroupedGeometry)
+
+    const groupId = await groupLayerIds(first, rectangleIds)
+    await expect.poll(() => getElementCount(second)).toBe(3)
+    const groupedGeometry = await getCanonicalHierarchyGeometry(first)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(groupedGeometry)
+
+    await undo(first)
+    await expect.poll(() => getElementCount(first)).toBe(2)
+    await expect.poll(() => getElementCount(second)).toBe(2)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(first))
+      .toEqual(ungroupedGeometry)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(ungroupedGeometry)
+
+    await redo(first)
+    await expect.poll(() => getElementCount(first)).toBe(3)
+    await expect.poll(() => getElementCount(second)).toBe(3)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(first))
+      .toEqual(groupedGeometry)
+    await expect
+      .poll(() => getCanonicalHierarchyGeometry(second))
+      .toEqual(groupedGeometry)
+
+    const remoteGroup = (await getCanonicalHierarchyGeometry(second)).find(
+      ({ id }) => id === groupId
+    )
+    expect(remoteGroup).toEqual(
+      groupedGeometry.find(({ id }) => id === groupId)
+    )
+    await Promise.all([
+      first.screenshot({
+        path: testInfo.outputPath('group-redo-source.png'),
+        fullPage: true
+      }),
+      second.screenshot({
+        path: testInfo.outputPath('group-redo-peer.png'),
+        fullPage: true
+      })
+    ])
+  } finally {
+    await Promise.all([firstContext.close(), secondContext.close()])
   }
 })
 

--- a/create-app/asyra-design/template/e2e/collaboration.spec.ts
+++ b/create-app/asyra-design/template/e2e/collaboration.spec.ts
@@ -4,6 +4,7 @@ import {
   createVectorPath,
   dragSelectedElementBy,
   getCanvasPosition,
+  getContentsPanel,
   getElementCount,
   getSelectedElementClientCenter,
   redo,
@@ -13,6 +14,55 @@ import {
 
 const collaborationUrl = (fileId: string) =>
   `/?fileId=${encodeURIComponent(fileId)}`
+
+const layerRow = (page: Page, elementId: string) =>
+  page.getByTestId(`element-item-${elementId}`)
+
+const getLayerIds = (page: Page): Promise<string[]> =>
+  getContentsPanel(page)
+    .locator('[data-layer-element="true"]')
+    .evaluateAll((rows) =>
+      rows.map(
+        (row) =>
+          row.getAttribute('data-testid')?.replace('element-item-', '') ?? ''
+      )
+    )
+
+const getSelectedIds = (page: Page): Promise<string[]> =>
+  page.evaluate(
+    () => window.__Core__?.deps.selection.getElementSelectionIds() ?? []
+  )
+
+const groupLayerIds = async (
+  page: Page,
+  elementIds: readonly string[]
+): Promise<string> => {
+  const contentsPanel = getContentsPanel(page)
+  const panelBounds = await contentsPanel.boundingBox()
+  if (!panelBounds) {
+    throw new Error('Layers panel bounds are unavailable')
+  }
+  await page.mouse.click(
+    panelBounds.x + panelBounds.width / 2,
+    panelBounds.y + panelBounds.height - 50
+  )
+  await expect.poll(() => getSelectedIds(page)).toEqual([])
+
+  await layerRow(page, elementIds[0]).click()
+  await page.keyboard.down('Shift')
+  try {
+    for (const elementId of elementIds.slice(1)) {
+      await layerRow(page, elementId).click()
+    }
+  } finally {
+    await page.keyboard.up('Shift')
+  }
+  const groupButton = page.getByTestId('layers-group-button')
+  await expect(groupButton).toBeEnabled()
+  await groupButton.click()
+  await expect.poll(() => getSelectedIds(page)).toHaveLength(1)
+  return (await getSelectedIds(page))[0]
+}
 
 const waitForCollaboration = async (page: Page) => {
   await expect
@@ -53,6 +103,66 @@ const getCanonicalRenderVisibility = (page: Page, elementId: string) =>
     (id) =>
       window.__Core__?.deps?.render?.getElementById?.(id)?.visible ?? null,
     elementId
+  )
+
+const getOwnerSave = (page: Page) =>
+  page.evaluate(() => ({
+    sceneTree: window.__Core__.deps.sceneTree.save(),
+    props: window.__Core__.deps.props.save()
+  }))
+
+const getUndoDepth = (page: Page) =>
+  page.evaluate(
+    () =>
+      (
+        window.__Core__.deps.factory.transact as unknown as {
+          undoStack?: unknown[]
+        }
+      ).undoStack?.length ?? 0
+  )
+
+const capturePublicationOutcomes = (page: Page) =>
+  page.evaluate(() => {
+    const runtime = globalThis as typeof globalThis & {
+      __remoteRestoreOutcomes?: unknown[]
+    }
+    runtime.__remoteRestoreOutcomes = []
+    const handle = window.__AsyraCollaboration__ as
+      | (NonNullable<Window['__AsyraCollaboration__']> & {
+          observePublicationOutcomes(
+            subscriber: (outcome: {
+              direction: string
+              status: string
+              publicationId: string
+              error?: unknown
+            }) => void
+          ): () => void
+        })
+      | undefined
+    handle?.observePublicationOutcomes((outcome) => {
+      runtime.__remoteRestoreOutcomes?.push({
+        ...outcome,
+        ...(outcome.error instanceof Error
+          ? {
+              error: {
+                name: outcome.error.name,
+                message: outcome.error.message,
+                stack: outcome.error.stack
+              }
+            }
+          : {})
+      })
+    })
+  })
+
+const getPublicationOutcomes = (page: Page) =>
+  page.evaluate(
+    () =>
+      (
+        globalThis as typeof globalThis & {
+          __remoteRestoreOutcomes?: unknown[]
+        }
+      ).__remoteRestoreOutcomes ?? []
   )
 
 const getVectorTopologySummary = (page: Page) =>
@@ -232,6 +342,223 @@ test('two real Asyra Design windows converge while connected and reconnect live-
       secondContext.close(),
       isolatedContext.close()
     ])
+  }
+})
+
+test('remote undo restores an exact nested Group with and without local tombstones', async ({
+  browser
+}, testInfo) => {
+  test.setTimeout(120_000)
+  const fileId = `restore-${Date.now()}-${testInfo.workerIndex}`
+  const senderContext = await browser.newContext()
+  const tombstoneContext = await browser.newContext()
+  const sender = await senderContext.newPage()
+  const tombstonePeer = await tombstoneContext.newPage()
+  let noTombstonePeer: Page | undefined
+
+  try {
+    await Promise.all([
+      sender.goto(collaborationUrl(fileId)),
+      tombstonePeer.goto(collaborationUrl(fileId))
+    ])
+    await Promise.all([waitForAppReady(sender), waitForAppReady(tombstonePeer)])
+    await Promise.all([
+      waitForCollaboration(sender),
+      waitForCollaboration(tombstonePeer)
+    ])
+
+    await createRectangle(sender, 0.28, 0.32)
+    await createRectangle(sender, 0.48, 0.45)
+    await createRectangle(sender, 0.68, 0.58)
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(3)
+    const rectangleIds = (await getCanonicalSnapshot(sender)).map(
+      ({ id }) => id
+    )
+    const innerGroupId = await groupLayerIds(sender, rectangleIds.slice(0, 2))
+    await sender.getByTestId(`layers-group-toggle-${innerGroupId}`).click()
+    const outerGroupId = await groupLayerIds(sender, [
+      rectangleIds[2],
+      innerGroupId
+    ])
+    await sender.getByTestId(`layers-group-toggle-${innerGroupId}`).click()
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(5)
+    await expect
+      .poll(() => getOwnerSave(tombstonePeer))
+      .toEqual(await getOwnerSave(sender))
+
+    const expectedOwnerSave = await getOwnerSave(sender)
+    const expectedLayerIds = await getLayerIds(sender)
+    const expectedElementIds = (await getCanonicalSnapshot(sender)).map(
+      ({ id }) => id
+    )
+
+    await layerRow(sender, outerGroupId).click()
+    await sender.keyboard.press('Delete')
+    await expect.poll(() => getElementCount(sender)).toBe(0)
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(0)
+    await expect
+      .poll(() =>
+        tombstonePeer.evaluate((expectedSceneCount) => {
+          const sceneTree = window.__Core__.deps.sceneTree as unknown as {
+            _deletedMap?: Map<string, unknown>
+          }
+          const props = window.__Core__.deps.props as unknown as {
+            _deletedMap?: Map<string, unknown>
+          }
+          return (
+            sceneTree._deletedMap?.size === expectedSceneCount &&
+            (props._deletedMap?.size ?? 0) > 0
+          )
+        }, expectedElementIds.length)
+      )
+      .toBe(true)
+
+    await expect
+      .poll(() =>
+        sender.evaluate(
+          ({ storageKey, removedGroupId }) => {
+            const raw = localStorage.getItem(storageKey)
+            if (!raw) return false
+            const saved = JSON.parse(raw) as {
+              sceneTree?: { elements?: Record<string, unknown> }
+            }
+            return !saved.sceneTree?.elements?.[removedGroupId]
+          },
+          {
+            storageKey: `FILE:${fileId}`,
+            removedGroupId: outerGroupId
+          }
+        )
+      )
+      .toBe(true)
+
+    noTombstonePeer = await senderContext.newPage()
+    await noTombstonePeer.goto(collaborationUrl(fileId))
+    await waitForAppReady(noTombstonePeer)
+    await waitForCollaboration(noTombstonePeer)
+    expect(await getElementCount(noTombstonePeer)).toBe(0)
+    expect(
+      await noTombstonePeer.evaluate(() => {
+        const sceneTree = window.__Core__.deps.sceneTree as unknown as {
+          _deletedMap?: Map<string, unknown>
+        }
+        const props = window.__Core__.deps.props as unknown as {
+          _deletedMap?: Map<string, unknown>
+        }
+        return {
+          scene: sceneTree._deletedMap?.size ?? 0,
+          props: props._deletedMap?.size ?? 0
+        }
+      })
+    ).toEqual({ scene: 0, props: 0 })
+
+    await noTombstonePeer.evaluate(() => {
+      const runtime = globalThis as typeof globalThis & {
+        __remoteRestorePublications?: unknown[]
+        __remoteRestoreCommits?: unknown[]
+      }
+      runtime.__remoteRestorePublications = []
+      runtime.__remoteRestoreCommits = []
+      window.__Core__.deps.factory.subscribeToSharedPublication((publication) =>
+        runtime.__remoteRestorePublications?.push(publication)
+      )
+      window.__Core__.deps.factory.subscribeToTransactionStatus((status) => {
+        if (status.origin === 'remote' && status.status === 'committed') {
+          runtime.__remoteRestoreCommits?.push(status)
+        }
+      })
+    })
+    const noTombstoneUndoDepth = await getUndoDepth(noTombstonePeer)
+    await Promise.all([
+      capturePublicationOutcomes(tombstonePeer),
+      capturePublicationOutcomes(noTombstonePeer)
+    ])
+
+    await undo(sender)
+    await expect
+      .poll(async () => (await getPublicationOutcomes(tombstonePeer)).length)
+      .toBeGreaterThan(0)
+    const remoteOutcomes = {
+      tombstone: await getPublicationOutcomes(tombstonePeer),
+      noTombstone: await getPublicationOutcomes(noTombstonePeer)
+    }
+    const processFailures = Object.values(remoteOutcomes)
+      .flat()
+      .filter(
+        (outcome) =>
+          typeof outcome === 'object' &&
+          outcome !== null &&
+          'status' in outcome &&
+          outcome.status === 'process-failed'
+      )
+    if (processFailures.length > 0) {
+      throw new Error(
+        `Remote restore processing failed:\n${JSON.stringify(
+          remoteOutcomes,
+          null,
+          2
+        )}`
+      )
+    }
+
+    try {
+      await expect
+        .poll(() => getOwnerSave(tombstonePeer))
+        .toEqual(expectedOwnerSave)
+    } catch (error) {
+      await testInfo.attach('remote-restore-outcomes.json', {
+        body: JSON.stringify(
+          {
+            tombstone: await getPublicationOutcomes(tombstonePeer),
+            noTombstone: await getPublicationOutcomes(noTombstonePeer)
+          },
+          null,
+          2
+        ),
+        contentType: 'application/json'
+      })
+      throw error
+    }
+    await expect
+      .poll(() => getOwnerSave(noTombstonePeer as Page))
+      .toEqual(expectedOwnerSave)
+    await expect
+      .poll(() => getLayerIds(tombstonePeer))
+      .toEqual(expectedLayerIds)
+    await expect
+      .poll(() => getLayerIds(noTombstonePeer as Page))
+      .toEqual(expectedLayerIds)
+    await expect
+      .poll(() => getCanonicalSnapshot(noTombstonePeer as Page))
+      .toEqual(await getCanonicalSnapshot(sender))
+
+    expect(await getUndoDepth(noTombstonePeer)).toBe(noTombstoneUndoDepth)
+    expect(
+      await noTombstonePeer.evaluate(() => {
+        const runtime = globalThis as typeof globalThis & {
+          __remoteRestorePublications?: unknown[]
+          __remoteRestoreCommits?: unknown[]
+        }
+        return {
+          publications: runtime.__remoteRestorePublications?.length ?? -1,
+          commits: runtime.__remoteRestoreCommits?.length ?? -1
+        }
+      })
+    ).toEqual({ publications: 0, commits: 1 })
+
+    for (const elementId of expectedElementIds) {
+      expect(
+        await getCanonicalRenderVisibility(noTombstonePeer, elementId)
+      ).not.toBeNull()
+    }
+
+    await redo(sender)
+    await expect.poll(() => getElementCount(sender)).toBe(0)
+    await expect.poll(() => getElementCount(tombstonePeer)).toBe(0)
+    await expect.poll(() => getElementCount(noTombstonePeer as Page)).toBe(0)
+    expect(await getUndoDepth(noTombstonePeer)).toBe(noTombstoneUndoDepth)
+  } finally {
+    await Promise.all([senderContext.close(), tombstoneContext.close()])
   }
 })
 

--- a/create-app/asyra-design/template/e2e/group-interaction.spec.ts
+++ b/create-app/asyra-design/template/e2e/group-interaction.spec.ts
@@ -89,6 +89,172 @@ const getWorldPositions = (
   }, elementIds)
 
 test.describe('Asyra Design Group interaction MVP', () => {
+  test('undoes and redoes a basic two-rectangle Group without losing either rectangle', async ({
+    page
+  }) => {
+    await page.goto('/')
+    await waitForAppReady(page)
+    await resetCanvas(page)
+
+    await createRectangle(page, 0.35, 0.42)
+    await createRectangle(page, 0.65, 0.58)
+
+    const initialIds = await getLayerIds(page)
+    expect(initialIds).toHaveLength(2)
+    const initialWorldPositions = await getWorldPositions(page, initialIds)
+    const initialHierarchy = await page.evaluate((elementIds) => {
+      const sceneTree = window.__Core__.deps.sceneTree
+      const workspaceId = String(sceneTree.workspace)
+      const workspace = sceneTree.getElementById(workspaceId)
+      return {
+        workspaceId,
+        workspaceChildren: [
+          ...((workspace?.get('children') as string[] | undefined) ?? [])
+        ],
+        parentIds: elementIds.map((elementId) =>
+          String(sceneTree.getElementById(elementId)?.get('parentId') ?? '')
+        )
+      }
+    }, initialIds)
+    expect(initialHierarchy.workspaceChildren).toEqual(initialIds)
+    expect(initialHierarchy.parentIds).toEqual(
+      initialIds.map(() => initialHierarchy.workspaceId)
+    )
+    await page.evaluate((elementIds) => {
+      const core = window.__Core__
+      ;(
+        window as typeof window & {
+          __BasicGroupUndoIdentity?: {
+            sceneElements: unknown[]
+            renderElements: unknown[]
+          }
+        }
+      ).__BasicGroupUndoIdentity = {
+        sceneElements: elementIds.map((elementId) =>
+          core.deps.sceneTree.getElementById(elementId)
+        ),
+        renderElements: elementIds.map((elementId) =>
+          core.deps.render.getElementById(elementId)
+        )
+      }
+    }, initialIds)
+
+    const groupId = await groupLayerIds(page, initialIds)
+    expect(groupId).not.toBe(initialIds[0])
+    expect(groupId).not.toBe(initialIds[1])
+    await expect
+      .poll(() =>
+        page.evaluate(
+          ({ createdGroupId, childIds }) => {
+            const sceneTree = window.__Core__.deps.sceneTree
+            const group = sceneTree.getElementById(createdGroupId)
+            return {
+              groupExists: Boolean(group),
+              groupChildren: [
+                ...((group?.get('children') as string[] | undefined) ?? [])
+              ],
+              childParentIds: childIds.map((childId) =>
+                String(sceneTree.getElementById(childId)?.get('parentId') ?? '')
+              )
+            }
+          },
+          { createdGroupId: groupId, childIds: initialIds }
+        )
+      )
+      .toEqual({
+        groupExists: true,
+        groupChildren: initialIds,
+        childParentIds: initialIds.map(() => groupId)
+      })
+
+    await undo(page)
+
+    await expect.poll(() => getLayerIds(page)).toEqual(initialIds)
+    await expect.poll(() => getSelectedIds(page)).toEqual(initialIds)
+    const undoHierarchy = await page.evaluate(
+      ({ createdGroupId, elementIds, workspaceId }) => {
+        const sceneTree = window.__Core__.deps.sceneTree
+        const workspace = sceneTree.getElementById(workspaceId)
+        return {
+          groupExists: Boolean(sceneTree.getElementById(createdGroupId)),
+          elementExists: elementIds.map((elementId) =>
+            Boolean(sceneTree.getElementById(elementId))
+          ),
+          workspaceChildren: [
+            ...((workspace?.get('children') as string[] | undefined) ?? [])
+          ],
+          parentIds: elementIds.map((elementId) =>
+            String(sceneTree.getElementById(elementId)?.get('parentId') ?? '')
+          )
+        }
+      },
+      {
+        createdGroupId: groupId,
+        elementIds: initialIds,
+        workspaceId: initialHierarchy.workspaceId
+      }
+    )
+    expect(undoHierarchy).toEqual({
+      groupExists: false,
+      elementExists: initialIds.map(() => true),
+      workspaceChildren: initialHierarchy.workspaceChildren,
+      parentIds: initialHierarchy.parentIds
+    })
+    expect(await getWorldPositions(page, initialIds)).toEqual(
+      initialWorldPositions
+    )
+    const undoIdentity = await page.evaluate((elementIds) => {
+      const core = window.__Core__
+      const initial = (
+        window as typeof window & {
+          __BasicGroupUndoIdentity?: {
+            sceneElements: unknown[]
+            renderElements: unknown[]
+          }
+        }
+      ).__BasicGroupUndoIdentity
+      if (!initial) {
+        throw new Error('Missing basic Group undo identity evidence')
+      }
+      return {
+        scene: elementIds.map(
+          (elementId, index) =>
+            core.deps.sceneTree.getElementById(elementId) ===
+            initial.sceneElements[index]
+        ),
+        render: elementIds.map(
+          (elementId, index) =>
+            core.deps.render.getElementById(elementId) ===
+            initial.renderElements[index]
+        ),
+        renderParentIds: elementIds.map(
+          (elementId) =>
+            core.deps.render.getElementById(elementId)?.parent?.label ?? null
+        )
+      }
+    }, initialIds)
+    expect(undoIdentity).toEqual({
+      scene: initialIds.map(() => true),
+      render: initialIds.map(() => true),
+      renderParentIds: initialIds.map(() => initialHierarchy.workspaceId)
+    })
+
+    await redo(page)
+
+    await expect.poll(() => getSelectedIds(page)).toEqual([groupId])
+    await expect(layerRow(page, groupId)).toBeVisible()
+    expect(await getWorldPositions(page, initialIds)).toEqual(
+      initialWorldPositions
+    )
+    await page.evaluate(() => {
+      delete (
+        window as typeof window & {
+          __BasicGroupUndoIdentity?: unknown
+        }
+      ).__BasicGroupUndoIdentity
+    })
+  })
+
   test('creates in the hierarchy-target Group or explicit workspace root from mouse down', async ({
     page
   }) => {

--- a/create-app/asyra-design/template/src/collaboration/lifecycle.ts
+++ b/create-app/asyra-design/template/src/collaboration/lifecycle.ts
@@ -1,7 +1,7 @@
 import { createCollaboration, type Collaboration } from '@asyra/collaboration'
 import { publishEvent } from '@asyra/reactive-events'
 import { idCounter } from '@asyra/utils'
-import { factory } from '../contexts'
+import core, { factory } from '../contexts'
 import type { CollaborationMode } from '../render-app/collaboration-mode'
 import { createDocumentCollaborationFactory } from './factory-adapter'
 import { createAsyraDesignPublicationProcessor } from './operations'
@@ -14,14 +14,20 @@ let startPromise:
 
 const createHandle = (
   instance: Collaboration
-): NonNullable<Window['__AsyraCollaboration__']> => ({
-  identity: instance.identity,
-  getStatus: () => instance.provider?.getStatus() ?? 'offline',
-  disconnect: () => instance.disconnect(),
-  reconnect: () => instance.reconnect(),
-  whenIdle: () => instance.whenIdle(),
-  dispose: () => instance.dispose()
-})
+): NonNullable<Window['__AsyraCollaboration__']> => {
+  const handle = {
+    identity: instance.identity,
+    getStatus: () => instance.provider?.getStatus() ?? 'offline',
+    disconnect: () => instance.disconnect(),
+    reconnect: () => instance.reconnect(),
+    whenIdle: () => instance.whenIdle(),
+    observePublicationOutcomes: (
+      subscriber: Parameters<Collaboration['observePublicationOutcomes']>[0]
+    ) => instance.observePublicationOutcomes(subscriber),
+    dispose: () => instance.dispose()
+  }
+  return handle
+}
 
 const start = async (
   mode: CollaborationMode
@@ -38,7 +44,9 @@ const start = async (
   })
   const processRemotePublication = createAsyraDesignPublicationProcessor(
     factory.runRemoteTransaction.bind(factory),
-    (event) => factory.applyRemoteEvent(event, publishEvent)
+    (event) => factory.applyRemoteEvent(event, publishEvent),
+    undefined,
+    core
   )
   const collaboration = createCollaboration({
     documentId: mode.fileId,

--- a/create-app/asyra-design/template/src/collaboration/operations.ts
+++ b/create-app/asyra-design/template/src/collaboration/operations.ts
@@ -1,8 +1,14 @@
 import type { SharedDelivery, SharedPublication } from '@asyra/factory'
 import { EventTypes, type AllEvent } from '@asyra/reactive-events'
 import {
+  type ElementPropertyOwnerRelation,
+  type EVENT_OPTIONS,
   PROPS_ACTIONS,
+  type PropsRestorePlan,
+  type PropsRestoreSnapshot,
   SCENE_TREE_ACTIONS,
+  type SceneTreeRestorePlan,
+  type SceneTreeRestoreSnapshot,
   SharedDataChannelNames,
   isRecord
 } from '@asyra/utils'
@@ -13,6 +19,28 @@ type RunRemoteTransaction = <T>(mutate: () => T) => T
 export type DecideRemotePublication = (
   publication: SharedPublication
 ) => SharedPublication | false
+export interface RemoteRestoreOwnerFacades {
+  preflightRestoreSubtree: (
+    snapshot: SceneTreeRestoreSnapshot
+  ) => SceneTreeRestorePlan
+  preflightRestoreProperties: (
+    snapshot: PropsRestoreSnapshot,
+    ownerRelations: readonly ElementPropertyOwnerRelation[]
+  ) => PropsRestorePlan
+  applyRestoreProperties: (
+    plan: PropsRestorePlan,
+    options?: EVENT_OPTIONS
+  ) => readonly string[]
+  applyRestoreSubtree: (
+    plan: SceneTreeRestorePlan,
+    options?: EVENT_OPTIONS
+  ) => unknown
+}
+
+interface ClassifiedRemoteRestore {
+  sceneSnapshot: SceneTreeRestoreSnapshot
+  propsSnapshot: PropsRestoreSnapshot
+}
 
 const owns = (value: object, key: string): boolean =>
   Object.prototype.hasOwnProperty.call(value, key)
@@ -141,6 +169,8 @@ const isSubtreeChange = (value: unknown): value is Record<string, unknown> => {
     !isRecord(value) ||
     value.eventName !== EventTypes.CHANGE_SUBTREE ||
     !isNonBlankString(value.elementId) ||
+    !Array.isArray(value.rootParentChildrenAfter) ||
+    !value.rootParentChildrenAfter.every(isNonBlankString) ||
     !Array.isArray(value.removed) ||
     value.removed.length === 0 ||
     !value.removed.every(isSubtreeEntry)
@@ -240,6 +270,59 @@ const isSupportedPayload = (delivery: SharedDelivery): boolean => {
   return false
 }
 
+const classifyRemoteRestore = (
+  publication: SharedPublication
+): ClassifiedRemoteRestore | undefined => {
+  const restoreDeliveries = publication.deliveries.filter(
+    (delivery) =>
+      delivery.channel === SharedDataChannelNames.SCENE_TREE &&
+      delivery.eventName === EventTypes.CHANGE_SUBTREE &&
+      isRecord(delivery.payload) &&
+      delivery.payload.action === SCENE_TREE_ACTIONS.RESTORE_SUBTREE
+  )
+  if (restoreDeliveries.length === 0) {
+    return
+  }
+  const restoreDelivery = restoreDeliveries[0] as SharedDelivery
+  const restoreIndex = publication.deliveries.indexOf(restoreDelivery)
+  const propertyDeliveries = publication.deliveries.slice(0, restoreIndex)
+  const validRestoreEnvelope =
+    restoreDeliveries.length === 1 &&
+    restoreIndex === publication.deliveries.length - 1 &&
+    propertyDeliveries.every(
+      (delivery) =>
+        delivery.channel === SharedDataChannelNames.PROPS &&
+        delivery.eventName === EventTypes.ADD_PROPERTY &&
+        isAddRemoveProperties(
+          delivery.payload,
+          PROPS_ACTIONS.ADD_PROPERTY,
+          EventTypes.ADD_PROPERTY
+        )
+    )
+  if (!validRestoreEnvelope || !isSubtreeChange(restoreDelivery.payload)) {
+    throw new Error(
+      '[asyra-design collaboration] invalid subtree restore publication'
+    )
+  }
+
+  const payload = restoreDelivery.payload
+  return {
+    sceneSnapshot: {
+      elementId: payload.elementId as string,
+      removed: payload.removed as SceneTreeRestoreSnapshot['removed'],
+      rootParentChildrenAfter:
+        payload.rootParentChildrenAfter as readonly string[]
+    },
+    propsSnapshot: {
+      components: propertyDeliveries.flatMap(
+        (delivery) =>
+          (delivery.payload as { data: PropsRestoreSnapshot['components'] })
+            .data
+      )
+    }
+  }
+}
+
 const toEvent = (delivery: SharedDelivery): AllEvent => {
   if (!isSupportedPayload(delivery)) {
     throw new Error(
@@ -254,15 +337,42 @@ export const createAsyraDesignPublicationProcessor =
     runRemoteTransaction: RunRemoteTransaction,
     process: ProcessOperation,
     decideRemotePublication: DecideRemotePublication = (publication) =>
-      publication
+      publication,
+    restoreOwners?: RemoteRestoreOwnerFacades
   ): ((publication: SharedPublication) => void) =>
   (publication) => {
     publication.deliveries.forEach(toEvent)
+    const inboundRestore = classifyRemoteRestore(publication)
     const acceptedPublication = decideRemotePublication(publication)
     if (acceptedPublication === false) {
       return
     }
     const events = acceptedPublication.deliveries.map(toEvent)
+    const acceptedRestore = classifyRemoteRestore(acceptedPublication)
+    if (Boolean(inboundRestore) !== Boolean(acceptedRestore)) {
+      throw new Error(
+        '[asyra-design collaboration] invalid subtree restore publication'
+      )
+    }
+    if (acceptedRestore) {
+      if (!restoreOwners) {
+        throw new Error(
+          '[asyra-design collaboration] subtree restore owner facades are required'
+        )
+      }
+      const scenePlan = restoreOwners.preflightRestoreSubtree(
+        acceptedRestore.sceneSnapshot
+      )
+      const propsPlan = restoreOwners.preflightRestoreProperties(
+        acceptedRestore.propsSnapshot,
+        scenePlan.propertyOwnerRelations
+      )
+      runRemoteTransaction(() => {
+        restoreOwners.applyRestoreProperties(propsPlan)
+        restoreOwners.applyRestoreSubtree(scenePlan)
+      })
+      return
+    }
     runRemoteTransaction(() => {
       events.forEach((event) => process(event))
     })

--- a/create-app/asyra-design/template/src/contents/__tests__/layer-hierarchy.test.ts
+++ b/create-app/asyra-design/template/src/contents/__tests__/layer-hierarchy.test.ts
@@ -62,6 +62,29 @@ describe('canonical Layers hierarchy projection', () => {
     ).toEqual(['root', 'sibling'])
   })
 
+  it('projects restored normal and empty Groups from canonical stable identities', () => {
+    const restoredMap = {
+      restored: element('restored', 'workspace', EntityTypes.GROUP),
+      child: element('child', 'restored'),
+      empty: element('empty', 'workspace', EntityTypes.GROUP)
+    }
+
+    expect(
+      projectVisibleLayerRows(
+        ['restored', 'child', 'empty'],
+        restoredMap,
+        new Set()
+      )
+    ).toEqual({
+      rows: [
+        { id: 'restored', depth: 0, isGroup: true, isExpanded: true },
+        { id: 'child', depth: 1, isGroup: false, isExpanded: false },
+        { id: 'empty', depth: 0, isGroup: true, isExpanded: true }
+      ],
+      error: null
+    })
+  })
+
   it('rejects duplicate, missing, misordered, and cyclic projections', () => {
     expect(
       projectVisibleLayerRows(['root', 'root'], elementDataMap, new Set())

--- a/create-app/asyra-design/template/src/init/__tests__/collaboration-lifecycle.test.ts
+++ b/create-app/asyra-design/template/src/init/__tests__/collaboration-lifecycle.test.ts
@@ -30,6 +30,9 @@ beforeEach(async () => {
   vi.restoreAllMocks()
   idCounter.clear()
   harness.collaboration.updateAwareness.mockReset()
+  harness.collaboration.observePublicationOutcomes
+    .mockReset()
+    .mockReturnValue(vi.fn())
   harness.collaboration.start.mockReset().mockResolvedValue(undefined)
   harness.collaboration.dispose.mockReset().mockResolvedValue(undefined)
   delete window.__AsyraCollaboration__
@@ -68,4 +71,27 @@ it('starts the real app collaboration composition without an Awareness preview r
   expect(idCounter.current(IDTypes.ELEMENT)).toBe('el-actor-lifecycle-0')
   expect(harness.collaboration.updateAwareness).not.toHaveBeenCalled()
   expect(window.__AsyraCollaboration__).toBeDefined()
+})
+
+it('exposes remote publication outcomes through the local collaboration handle', async () => {
+  vi.spyOn(collaborationModule, 'createCollaboration').mockReturnValue(
+    harness.collaboration as never
+  )
+  const handle = await startCollaboration({
+    fileId: 'file-lifecycle',
+    actorId: 'actor-lifecycle',
+    endpoint: 'ws://127.0.0.1:4101/asyra-design-collaboration'
+  })
+  const subscriber = vi.fn()
+
+  const unsubscribe = (
+    handle as typeof handle & {
+      observePublicationOutcomes(callback: typeof subscriber): () => void
+    }
+  ).observePublicationOutcomes(subscriber)
+
+  expect(harness.collaboration.observePublicationOutcomes).toHaveBeenCalledWith(
+    subscriber
+  )
+  expect(unsubscribe).toEqual(expect.any(Function))
 })

--- a/create-app/asyra-design/template/src/init/__tests__/collaboration-operations.test.ts
+++ b/create-app/asyra-design/template/src/init/__tests__/collaboration-operations.test.ts
@@ -3,7 +3,9 @@ import { EventTypes } from '@asyra/reactive-events'
 import {
   PROPS_ACTIONS,
   SCENE_TREE_ACTIONS,
-  SharedDataChannelNames
+  SharedDataChannelNames,
+  type PropsRestorePlan,
+  type SceneTreeRestorePlan
 } from '@asyra/utils'
 import { describe, expect, it, vi } from 'vitest'
 import { createAsyraDesignPublicationProcessor } from '../../collaboration/operations'
@@ -80,6 +82,7 @@ const validDeliveries = (): readonly SharedDelivery[] => [
     undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
     eventName: EventTypes.CHANGE_SUBTREE,
     elementId: 'group-a',
+    rootParentChildrenAfter: [],
     removed: [
       {
         elementId: 'rect-a',
@@ -120,7 +123,258 @@ const validDeliveries = (): readonly SharedDelivery[] => [
   })
 ]
 
+const restoreDeliveries = (): readonly SharedDelivery[] => [
+  delivery(SharedDataChannelNames.PROPS, EventTypes.ADD_PROPERTY, {
+    action: PROPS_ACTIONS.ADD_PROPERTY,
+    undoType: EventTypes.REMOVE_PROPERTY,
+    undoAction: PROPS_ACTIONS.REMOVE_PROPERTY,
+    eventName: EventTypes.ADD_PROPERTY,
+    data: [
+      {
+        id: 'position-group-a',
+        type: 'position',
+        x: 12,
+        y: 24
+      }
+    ]
+  }),
+  delivery(SharedDataChannelNames.SCENE_TREE, EventTypes.CHANGE_SUBTREE, {
+    action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+    undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
+    eventName: EventTypes.CHANGE_SUBTREE,
+    elementId: 'group-a',
+    rootParentChildrenAfter: [],
+    removed: [
+      {
+        elementId: 'group-a',
+        parentId: 'workspace-a',
+        index: 0,
+        data: {
+          id: 'group-a',
+          type: 'group',
+          parentId: 'workspace-a',
+          children: [],
+          props: { position: 'position-group-a' }
+        }
+      }
+    ]
+  })
+]
+
+const createRestoreOwners = () => {
+  const scenePlan = Object.freeze({
+    kind: 'scene-tree-restore-plan',
+    elementId: 'group-a',
+    entries: Object.freeze([
+      Object.freeze({
+        elementId: 'group-a',
+        strategy: 'materialize' as const
+      })
+    ]),
+    propertyOwnerRelations: Object.freeze([
+      Object.freeze({
+        ownerElementId: 'group-a',
+        ownerElementType: 'group',
+        ownerPropertyName: 'position',
+        componentId: 'position-group-a'
+      })
+    ])
+  }) satisfies SceneTreeRestorePlan
+  const propsPlan = Object.freeze({
+    kind: 'props-restore-plan',
+    entries: Object.freeze([
+      Object.freeze({
+        componentId: 'position-group-a',
+        strategy: 'materialize' as const
+      })
+    ]),
+    ownerRelations: scenePlan.propertyOwnerRelations
+  }) satisfies PropsRestorePlan
+
+  return {
+    scenePlan,
+    propsPlan,
+    owners: {
+      preflightRestoreSubtree: vi.fn(() => scenePlan),
+      preflightRestoreProperties: vi.fn(() => propsPlan),
+      applyRestoreProperties: vi.fn(() => Object.freeze(['position-group-a'])),
+      applyRestoreSubtree: vi.fn()
+    }
+  }
+}
+
 describe('Asyra Design app-owned collaboration processing', () => {
+  it('preflights one complete restore before applying Props then Scene in one remote transaction', () => {
+    const callOrder: string[] = []
+    const runRemoteTransaction = vi.fn((mutate: () => void) => {
+      callOrder.push('transaction')
+      mutate()
+    })
+    const process = vi.fn()
+    const { scenePlan, propsPlan, owners } = createRestoreOwners()
+    owners.preflightRestoreSubtree.mockImplementation((snapshot) => {
+      callOrder.push('preflight-scene')
+      expect(snapshot).toEqual(
+        expect.objectContaining({
+          elementId: 'group-a',
+          rootParentChildrenAfter: []
+        })
+      )
+      return scenePlan
+    })
+    owners.preflightRestoreProperties.mockImplementation(
+      (snapshot, ownerRelations) => {
+        callOrder.push('preflight-props')
+        expect(snapshot).toEqual({
+          components: [
+            {
+              id: 'position-group-a',
+              type: 'position',
+              x: 12,
+              y: 24
+            }
+          ]
+        })
+        expect(ownerRelations).toBe(scenePlan.propertyOwnerRelations)
+        return propsPlan
+      }
+    )
+    owners.applyRestoreProperties.mockImplementation(() => {
+      callOrder.push('apply-props')
+      return Object.freeze(['position-group-a'])
+    })
+    owners.applyRestoreSubtree.mockImplementation(() => {
+      callOrder.push('apply-scene')
+      return {
+        elementId: 'group-a',
+        removed: [],
+        rootParentChildrenAfter: []
+      }
+    })
+    const processPublication = createAsyraDesignPublicationProcessor(
+      runRemoteTransaction,
+      process,
+      (item) => item,
+      owners
+    )
+
+    processPublication(publication(restoreDeliveries(), 'restore-group-a'))
+
+    expect(callOrder).toEqual([
+      'preflight-scene',
+      'preflight-props',
+      'transaction',
+      'apply-props',
+      'apply-scene'
+    ])
+    expect(owners.applyRestoreProperties).toHaveBeenCalledWith(propsPlan)
+    expect(owners.applyRestoreSubtree).toHaveBeenCalledWith(scenePlan)
+    expect(process).not.toHaveBeenCalled()
+  })
+
+  it('rejects mixed or out-of-order restore deliveries before owner preflight', () => {
+    const cases = [
+      [
+        ...(restoreDeliveries() as SharedDelivery[]),
+        validDeliveries()[0] as SharedDelivery
+      ],
+      [...restoreDeliveries()].reverse()
+    ]
+
+    cases.forEach((deliveries, index) => {
+      const runRemoteTransaction = vi.fn((mutate: () => void) => mutate())
+      const process = vi.fn()
+      const { owners } = createRestoreOwners()
+      const processPublication = createAsyraDesignPublicationProcessor(
+        runRemoteTransaction,
+        process,
+        (item) => item,
+        owners
+      )
+
+      expect(() =>
+        processPublication(publication(deliveries, `invalid-restore-${index}`))
+      ).toThrow('invalid subtree restore publication')
+      expect(owners.preflightRestoreSubtree).not.toHaveBeenCalled()
+      expect(owners.preflightRestoreProperties).not.toHaveBeenCalled()
+      expect(runRemoteTransaction).not.toHaveBeenCalled()
+      expect(process).not.toHaveBeenCalled()
+    })
+  })
+
+  it('rejects restore evidence without detached root-parent order before policy or mutation', () => {
+    const [propsDelivery, sceneDelivery] = restoreDeliveries()
+    const malformedScene = {
+      ...sceneDelivery,
+      payload: {
+        ...(sceneDelivery?.payload as Record<string, unknown>)
+      }
+    } as SharedDelivery
+    delete (malformedScene.payload as Record<string, unknown>)
+      .rootParentChildrenAfter
+    const decide = vi.fn((item: SharedPublication) => item)
+    const runRemoteTransaction = vi.fn((mutate: () => void) => mutate())
+    const { owners } = createRestoreOwners()
+    const processPublication = createAsyraDesignPublicationProcessor(
+      runRemoteTransaction,
+      vi.fn(),
+      decide,
+      owners
+    )
+
+    expect(() =>
+      processPublication(
+        publication(
+          [propsDelivery as SharedDelivery, malformedScene],
+          'malformed-root-order'
+        )
+      )
+    ).toThrow('unsupported collaboration delivery')
+    expect(decide).not.toHaveBeenCalled()
+    expect(owners.preflightRestoreSubtree).not.toHaveBeenCalled()
+    expect(runRemoteTransaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects restore policy or owner preflight failure before the remote transaction', () => {
+    const rejectedOwners = createRestoreOwners().owners
+    const rejectedTransaction = vi.fn((mutate: () => void) => mutate())
+    const rejectPublication = createAsyraDesignPublicationProcessor(
+      rejectedTransaction,
+      vi.fn(),
+      () => false,
+      rejectedOwners
+    )
+
+    rejectPublication(
+      publication(restoreDeliveries(), 'unauthorized-restore-group-a')
+    )
+
+    expect(rejectedOwners.preflightRestoreSubtree).not.toHaveBeenCalled()
+    expect(rejectedOwners.preflightRestoreProperties).not.toHaveBeenCalled()
+    expect(rejectedTransaction).not.toHaveBeenCalled()
+
+    const staleOwners = createRestoreOwners().owners
+    staleOwners.preflightRestoreProperties.mockImplementation(() => {
+      throw new Error('stale property owner evidence')
+    })
+    const staleTransaction = vi.fn((mutate: () => void) => mutate())
+    const rejectStale = createAsyraDesignPublicationProcessor(
+      staleTransaction,
+      vi.fn(),
+      (item) => item,
+      staleOwners
+    )
+
+    expect(() =>
+      rejectStale(publication(restoreDeliveries(), 'stale-restore-group-a'))
+    ).toThrow('stale property owner evidence')
+    expect(staleOwners.preflightRestoreSubtree).toHaveBeenCalledOnce()
+    expect(staleOwners.preflightRestoreProperties).toHaveBeenCalledOnce()
+    expect(staleOwners.applyRestoreProperties).not.toHaveBeenCalled()
+    expect(staleOwners.applyRestoreSubtree).not.toHaveBeenCalled()
+    expect(staleTransaction).not.toHaveBeenCalled()
+  })
+
   it('validates all supported Scene Tree and Props routes before one remote transaction', () => {
     const runRemoteTransaction = vi.fn((mutate: () => void) => mutate())
     const process = vi.fn(() => true)

--- a/docs/ai/apps/asyra-design/PLANS.md
+++ b/docs/ai/apps/asyra-design/PLANS.md
@@ -5,19 +5,21 @@ Never record completed plans here.
 ## Current Status
 
 - Ordered proposed next implementation plans:
-  1. `plans/remote-subtree-restore-snapshot-plan.md`
-  2. `plans/group-context-menu-plan.md`
-- Both remain plan-only until user review. Their Group prerequisite completed
-  and merged through PR #94 on 2026-07-24; the second plan may start only after
-  the first is implemented, reviewed, closed out, and merged.
+  1. `plans/group-context-menu-plan.md`
+- It remains plan-only until user review. Its Group prerequisite completed and
+  merged through PR #94 on 2026-07-24; its remote subtree restore prerequisite
+  completed and closed out on 2026-07-25, with merge still required before the
+  user may explicitly start the plan.
 - Current plan in this index: none.
 - Group Interaction MVP and Layer Tree Reparent/Reorder completed on
-  2026-07-24. Their canonical records are:
+  2026-07-24. Remote Subtree Restore Snapshot completed on 2026-07-25. Their
+  canonical records are:
   1. `plans/completed/group-interaction-mvp-plan.md`
   2. `plans/completed/layer-tree-reparent-reorder-plan.md`
+  3. `plans/completed/remote-subtree-restore-snapshot-plan.md`
 - Separately queued app/server plan after the completed network collaboration
-  transport Gate 2. It is sequenced behind both ordered plans above and remains
-  inactive until the user explicitly starts it:
+  transport Gate 2. It is sequenced behind the remaining ordered plan above
+  and remains inactive until the user explicitly starts it:
   `plans/durable-collaboration-server-and-continuous-sync-plan.md`.
 - Deferred profiling candidate, neither active nor queued:
   `plans/vector-gradient-move-120fps-plan.md`.

--- a/docs/ai/apps/asyra-design/decisions/releases/unreleased.md
+++ b/docs/ai/apps/asyra-design/decisions/releases/unreleased.md
@@ -6756,3 +6756,29 @@ join` constrained dashed product path across:
   - PR #94 remains unmerged until the user inspects this closeout.
 - Related Plan:
   - `docs/ai/apps/asyra-design/plans/completed/layer-tree-reparent-reorder-plan.md`
+
+## 2026-07-25 - Complete Remote Subtree Restore Snapshot
+
+- Context:
+  - A receiving peer that had the current post-delete document but had not
+    observed the original delete lacked compatible Scene Tree and Props
+    tombstones for local restoration.
+  - Remote Group undo/redo also required exact owner snapshots so receiving
+    clients would not reconstruct defaults or repair canonical geometry.
+- Decision:
+  - Close the Remote Subtree Restore Snapshot plan after its exact Inspector
+    owner flow, formal framework/app gates, synchronized product review, and
+    explicit user approval.
+  - Preserve `element.save()` Scene Tree evidence and component `save()` Props
+    evidence in one existing Factory `SharedPublication`.
+  - Keep receiving restore atomic and tombstone-optional, with no create
+    defaults, replacement ids, Collaboration semantics, or remote Group
+    geometry repair.
+- Consequences:
+  - Valid remote subtree restores preserve stable ids, hierarchy, exact
+    properties, save output, Render/Layers projection, and redo behavior
+    whether or not the receiver has matching tombstones.
+  - The Group Context Menu plan becomes the next proposed app plan after this
+    closeout is merged and explicitly started.
+- Related Plan:
+  - `docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md`

--- a/docs/ai/apps/asyra-design/plans/__tests__/remote-subtree-restore-snapshot-flow-inspector.contract.test.cjs
+++ b/docs/ai/apps/asyra-design/plans/__tests__/remote-subtree-restore-snapshot-flow-inspector.contract.test.cjs
@@ -45,7 +45,7 @@ test('Remote Restore Inspector and product authorities resolve', () => {
   assert.equal(data.target.title, 'Remote Subtree Restore Snapshot Inspector')
   assert.equal(
     data.authority.specPath,
-    'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-plan.md'
+    'docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md'
   )
   assert.equal(
     data.authority.inspectorPath,

--- a/docs/ai/apps/asyra-design/plans/__tests__/remote-subtree-restore-snapshot-flow-inspector.contract.test.cjs
+++ b/docs/ai/apps/asyra-design/plans/__tests__/remote-subtree-restore-snapshot-flow-inspector.contract.test.cjs
@@ -275,6 +275,12 @@ test('Scene Tree and Props preflight tombstone reuse or exact known-data materia
     /stable id.*parent.*root index.*child order.*raw Group data/i
   )
   assert.match(propsApply, /component id.*data.*owner relation/i)
+  assert.match(propsApply, /issuing Props Manager accessor.*child relation/i)
+  assert.ok(
+    step('materialize-props-restore').implementationBoundary.includes(
+      'packages/props-manager/src/registries/declarative-property-type.ts'
+    )
+  )
   assert.match(`${sceneApply} ${propsApply}`, /no defaults.*replacement ids/i)
 })
 
@@ -301,6 +307,12 @@ test('Preset, Render, and Layers consume only ordinary canonical projection', ()
   const layers = contractText(step('project-layers-ui'))
 
   assert.match(preset, /ordinary canonical updates.*Group bounds/i)
+  assert.match(preset, /children-map.*issuing Props Manager accessor/i)
+  assert.ok(
+    step('project-preset-group-state').implementationBoundary.includes(
+      'packages/preset/src/props/components/children-map-property-component.ts'
+    )
+  )
   assert.match(
     render,
     /same stable identities.*ordinary Scene Tree projection/i

--- a/docs/ai/apps/asyra-design/plans/__tests__/remote-subtree-restore-snapshot-flow-inspector.contract.test.cjs
+++ b/docs/ai/apps/asyra-design/plans/__tests__/remote-subtree-restore-snapshot-flow-inspector.contract.test.cjs
@@ -1,0 +1,331 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const data = require('../remote-subtree-restore-snapshot-flow-inspector.data.cjs')
+const repoRoot = path.resolve(__dirname, '../../../../../..')
+
+const step = (id) => {
+  const value = data.steps.find((item) => item.id === id)
+  assert.ok(value, `Missing Inspector step: ${id}`)
+  return value
+}
+
+const contractText = (owner) =>
+  [
+    owner.purpose,
+    ...owner.inputs,
+    ...owner.outputs,
+    ...owner.conditions,
+    ...owner.bypasses,
+    ...owner.allowedContributors,
+    ...owner.forbiddenContributors,
+    ...owner.implementationBoundary
+  ].join(' ')
+
+const anchorForHeading = (heading) =>
+  heading
+    .trim()
+    .toLowerCase()
+    .replace(/[`*_~]/g, '')
+    .replace(/[^\p{Letter}\p{Number}\s-]/gu, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+
+const anchorsIn = (markdown) =>
+  new Set(
+    markdown
+      .split('\n')
+      .filter((line) => /^#{1,6}\s+/.test(line))
+      .map((line) => anchorForHeading(line.replace(/^#{1,6}\s+/, '')))
+  )
+
+test('Remote Restore Inspector and product authorities resolve', () => {
+  assert.equal(data.target.title, 'Remote Subtree Restore Snapshot Inspector')
+  assert.equal(
+    data.authority.specPath,
+    'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-plan.md'
+  )
+  assert.equal(
+    data.authority.inspectorPath,
+    'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs'
+  )
+  assert.ok(fs.existsSync(path.resolve(repoRoot, data.authority.specPath)))
+  assert.ok(fs.existsSync(path.resolve(repoRoot, data.authority.inspectorPath)))
+  assert.ok(
+    fs.existsSync(
+      path.resolve(
+        __dirname,
+        '..',
+        'remote-subtree-restore-snapshot-flow-inspector.html'
+      )
+    )
+  )
+  assert.ok(Object.isFrozen(data))
+  assert.ok(data.steps.every(Object.isFrozen))
+})
+
+test('every owner step has exact readiness fields and a product-case/DoD contract', () => {
+  const requiredFields = [
+    'id',
+    'order',
+    'laneId',
+    'title',
+    'ownerPackage',
+    'purpose',
+    'inputs',
+    'outputs',
+    'conditions',
+    'bypasses',
+    'allowedContributors',
+    'forbiddenContributors',
+    'cacheDimensions',
+    'implementationBoundary',
+    'specRefs',
+    'failureOwnerStepId'
+  ]
+  const laneIds = new Set(data.lanes.map((item) => item.id))
+  const stepIds = new Set(data.steps.map((item) => item.id))
+  const acceptedStepIds = new Set(
+    data.acceptanceContracts.flatMap((contract) => contract.stepIds)
+  )
+
+  assert.equal(laneIds.size, data.lanes.length, 'duplicate lane id')
+  assert.equal(stepIds.size, data.steps.length, 'duplicate step id')
+  data.steps.forEach((item) => {
+    requiredFields.forEach((field) =>
+      assert.notEqual(item[field], undefined, `${item.id} missing ${field}`)
+    )
+    assert.ok(laneIds.has(item.laneId), `${item.id} lane`)
+    assert.ok(stepIds.has(item.failureOwnerStepId), `${item.id} failure owner`)
+    assert.deepEqual(item.cacheDimensions, [], `${item.id} unjustified cache`)
+    ;[
+      'inputs',
+      'outputs',
+      'conditions',
+      'bypasses',
+      'allowedContributors',
+      'forbiddenContributors',
+      'implementationBoundary',
+      'specRefs'
+    ].forEach((field) => {
+      assert.ok(item[field].length > 0, `${item.id} empty ${field}`)
+    })
+    assert.ok(acceptedStepIds.has(item.id), `${item.id} lacks product case/DoD`)
+  })
+})
+
+test('every route, artifact, invariant, and acceptance contract resolves', () => {
+  const stepIds = new Set(data.steps.map((item) => item.id))
+  const artifactIds = new Set(data.artifacts.map((item) => item.id))
+
+  assert.equal(artifactIds.size, data.artifacts.length, 'duplicate artifact id')
+  assert.equal(
+    new Set(data.routes.map((item) => item.id)).size,
+    data.routes.length,
+    'duplicate route id'
+  )
+  assert.equal(
+    new Set(data.invariants.map((item) => item.id)).size,
+    data.invariants.length,
+    'duplicate invariant id'
+  )
+  assert.equal(
+    new Set(data.acceptanceContracts.map((item) => item.id)).size,
+    data.acceptanceContracts.length,
+    'duplicate acceptance id'
+  )
+
+  data.steps.forEach((item) => {
+    item.inputs
+      .filter((input) => input.startsWith('artifact:'))
+      .forEach((id) => assert.ok(artifactIds.has(id), `${item.id} input ${id}`))
+    item.outputs.forEach((id) =>
+      assert.ok(artifactIds.has(id), `${item.id} output ${id}`)
+    )
+  })
+
+  data.routes.forEach((route) => {
+    assert.ok(stepIds.has(route.from), `${route.id} from`)
+    if (route.to) assert.ok(stepIds.has(route.to), `${route.id} to`)
+    route.producedArtifacts.forEach((id) => {
+      const artifact = data.artifacts.find((item) => item.id === id)
+      assert.ok(artifact, `${route.id} artifact ${id}`)
+      assert.equal(artifact.ownerStepId, route.from, `${route.id} owner ${id}`)
+      if (route.to) {
+        assert.ok(
+          artifact.consumerStepIds.includes(route.to),
+          `${route.id} consumer ${id}`
+        )
+      }
+    })
+  })
+
+  data.artifacts.forEach((artifact) => {
+    assert.ok(step(artifact.ownerStepId).outputs.includes(artifact.id))
+    assert.equal(typeof artifact.channel, 'string', `${artifact.id} channel`)
+    artifact.consumerStepIds.forEach((consumerId) => {
+      assert.ok(step(consumerId).inputs.includes(artifact.id))
+    })
+    if (!artifact.terminal) {
+      assert.ok(artifact.consumerStepIds.length > 0, `${artifact.id} consumer`)
+    }
+  })
+
+  data.invariants.forEach((invariant) => {
+    invariant.stepIds.forEach((id) => assert.ok(stepIds.has(id), id))
+    invariant.artifactIds.forEach((id) => assert.ok(artifactIds.has(id), id))
+  })
+})
+
+test('every implementation boundary resolves to an existing project target', () => {
+  data.steps.forEach((item) => {
+    item.implementationBoundary.forEach((boundary) => {
+      assert.ok(
+        fs.existsSync(path.resolve(repoRoot, boundary)),
+        `${item.id} missing implementation boundary ${boundary}`
+      )
+    })
+  })
+})
+
+test('all local specification anchors resolve', () => {
+  const markdown = fs.readFileSync(
+    path.resolve(repoRoot, data.authority.specPath),
+    'utf8'
+  )
+  const anchors = anchorsIn(markdown)
+  ;[
+    ...data.steps.flatMap((item) => item.specRefs),
+    ...data.acceptanceContracts.flatMap((item) => item.specRefs)
+  ].forEach((reference) => {
+    assert.ok(reference.startsWith('#'), `external spec ref: ${reference}`)
+    assert.ok(anchors.has(reference.slice(1)), `missing anchor ${reference}`)
+  })
+})
+
+test('delete evidence and local undo preserve one detached owner-partitioned publication', () => {
+  const scene = contractText(step('capture-scene-tree-delete-evidence'))
+  const props = contractText(step('capture-props-delete-evidence'))
+  const factory = contractText(step('publish-local-restore-snapshot'))
+
+  assert.match(scene, /detached.*subtree/i)
+  assert.match(
+    scene,
+    /stable ids.*parent.*root sibling index.*child order.*raw/i
+  )
+  assert.match(scene, /post-delete root-parent order evidence/i)
+  assert.match(props, /exact property-component data.*owner relation/i)
+  assert.match(props, /later caller or runtime mutation/i)
+  assert.match(factory, /one intended transaction.*one SharedPublication/i)
+  assert.match(
+    factory,
+    /Props ADD_PROPERTY.*Scene Tree CHANGE_SUBTREE.*RESTORE_SUBTREE/i
+  )
+  assert.match(factory, /does not reconstruct evidence at undo time/i)
+})
+
+test('Collaboration remains opaque transport-only and Core remains a narrow facade', () => {
+  const transport = contractText(step('transport-restore-publication'))
+  const core = contractText(step('expose-instance-safe-owner-facades'))
+
+  assert.equal(
+    step('transport-restore-publication').ownerPackage,
+    '@asyra/collaboration'
+  )
+  assert.match(transport, /opaque completed SharedPublication/i)
+  assert.match(transport, /unchanged.*order.*metadata.*repeated/i)
+  assert.match(
+    transport,
+    /restore classifier.*tombstone.*semantic history.*dedupe.*LWW.*timestamp.*conflict.*convergence/i
+  )
+  assert.match(core, /instance-safe.*Scene Tree.*Props/i)
+  assert.match(core, /no restore policy.*snapshot semantic/i)
+  assert.match(core, /does not restrict core\.load/i)
+})
+
+test('App classifies the complete restore and owns strict accept/reject policy', () => {
+  const app = contractText(step('classify-and-authorize-remote-restore'))
+
+  assert.match(app, /exactly one typed.*CHANGE_SUBTREE.*RESTORE_SUBTREE/i)
+  assert.match(app, /complete publication before the first canonical mutation/i)
+  assert.match(app, /permission.*domain ordering.*duplicate.*stale.*conflict/i)
+  assert.match(app, /mixed or malformed.*whole publication/i)
+  assert.match(app, /does not repair, reorder, merge, or downgrade/i)
+  assert.match(app, /ordinary non-restore publications.*existing route/i)
+})
+
+test('Scene Tree and Props preflight tombstone reuse or exact known-data materialization', () => {
+  const scene = contractText(step('preflight-scene-tree-restore'))
+  const props = contractText(step('preflight-props-restore'))
+  const sceneApply = contractText(step('materialize-scene-tree-restore'))
+  const propsApply = contractText(step('materialize-props-restore'))
+
+  assert.match(
+    scene,
+    /active id.*duplicate id.*parent.*root index.*cycle.*child order/i
+  )
+  assert.match(scene, /compatible tombstone.*exact known-data materialization/i)
+  assert.match(scene, /post-delete root-parent order evidence/i)
+  assert.match(props, /registration.*relation.*duplicate.*missing owner data/i)
+  assert.match(props, /compatible tombstone.*exact known-data materialization/i)
+  assert.match(
+    sceneApply,
+    /stable id.*parent.*root index.*child order.*raw Group data/i
+  )
+  assert.match(propsApply, /component id.*data.*owner relation/i)
+  assert.match(`${sceneApply} ${propsApply}`, /no defaults.*replacement ids/i)
+})
+
+test('Factory settles one rollbackable non-undoable no-echo remote transaction', () => {
+  const settlement = contractText(step('settle-remote-restore-transaction'))
+
+  assert.equal(
+    step('settle-remote-restore-transaction').ownerPackage,
+    '@asyra/factory'
+  )
+  assert.match(settlement, /one accepted publication.*one remote transaction/i)
+  assert.match(settlement, /rollbackable.*non-undoable.*no-echo/i)
+  assert.match(settlement, /Props.*before.*Scene Tree/i)
+  assert.match(
+    settlement,
+    /failure.*exact pre-publication Scene Tree and Props state/i
+  )
+  assert.match(settlement, /does not interpret hierarchy or property meaning/i)
+})
+
+test('Preset, Render, and Layers consume only ordinary canonical projection', () => {
+  const preset = contractText(step('project-preset-group-state'))
+  const render = contractText(step('project-render-identities'))
+  const layers = contractText(step('project-layers-ui'))
+
+  assert.match(preset, /ordinary canonical updates.*Group bounds/i)
+  assert.match(
+    render,
+    /same stable identities.*ordinary Scene Tree projection/i
+  )
+  assert.match(layers, /flattenedElementIds.*elementDataMap/i)
+  ;[preset, render, layers].forEach((text) => {
+    assert.match(text, /no restore-only.*fallback|no fallback.*restore-only/i)
+  })
+})
+
+test('acceptance contracts cover the complete bounded restore product cases and DoD', () => {
+  const text = data.acceptanceContracts
+    .flatMap((contract) => [contract.title, ...contract.assertions])
+    .join(' ')
+
+  ;[
+    /tombstone-present.*tombstone-absent.*equivalent.*ids.*data.*hierarchy.*properties.*save.*projections/i,
+    /normal and empty Group.*parent.*root sibling index.*descendant child order.*raw Group data/i,
+    /one local undo.*one grouped publication.*one accepted remote restore.*one remote transaction/i,
+    /non-undoable.*no outbound echo.*remote redo.*same exact subtree/i,
+    /id collision.*incompatible tombstone.*stale parent.*stale order.*duplicate ids.*missing owner data.*invalid registration.*malformed relation.*cycle.*inconsistent child order.*permission/i,
+    /no partial Scene Tree or Props state/i,
+    /detached from later caller and runtime mutation/i,
+    /save after restore.*Render.*Layers.*stable identities/i,
+    /two independent Core.*Scene Tree.*Props.*Factory.*instance-isolated/i,
+    /Collaboration remains transport-only.*core\.load remains unrestricted.*Context Menu.*closeout/i
+  ].forEach((pattern) => assert.match(text, pattern))
+})

--- a/docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md
+++ b/docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md
@@ -1,22 +1,27 @@
 # Asyra Design Remote Subtree Restore Snapshot Plan
 
-## Status and Priority
+## Completion
 
-Proposed as the highest-priority next Asyra Design implementation plan.
+Completed on 2026-07-25 after implementation review and explicit user closeout
+authorization.
 
-The Group Interaction MVP and Layers hierarchy prerequisite completed, closed
-out, and merged through PR #94 on 2026-07-24. Their canonical records remain:
+- Outcome: a local subtree undo now publishes one exact owner-partitioned
+  restore snapshot through the existing Factory `SharedPublication`; receiving
+  peers apply it atomically with or without compatible local tombstones.
+- Final decision: Scene Tree and Props remain the canonical restore owners,
+  Factory retains transaction/publication ownership, Collaboration remains
+  transport-only, and Asyra Design retains remote policy and routing.
+- Canonical record:
+  `docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md`.
+- Exit criteria: Inspector/readiness contracts, affected framework/app tests,
+  remote undo/redo product cases, build/lint/dependency gates, synchronized
+  visual review, and bounded direct-consumer review passed before closeout.
 
-1. `completed/group-interaction-mvp-plan.md`; and
-2. `completed/layer-tree-reparent-reorder-plan.md`.
+Architecture authority:
 
-Production implementation for this plan may begin only after:
-
-1. this plan PR is approved and merged; and
-2. a matching Inspector owner flow and readiness contract tests pass.
-
-This PR is plan-only. It must not contain production implementation, closeout,
-or merge work.
+- `docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs`
+- `docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.html`
+- `docs/ai/apps/asyra-design/plans/__tests__/remote-subtree-restore-snapshot-flow-inspector.contract.test.cjs`
 
 ## Decision
 

--- a/docs/ai/apps/asyra-design/plans/durable-collaboration-server-and-continuous-sync-plan.md
+++ b/docs/ai/apps/asyra-design/plans/durable-collaboration-server-and-continuous-sync-plan.md
@@ -2,10 +2,12 @@
 
 ## Status
 
-Queued behind `remote-subtree-restore-snapshot-plan.md` and
-`group-context-menu-plan.md` as a later Asyra Design app/server implementation
-stage after the completed network collaboration transport Gate 2. It remains
-inactive until the user explicitly starts it.
+Queued behind
+`docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md`
+and `docs/ai/apps/asyra-design/plans/group-context-menu-plan.md` as a later
+Asyra Design app/server implementation stage after the completed network
+collaboration transport Gate 2. It remains inactive until the user explicitly
+starts it.
 
 This is an app-owned reference implementation plan. It does not make durable
 CRDT transport a framework requirement, reopen the completed Gate 2 contract,

--- a/docs/ai/apps/asyra-design/plans/group-context-menu-plan.md
+++ b/docs/ai/apps/asyra-design/plans/group-context-menu-plan.md
@@ -2,8 +2,9 @@
 
 ## Status and Priority
 
-Proposed as the second plan in the ordered Asyra Design implementation queue,
-immediately after `remote-subtree-restore-snapshot-plan.md`.
+Proposed as the next plan in the ordered Asyra Design implementation queue,
+after the completed
+`docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md`.
 
 The Group interaction prerequisite completed, closed out, and merged through
 PR #94 on 2026-07-24. This plan must reuse the canonical Group/Ungroup features,
@@ -14,8 +15,7 @@ command eligibility, and Inspector authority from:
 
 This PR is plan-only. Production implementation may begin only after:
 
-1. the remote subtree restore snapshot plan is implemented, reviewed, closed
-   out, and merged;
+1. the completed remote subtree restore snapshot plan is merged;
 2. this plan is approved and merged; and
 3. a matching Inspector owner flow and readiness contract tests pass.
 

--- a/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
+++ b/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
@@ -561,6 +561,7 @@
       implementationBoundary: [
         'packages/scene-tree/src/sceneTree.ts',
         'packages/scene-tree/src/entity-data.ts',
+        'packages/scene-tree/src/props-manager-context.ts',
         'packages/scene-tree/src/create-dynamic-component.ts',
         'packages/scene-tree/src/create-dynamic-props.ts',
         'packages/scene-tree/src/components/element.ts',

--- a/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
+++ b/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
@@ -1,0 +1,1355 @@
+;(function () {
+  'use strict'
+
+  const specPath =
+    'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-plan.md'
+  const inspectorPath =
+    'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs'
+
+  const lanes = [
+    { id: 'sender', title: 'Delete Evidence and Local Undo', order: 1 },
+    { id: 'transport', title: 'Opaque Publication Transport', order: 2 },
+    { id: 'app', title: 'App Classification and Policy', order: 3 },
+    { id: 'owners', title: 'Canonical Owner Restore', order: 4 },
+    { id: 'factory', title: 'Remote Transaction Settlement', order: 5 },
+    { id: 'projection', title: 'Ordinary Canonical Projection', order: 6 }
+  ]
+
+  const steps = [
+    {
+      id: 'capture-scene-tree-delete-evidence',
+      order: 1,
+      laneId: 'sender',
+      title: 'Capture Scene Tree delete evidence',
+      ownerPackage: '@asyra/scene-tree',
+      purpose:
+        'Capture one detached exact subtree snapshot at the original delete mutation before runtime state can change.',
+      inputs: [
+        'one validated canonical subtree removal request',
+        'current canonical parent membership and child order',
+        'current raw element and Group data'
+      ],
+      outputs: ['artifact:scene-tree-delete-evidence'],
+      conditions: [
+        'Evidence contains stable ids, exact parent ids, the root sibling index, descendant child order, raw element and Group data, and exact post-delete root-parent order evidence derivable from the mutation-time before image.',
+        'Evidence covers exactly the affected subtree and its external root-parent stale-before boundary, never the whole document.',
+        'The owner snapshot is detached before caller or runtime objects can mutate.'
+      ],
+      bypasses: [
+        'A rejected, missing, workspace-root, or semantic no-op delete produces no evidence or canonical mutation.'
+      ],
+      allowedContributors: [
+        'canonical Scene Tree element instances',
+        'registered container metadata',
+        'exact parent and children before images',
+        'owner-local detached cloning'
+      ],
+      forbiddenContributors: [
+        'Props component reconstruction',
+        'Factory hierarchy interpretation',
+        'Render or Layers hierarchy',
+        'whole-document snapshot',
+        'later undo-time state reads'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/utils/src/types/scene-tree.ts',
+        'packages/scene-tree/src/sceneTree.ts',
+        'packages/scene-tree/src/__tests__'
+      ],
+      specRefs: [
+        '#restore-snapshot',
+        '#sender-behavior',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'capture-scene-tree-delete-evidence'
+    },
+    {
+      id: 'capture-props-delete-evidence',
+      order: 2,
+      laneId: 'sender',
+      title: 'Capture Props delete evidence',
+      ownerPackage: '@asyra/props-manager',
+      purpose:
+        'Capture detached exact property-component data and owner relation evidence removed by the same subtree delete.',
+      inputs: [
+        'artifact:scene-tree-delete-evidence',
+        'registered property component and relation definitions',
+        'property-component mutation-time before images'
+      ],
+      outputs: ['artifact:props-delete-evidence'],
+      conditions: [
+        'Every affected property component keeps its stable id, registered type, exact persisted data, and exact owner relation.',
+        'Evidence is captured during the original intended transaction and remains detached from later caller or runtime mutation.',
+        'No create defaults or generated replacement ids enter the evidence.'
+      ],
+      bypasses: [
+        'A subtree with no property components contributes an explicit empty owner section rather than fabricated defaults.'
+      ],
+      allowedContributors: [
+        'canonical Props Manager component instances',
+        'registered property definitions',
+        'exact element/property relation input from the Scene Tree owner boundary',
+        'owner-local detached cloning'
+      ],
+      forbiddenContributors: [
+        'Scene Tree property-data validation',
+        'Factory property interpretation',
+        'App reconstruction from computed data',
+        'Render or UI state'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/utils/src/types/props-manager.ts',
+        'packages/props-manager/src/manager/props-manager.ts',
+        'packages/props-manager/src/manager/subscribes.ts',
+        'packages/props-manager/src/__tests__'
+      ],
+      specRefs: [
+        '#restore-snapshot',
+        '#sender-behavior',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'capture-props-delete-evidence'
+    },
+    {
+      id: 'publish-local-restore-snapshot',
+      order: 3,
+      laneId: 'sender',
+      title: 'Restore locally and publish one snapshot',
+      ownerPackage: '@asyra/factory',
+      purpose:
+        'Complete ordinary local owner undo and group its exact inverse deliveries into one existing SharedPublication.',
+      inputs: [
+        'artifact:scene-tree-delete-evidence',
+        'artifact:props-delete-evidence',
+        'one committed local delete transaction and its inverse journal'
+      ],
+      outputs: ['artifact:local-restore-publication'],
+      conditions: [
+        'Canonical owners restore locally before the undo transaction settles.',
+        'One intended transaction and one local undo produce one SharedPublication containing the exact inverse owner deliveries in replay order.',
+        'Props ADD_PROPERTY deliveries and one typed Scene Tree CHANGE_SUBTREE delivery with RESTORE_SUBTREE remain ordinary Factory deliveries.',
+        'Factory groups and detaches evidence but does not reconstruct evidence at undo time or interpret hierarchy/property meaning.'
+      ],
+      bypasses: [
+        'A failed local undo rolls back locally and publishes no restore snapshot.',
+        'An unshared local delete retains ordinary local undo behavior without a network publication.'
+      ],
+      allowedContributors: [
+        'Factory transaction journal and inverse replay',
+        'artifact:scene-tree-delete-evidence',
+        'artifact:props-delete-evidence',
+        'existing Factory SharedPublication boundary'
+      ],
+      forbiddenContributors: [
+        'second publication envelope',
+        'restore-specific Provider message',
+        'feature-level create steps',
+        'Factory hierarchy or property policy'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/factory/src/data-transact.ts',
+        'packages/factory/src/factory.ts',
+        'packages/factory/src/shared-delivery.ts',
+        'packages/factory/src/__tests__',
+        'packages/core/src/__tests__/hierarchy-transaction.test.ts'
+      ],
+      specRefs: [
+        '#restore-snapshot',
+        '#sender-behavior',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'publish-local-restore-snapshot'
+    },
+    {
+      id: 'transport-restore-publication',
+      order: 1,
+      laneId: 'transport',
+      title: 'Transport the restore publication unchanged',
+      ownerPackage: '@asyra/collaboration',
+      purpose:
+        'Forward one opaque completed SharedPublication unchanged through the existing FIFO Provider handoff.',
+      inputs: ['artifact:local-restore-publication'],
+      outputs: ['artifact:inbound-restore-publication'],
+      conditions: [
+        'The publication, delivery order, metadata, payloads, and repeated values remain unchanged.',
+        'One Factory publication remains one Provider send and one receiving app callback.',
+        'Collaboration retains no semantic publication history after settlement.'
+      ],
+      bypasses: [
+        'A disconnected peer misses the live publication and receives no framework replay.',
+        'Collaboration-disabled apps create no transport resources.'
+      ],
+      allowedContributors: [
+        'artifact:local-restore-publication',
+        'Provider wire integrity',
+        'transport-safe detached cloning',
+        'live FIFO delivery'
+      ],
+      forbiddenContributors: [
+        'restore classifier',
+        'tombstone store',
+        'semantic history',
+        'dedupe or LWW',
+        'timestamp ordering',
+        'conflict resolution or convergence registry'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/collaboration/src/process.ts',
+        'packages/collaboration/src/__tests__/process.test.ts',
+        'packages/collaboration/src/__tests__/action-publication.test.ts',
+        'docs/ai/framework/plans/__tests__/network-collaboration-transport-flow-inspector.contract.test.cjs'
+      ],
+      specRefs: [
+        '#ownership-contract',
+        '#receiver-classification-and-routing',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'transport-restore-publication'
+    },
+    {
+      id: 'expose-instance-safe-owner-facades',
+      order: 1,
+      laneId: 'app',
+      title: 'Expose narrow instance-safe owner facades',
+      ownerPackage: '@asyra/core',
+      purpose:
+        'Bind the app processor to the intended Scene Tree and Props owner instances; Core owns no restore policy and no snapshot semantic decisions.',
+      inputs: [
+        'Core-bound Scene Tree instance',
+        'Core-bound Props Manager instance',
+        'owner preflight and materialization contracts'
+      ],
+      outputs: ['artifact:instance-safe-owner-facades'],
+      conditions: [
+        'The facade delegates only to the injected owner instances.',
+        'Core has no restore policy and no snapshot semantic ownership.',
+        'Separate Core, Scene Tree, Props, and Factory compositions cannot cross-read, apply, or project one another’s restore state.',
+        'This route does not restrict core.load and does not introduce core.append.'
+      ],
+      bypasses: [
+        'Framework consumers that do not process remote subtree restores need not call the scoped restore facades.'
+      ],
+      allowedContributors: [
+        'Core dependency injection',
+        'public owner artifact types',
+        'bounded Scene Tree and Props delegates'
+      ],
+      forbiddenContributors: [
+        'Core restore policy',
+        'Core snapshot semantic ownership',
+        'whole-document load as subtree restore',
+        'module-global owner substitution'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/core/src/core.ts',
+        'packages/core/src/apis/create-apis.ts',
+        'packages/core/src/apis/scene-tree.ts',
+        'packages/core/src/apis/props.ts',
+        'packages/core/src/types',
+        'packages/core/src/index.ts',
+        'packages/core/src/__tests__'
+      ],
+      specRefs: [
+        '#ownership-contract',
+        '#coreload-boundary',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'expose-instance-safe-owner-facades'
+    },
+    {
+      id: 'classify-and-authorize-remote-restore',
+      order: 2,
+      laneId: 'app',
+      title: 'Classify and authorize the complete restore',
+      ownerPackage: 'Asyra Design collaboration adapter',
+      purpose:
+        'Validate the complete publication before the first canonical mutation, classify the typed restore, and apply app/backend permission, domain-order, duplicate, stale, and conflict policy.',
+      inputs: [
+        'artifact:inbound-restore-publication',
+        'artifact:instance-safe-owner-facades',
+        'app/backend permission and domain policy'
+      ],
+      outputs: [
+        'artifact:accepted-restore-publication',
+        'artifact:remote-restore-rejection'
+      ],
+      conditions: [
+        'A restore publication contains exactly one typed Scene Tree CHANGE_SUBTREE delivery whose action is RESTORE_SUBTREE and only the matching owner deliveries allowed by the snapshot contract.',
+        'The App validates the complete publication before the first canonical mutation.',
+        'The App owns permission, domain ordering, duplicate, stale, and conflict accept/reject policy.',
+        'Mixed or malformed restore input rejects the whole publication.'
+      ],
+      bypasses: [
+        'Ordinary non-restore publications continue through the existing route with its current validation.',
+        'A policy rejection produces no Scene Tree, Props, transaction, Render, or Layers mutation.'
+      ],
+      allowedContributors: [
+        'artifact:inbound-restore-publication',
+        'typed Scene Tree and Props payload guards',
+        'artifact:instance-safe-owner-facades',
+        'app/backend decision callback'
+      ],
+      forbiddenContributors: [
+        'Collaboration semantic decisions',
+        'partial apply',
+        'The App does not repair, reorder, merge, or downgrade rejected restore input.',
+        'feature-level create command',
+        'Render or UI state authority'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'apps/asyra-design/src/collaboration/operations.ts',
+        'apps/asyra-design/src/collaboration/lifecycle.ts',
+        'apps/asyra-design/src/init/__tests__/collaboration-operations.test.ts',
+        'apps/asyra-design/src/init/__tests__/collaboration-lifecycle.test.ts',
+        'apps/asyra-design/e2e'
+      ],
+      specRefs: [
+        '#receiver-classification-and-routing',
+        '#strict-stale-restore-policy',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'classify-and-authorize-remote-restore'
+    },
+    {
+      id: 'preflight-scene-tree-restore',
+      order: 1,
+      laneId: 'owners',
+      title: 'Preflight Scene Tree restore',
+      ownerPackage: '@asyra/scene-tree',
+      purpose:
+        'Validate the complete hierarchy snapshot and prepare exact tombstone reuse or known-data materialization without canonical mutation.',
+      inputs: ['artifact:accepted-restore-publication'],
+      outputs: ['artifact:scene-tree-restore-plan'],
+      conditions: [
+        'Preflight rejects active id collision, duplicate id, incompatible tombstone, missing or invalid parent, invalid root index, stale post-delete root-parent order evidence, cycle, and inconsistent child order.',
+        'Every entry has exact registered element data, parent membership, root index, and one coherent descendant hierarchy.',
+        'A compatible tombstone is selected for reuse; otherwise the plan selects exact known-data materialization with the same stable id.'
+      ],
+      bypasses: [
+        'A failed preflight produces no canonical hierarchy mutation and blocks the complete publication.',
+        'Tombstone absence is a materialization condition, not a rejection by itself.'
+      ],
+      allowedContributors: [
+        'artifact:accepted-restore-publication',
+        'canonical active and deleted Scene Tree maps',
+        'registered component/container definitions',
+        'detached hierarchy evidence'
+      ],
+      forbiddenContributors: [
+        'Props data validation',
+        'App hierarchy reconstruction',
+        'Render or Layers hierarchy',
+        'create defaults',
+        'replacement ids'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/utils/src/types/scene-tree.ts',
+        'packages/scene-tree/src/sceneTree.ts',
+        'packages/scene-tree/src/entity-data.ts',
+        'packages/scene-tree/src/component-registry.ts',
+        'packages/scene-tree/src/__tests__'
+      ],
+      specRefs: [
+        '#canonical-restore',
+        '#strict-stale-restore-policy',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'preflight-scene-tree-restore'
+    },
+    {
+      id: 'preflight-props-restore',
+      order: 2,
+      laneId: 'owners',
+      title: 'Preflight Props restore',
+      ownerPackage: '@asyra/props-manager',
+      purpose:
+        'Validate the complete property-component snapshot and prepare exact tombstone reuse or known-data materialization without canonical mutation.',
+      inputs: [
+        'artifact:accepted-restore-publication',
+        'artifact:scene-tree-restore-plan'
+      ],
+      outputs: ['artifact:props-restore-plan'],
+      conditions: [
+        'Preflight rejects invalid registration, malformed relation, duplicate id, active id collision, incompatible tombstone, and missing owner data.',
+        'Every direct element/property relation and registered child-component relation resolves to exact snapshot or compatible current owner data.',
+        'A compatible tombstone is selected for reuse; otherwise the plan selects exact known-data materialization with the same component id and data.'
+      ],
+      bypasses: [
+        'An explicitly property-free subtree produces a valid empty Props plan.',
+        'A failed preflight produces no canonical property mutation and blocks the complete publication.'
+      ],
+      allowedContributors: [
+        'artifact:accepted-restore-publication',
+        'artifact:scene-tree-restore-plan',
+        'canonical active and deleted Props maps',
+        'registered property component and relation definitions'
+      ],
+      forbiddenContributors: [
+        'Scene Tree property-data validation',
+        'App component construction',
+        'create defaults',
+        'replacement ids',
+        'Render or UI property state'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/utils/src/types/props-manager.ts',
+        'packages/props-manager/src/manager/props-manager.ts',
+        'packages/props-manager/src/manager/component-accessor.ts',
+        'packages/props-manager/src/registries/property-component.ts',
+        'packages/props-manager/src/registries/property-definition.ts',
+        'packages/props-manager/src/__tests__'
+      ],
+      specRefs: [
+        '#canonical-restore',
+        '#strict-stale-restore-policy',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'preflight-props-restore'
+    },
+    {
+      id: 'settle-remote-restore-transaction',
+      order: 1,
+      laneId: 'factory',
+      title: 'Settle one remote restore transaction',
+      ownerPackage: '@asyra/factory',
+      purpose:
+        'Open and settle one rollbackable, non-undoable, no-echo remote transaction around the accepted owner plans; Factory does not interpret hierarchy or property meaning.',
+      inputs: [
+        'artifact:accepted-restore-publication',
+        'artifact:scene-tree-restore-plan',
+        'artifact:props-restore-plan',
+        'artifact:props-restored-state',
+        'artifact:scene-tree-restored-state'
+      ],
+      outputs: [
+        'artifact:remote-restore-transaction-scope',
+        'artifact:committed-remote-restore',
+        'artifact:rolled-back-remote-restore'
+      ],
+      conditions: [
+        'One accepted publication opens one remote transaction.',
+        'The transaction is rollbackable, non-undoable, and no-echo regardless of delivery options.',
+        'Exact publication replay order materializes Props before Scene Tree so element relations resolve without defaults.',
+        'Any owner apply or settlement failure restores exact pre-publication Scene Tree and Props state.'
+      ],
+      bypasses: [
+        'A rejected publication or failed preflight never opens the remote transaction.',
+        'A successful remote restore creates no local undo entry and no outbound SharedPublication.'
+      ],
+      allowedContributors: [
+        'Factory runRemoteTransaction boundary',
+        'artifact:scene-tree-restore-plan',
+        'artifact:props-restore-plan',
+        'owner-recorded exact inverse journal entries'
+      ],
+      forbiddenContributors: [
+        'Factory does not interpret hierarchy or property meaning.',
+        'Factory stale or conflict policy',
+        'partial rollback acceptance',
+        'outbound remote echo'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/factory/src/factory.ts',
+        'packages/factory/src/data-transact.ts',
+        'packages/factory/src/__tests__',
+        'packages/core/src/__tests__/hierarchy-transaction.test.ts',
+        'apps/asyra-design/src/init/__tests__/collaboration-operations.test.ts'
+      ],
+      specRefs: [
+        '#canonical-restore',
+        '#strict-stale-restore-policy',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'settle-remote-restore-transaction'
+    },
+    {
+      id: 'materialize-props-restore',
+      order: 3,
+      laneId: 'owners',
+      title: 'Materialize exact Props state',
+      ownerPackage: '@asyra/props-manager',
+      purpose:
+        'Apply the prepared property plan in exact delivery order by reusing compatible tombstones or creating isolated runtime components from known data.',
+      inputs: [
+        'artifact:props-restore-plan',
+        'artifact:remote-restore-transaction-scope'
+      ],
+      outputs: ['artifact:props-restored-state'],
+      conditions: [
+        'Every component preserves its component id, exact data, and owner relation.',
+        'Tombstone-present and tombstone-absent paths produce equivalent canonical Props state.',
+        'Materialization applies no defaults and allocates no replacement ids.'
+      ],
+      bypasses: [
+        'An empty valid Props plan performs no component mutation and still permits the Scene Tree owner step.',
+        'An apply failure throws into Factory settlement and cannot be downgraded.'
+      ],
+      allowedContributors: [
+        'artifact:props-restore-plan',
+        'artifact:remote-restore-transaction-scope',
+        'canonical Props Manager add/relation path',
+        'owner-recorded inverse evidence'
+      ],
+      forbiddenContributors: [
+        'App-created property instances',
+        'Scene Tree data repair',
+        'create defaults',
+        'replacement ids',
+        'partial property apply acceptance'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/props-manager/src/manager/props-manager.ts',
+        'packages/props-manager/src/manager/subscribes.ts',
+        'packages/props-manager/src/factories/create-property.ts',
+        'packages/props-manager/src/__tests__'
+      ],
+      specRefs: [
+        '#canonical-restore',
+        '#product-cases',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'materialize-props-restore'
+    },
+    {
+      id: 'materialize-scene-tree-restore',
+      order: 4,
+      laneId: 'owners',
+      title: 'Materialize exact Scene Tree state',
+      ownerPackage: '@asyra/scene-tree',
+      purpose:
+        'Apply the prepared hierarchy plan by reusing compatible tombstones or creating isolated runtime elements from exact known data.',
+      inputs: [
+        'artifact:scene-tree-restore-plan',
+        'artifact:props-restored-state',
+        'artifact:remote-restore-transaction-scope'
+      ],
+      outputs: ['artifact:scene-tree-restored-state'],
+      conditions: [
+        'Every element preserves its stable id, exact parent, root index, descendant child order, raw element data, and raw Group data.',
+        'Parents materialize before descendants while the final canonical children arrays exactly match the snapshot.',
+        'Tombstone-present and tombstone-absent paths produce equivalent canonical Scene Tree state.',
+        'Materialization applies no defaults and allocates no replacement ids.'
+      ],
+      bypasses: [
+        'An apply failure throws into Factory settlement and cannot leave an accepted partial hierarchy.',
+        'An empty Group has no descendant materialization but keeps exact raw Group data and root placement.'
+      ],
+      allowedContributors: [
+        'artifact:scene-tree-restore-plan',
+        'artifact:props-restored-state',
+        'artifact:remote-restore-transaction-scope',
+        'canonical Scene Tree hierarchy mutation path'
+      ],
+      forbiddenContributors: [
+        'App hierarchy construction',
+        'Render or Layers repair',
+        'feature-level create operations',
+        'create defaults',
+        'replacement ids'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/scene-tree/src/sceneTree.ts',
+        'packages/scene-tree/src/entity-data.ts',
+        'packages/scene-tree/src/create-dynamic-component.ts',
+        'packages/scene-tree/src/create-dynamic-props.ts',
+        'packages/scene-tree/src/components/element.ts',
+        'packages/scene-tree/src/components/group.ts',
+        'packages/scene-tree/src/components/computed.ts',
+        'packages/scene-tree/src/components/props.ts',
+        'packages/scene-tree/src/__tests__'
+      ],
+      specRefs: [
+        '#canonical-restore',
+        '#product-cases',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'materialize-scene-tree-restore'
+    },
+    {
+      id: 'project-preset-group-state',
+      order: 1,
+      laneId: 'projection',
+      title: 'Project ordinary Preset Group state',
+      ownerPackage: '@asyra/preset',
+      purpose:
+        'Consume committed ordinary canonical updates for Group bounds and UI-context derivation with no restore-only state or fallback.',
+      inputs: ['artifact:committed-remote-restore'],
+      outputs: ['artifact:preset-canonical-projection'],
+      conditions: [
+        'Existing Scene Tree channel handling derives Group bounds and canonical UI-context values after commit.',
+        'Projection consumes the same stable ids and data used by local undo.'
+      ],
+      bypasses: [
+        'A rolled-back or rejected restore produces no final projection.',
+        'Headless consumers may omit Preset projection without changing canonical state.'
+      ],
+      allowedContributors: [
+        'artifact:committed-remote-restore',
+        'ordinary canonical Scene Tree and Props updates',
+        'existing Preset Group and UI-context observers'
+      ],
+      forbiddenContributors: [
+        'restore-only projection state or fallback',
+        'Preset hierarchy reconstruction',
+        'App stale repair',
+        'Render-derived bounds authority'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/preset/src/subscriptions/data-channel.ts',
+        'packages/preset/src/components/group.ts',
+        'packages/preset/src/__tests__/selection-subscriptions.test.ts',
+        'packages/preset/src/__tests__/group-operations.test.ts'
+      ],
+      specRefs: [
+        '#ownership-contract',
+        '#product-cases',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'project-preset-group-state'
+    },
+    {
+      id: 'project-render-identities',
+      order: 2,
+      laneId: 'projection',
+      title: 'Project stable Render identities',
+      ownerPackage: '@asyra/render',
+      purpose:
+        'Project the committed subtree through the ordinary Scene Tree projection with the same stable identities and hierarchy and no restore-only state or fallback.',
+      inputs: [
+        'artifact:committed-remote-restore',
+        'artifact:preset-canonical-projection'
+      ],
+      outputs: ['artifact:rendered-restored-subtree'],
+      conditions: [
+        'Parents project before descendants and preserve exact sibling placement.',
+        'The ordinary Scene Tree projection owns stable element-to-engine identity.'
+      ],
+      bypasses: [
+        'A rolled-back or rejected restore leaves no restored Render node.',
+        'Headless Core remains canonically correct without Render.'
+      ],
+      allowedContributors: [
+        'artifact:committed-remote-restore',
+        'artifact:preset-canonical-projection',
+        'ordinary Scene Tree projection store',
+        'engine-neutral hierarchy handoff'
+      ],
+      forbiddenContributors: [
+        'restore-only Render state or fallback',
+        'Render hierarchy reconstruction',
+        'duplicate visual identities',
+        'app-specific visual exception'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/render/src/stores/scene-tree.ts',
+        'packages/render/src/__tests__/scene-tree-store.test.ts',
+        'packages/render/src/__tests__/render.test.ts'
+      ],
+      specRefs: [
+        '#ownership-contract',
+        '#product-cases',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'project-render-identities'
+    },
+    {
+      id: 'project-layers-ui',
+      order: 3,
+      laneId: 'projection',
+      title: 'Project the canonical Layers hierarchy',
+      ownerPackage: 'Asyra Design Layers/UI',
+      purpose:
+        'Consume ordinary flattenedElementIds and elementDataMap projection so Layers displays the exact restored hierarchy with no restore-only state or fallback.',
+      inputs: [
+        'artifact:committed-remote-restore',
+        'artifact:preset-canonical-projection'
+      ],
+      outputs: ['artifact:layers-restored-subtree'],
+      conditions: [
+        'Layers rows use the same stable ids, parent ids, and child order as canonical Scene Tree state.',
+        'Normal and empty Groups use the existing canonical row projection.'
+      ],
+      bypasses: [
+        'A rolled-back or rejected restore creates no Layers row.',
+        'Collapsed state remains UI-local and does not alter canonical restore.'
+      ],
+      allowedContributors: [
+        'artifact:preset-canonical-projection',
+        'flattenedElementIds',
+        'elementDataMap',
+        'existing Layers row projection'
+      ],
+      forbiddenContributors: [
+        'restore-only UI state or fallback',
+        'DOM hierarchy as canonical input',
+        'Render hierarchy repair',
+        'saved or shared collapsed state'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'apps/asyra-design/src/contents/layer-hierarchy.ts',
+        'apps/asyra-design/src/contents',
+        'apps/asyra-design/src/providers',
+        'apps/asyra-design/e2e/group-interaction.spec.ts',
+        'apps/asyra-design/e2e/collaboration.spec.ts'
+      ],
+      specRefs: [
+        '#ownership-contract',
+        '#product-cases',
+        '#required-inspector-readiness'
+      ],
+      failureOwnerStepId: 'project-layers-ui'
+    }
+  ]
+
+  const routes = [
+    {
+      id: 'scene-evidence-recorded',
+      from: 'capture-scene-tree-delete-evidence',
+      to: 'publish-local-restore-snapshot',
+      kind: 'handoff',
+      predicate:
+        'The canonical subtree delete captures exact hierarchy evidence.',
+      producedArtifacts: ['artifact:scene-tree-delete-evidence']
+    },
+    {
+      id: 'scene-evidence-selects-props',
+      from: 'capture-scene-tree-delete-evidence',
+      to: 'capture-props-delete-evidence',
+      kind: 'handoff',
+      predicate:
+        'The exact subtree identifies affected property owner relations.',
+      producedArtifacts: ['artifact:scene-tree-delete-evidence']
+    },
+    {
+      id: 'props-evidence-recorded',
+      from: 'capture-props-delete-evidence',
+      to: 'publish-local-restore-snapshot',
+      kind: 'handoff',
+      predicate: 'The same delete transaction captures exact Props evidence.',
+      producedArtifacts: ['artifact:props-delete-evidence']
+    },
+    {
+      id: 'local-undo-publication-ready',
+      from: 'publish-local-restore-snapshot',
+      to: 'transport-restore-publication',
+      kind: 'handoff',
+      predicate: 'Local canonical undo and publication settlement succeed.',
+      producedArtifacts: ['artifact:local-restore-publication']
+    },
+    {
+      id: 'restore-publication-received',
+      from: 'transport-restore-publication',
+      to: 'classify-and-authorize-remote-restore',
+      kind: 'handoff',
+      predicate: 'A currently connected peer receives one opaque publication.',
+      producedArtifacts: ['artifact:inbound-restore-publication']
+    },
+    {
+      id: 'core-facades-available-to-app',
+      from: 'expose-instance-safe-owner-facades',
+      to: 'classify-and-authorize-remote-restore',
+      kind: 'resource',
+      predicate: 'The app composition binds its intended owner instances.',
+      producedArtifacts: ['artifact:instance-safe-owner-facades']
+    },
+    {
+      id: 'remote-restore-rejected',
+      from: 'classify-and-authorize-remote-restore',
+      kind: 'terminal',
+      predicate: 'Validation or app/backend policy rejects the publication.',
+      producedArtifacts: ['artifact:remote-restore-rejection']
+    },
+    {
+      id: 'accepted-restore-to-scene-preflight',
+      from: 'classify-and-authorize-remote-restore',
+      to: 'preflight-scene-tree-restore',
+      kind: 'handoff',
+      predicate: 'The App accepts one complete restore publication.',
+      producedArtifacts: ['artifact:accepted-restore-publication']
+    },
+    {
+      id: 'accepted-restore-to-props-preflight',
+      from: 'classify-and-authorize-remote-restore',
+      to: 'preflight-props-restore',
+      kind: 'handoff',
+      predicate: 'The Props owner validates the same accepted publication.',
+      producedArtifacts: ['artifact:accepted-restore-publication']
+    },
+    {
+      id: 'accepted-restore-to-settlement',
+      from: 'classify-and-authorize-remote-restore',
+      to: 'settle-remote-restore-transaction',
+      kind: 'handoff',
+      predicate:
+        'Both owner preflights must succeed before Factory settles the accepted publication.',
+      producedArtifacts: ['artifact:accepted-restore-publication']
+    },
+    {
+      id: 'scene-plan-informs-props-relations',
+      from: 'preflight-scene-tree-restore',
+      to: 'preflight-props-restore',
+      kind: 'handoff',
+      predicate:
+        'Scene Tree has validated exact element/property relation evidence.',
+      producedArtifacts: ['artifact:scene-tree-restore-plan']
+    },
+    {
+      id: 'scene-plan-ready-to-settle',
+      from: 'preflight-scene-tree-restore',
+      to: 'settle-remote-restore-transaction',
+      kind: 'handoff',
+      predicate: 'Scene Tree preflight succeeds without mutation.',
+      producedArtifacts: ['artifact:scene-tree-restore-plan']
+    },
+    {
+      id: 'scene-plan-ready-to-materialize',
+      from: 'preflight-scene-tree-restore',
+      to: 'materialize-scene-tree-restore',
+      kind: 'handoff',
+      predicate:
+        'Scene Tree materialization consumes only its validated one-shot plan.',
+      producedArtifacts: ['artifact:scene-tree-restore-plan']
+    },
+    {
+      id: 'props-plan-ready-to-settle',
+      from: 'preflight-props-restore',
+      to: 'settle-remote-restore-transaction',
+      kind: 'handoff',
+      predicate: 'Props preflight succeeds without mutation.',
+      producedArtifacts: ['artifact:props-restore-plan']
+    },
+    {
+      id: 'props-plan-ready-to-materialize',
+      from: 'preflight-props-restore',
+      to: 'materialize-props-restore',
+      kind: 'handoff',
+      predicate:
+        'Props materialization consumes only its validated one-shot plan.',
+      producedArtifacts: ['artifact:props-restore-plan']
+    },
+    {
+      id: 'begin-owner-materialization',
+      from: 'settle-remote-restore-transaction',
+      to: 'materialize-props-restore',
+      kind: 'handoff',
+      predicate: 'Factory opens the accepted remote transaction.',
+      producedArtifacts: ['artifact:remote-restore-transaction-scope']
+    },
+    {
+      id: 'props-ready-for-scene-materialization',
+      from: 'materialize-props-restore',
+      to: 'materialize-scene-tree-restore',
+      kind: 'handoff',
+      predicate: 'Exact property components and relations are active.',
+      producedArtifacts: ['artifact:props-restored-state']
+    },
+    {
+      id: 'props-state-ready-to-settle',
+      from: 'materialize-props-restore',
+      to: 'settle-remote-restore-transaction',
+      kind: 'handoff',
+      predicate: 'Props owner apply completes inside the remote transaction.',
+      producedArtifacts: ['artifact:props-restored-state']
+    },
+    {
+      id: 'transaction-scope-reaches-scene',
+      from: 'settle-remote-restore-transaction',
+      to: 'materialize-scene-tree-restore',
+      kind: 'resource',
+      predicate:
+        'Scene materialization remains inside the same remote transaction.',
+      producedArtifacts: ['artifact:remote-restore-transaction-scope']
+    },
+    {
+      id: 'scene-state-ready-to-settle',
+      from: 'materialize-scene-tree-restore',
+      to: 'settle-remote-restore-transaction',
+      kind: 'handoff',
+      predicate:
+        'Scene Tree owner apply completes inside the remote transaction.',
+      producedArtifacts: ['artifact:scene-tree-restored-state']
+    },
+    {
+      id: 'remote-restore-rolled-back',
+      from: 'settle-remote-restore-transaction',
+      kind: 'terminal',
+      predicate:
+        'Any owner or settlement failure restores pre-publication state.',
+      producedArtifacts: ['artifact:rolled-back-remote-restore']
+    },
+    {
+      id: 'remote-restore-committed-to-preset',
+      from: 'settle-remote-restore-transaction',
+      to: 'project-preset-group-state',
+      kind: 'projection',
+      predicate: 'The complete remote transaction commits.',
+      producedArtifacts: ['artifact:committed-remote-restore']
+    },
+    {
+      id: 'remote-restore-committed-to-render',
+      from: 'settle-remote-restore-transaction',
+      to: 'project-render-identities',
+      kind: 'projection',
+      predicate: 'Ordinary committed canonical updates reach Render.',
+      producedArtifacts: ['artifact:committed-remote-restore']
+    },
+    {
+      id: 'remote-restore-committed-to-layers',
+      from: 'settle-remote-restore-transaction',
+      to: 'project-layers-ui',
+      kind: 'projection',
+      predicate: 'Ordinary committed canonical updates reach app projection.',
+      producedArtifacts: ['artifact:committed-remote-restore']
+    },
+    {
+      id: 'preset-projection-reaches-render',
+      from: 'project-preset-group-state',
+      to: 'project-render-identities',
+      kind: 'projection',
+      predicate: 'Existing Preset observers route canonical Group state.',
+      producedArtifacts: ['artifact:preset-canonical-projection']
+    },
+    {
+      id: 'preset-projection-reaches-layers',
+      from: 'project-preset-group-state',
+      to: 'project-layers-ui',
+      kind: 'projection',
+      predicate:
+        'Existing UI-context observers publish canonical hierarchy data.',
+      producedArtifacts: ['artifact:preset-canonical-projection']
+    },
+    {
+      id: 'render-restored-subtree',
+      from: 'project-render-identities',
+      kind: 'terminal',
+      predicate: 'The ordinary Render projection succeeds.',
+      producedArtifacts: ['artifact:rendered-restored-subtree']
+    },
+    {
+      id: 'layers-restored-subtree',
+      from: 'project-layers-ui',
+      kind: 'terminal',
+      predicate: 'The ordinary Layers projection succeeds.',
+      producedArtifacts: ['artifact:layers-restored-subtree']
+    }
+  ]
+
+  const artifacts = [
+    {
+      id: 'artifact:scene-tree-delete-evidence',
+      ownerStepId: 'capture-scene-tree-delete-evidence',
+      channel: 'Scene Tree transaction evidence',
+      consumerStepIds: [
+        'capture-props-delete-evidence',
+        'publish-local-restore-snapshot'
+      ],
+      terminal: false
+    },
+    {
+      id: 'artifact:props-delete-evidence',
+      ownerStepId: 'capture-props-delete-evidence',
+      channel: 'Props transaction evidence',
+      consumerStepIds: ['publish-local-restore-snapshot'],
+      terminal: false
+    },
+    {
+      id: 'artifact:local-restore-publication',
+      ownerStepId: 'publish-local-restore-snapshot',
+      channel: 'Factory SharedPublication',
+      consumerStepIds: ['transport-restore-publication'],
+      terminal: false
+    },
+    {
+      id: 'artifact:inbound-restore-publication',
+      ownerStepId: 'transport-restore-publication',
+      channel: 'Collaboration callback',
+      consumerStepIds: ['classify-and-authorize-remote-restore'],
+      terminal: false
+    },
+    {
+      id: 'artifact:instance-safe-owner-facades',
+      ownerStepId: 'expose-instance-safe-owner-facades',
+      channel: 'Core public facade',
+      consumerStepIds: ['classify-and-authorize-remote-restore'],
+      terminal: false
+    },
+    {
+      id: 'artifact:accepted-restore-publication',
+      ownerStepId: 'classify-and-authorize-remote-restore',
+      channel: 'app policy result',
+      consumerStepIds: [
+        'preflight-scene-tree-restore',
+        'preflight-props-restore',
+        'settle-remote-restore-transaction'
+      ],
+      terminal: false
+    },
+    {
+      id: 'artifact:remote-restore-rejection',
+      ownerStepId: 'classify-and-authorize-remote-restore',
+      channel: 'terminal app policy result',
+      consumerStepIds: [],
+      terminal: true
+    },
+    {
+      id: 'artifact:scene-tree-restore-plan',
+      ownerStepId: 'preflight-scene-tree-restore',
+      channel: 'owner-issued one-shot preflight artifact',
+      consumerStepIds: [
+        'preflight-props-restore',
+        'settle-remote-restore-transaction',
+        'materialize-scene-tree-restore'
+      ],
+      terminal: false
+    },
+    {
+      id: 'artifact:props-restore-plan',
+      ownerStepId: 'preflight-props-restore',
+      channel: 'owner-issued one-shot preflight artifact',
+      consumerStepIds: [
+        'settle-remote-restore-transaction',
+        'materialize-props-restore'
+      ],
+      terminal: false
+    },
+    {
+      id: 'artifact:remote-restore-transaction-scope',
+      ownerStepId: 'settle-remote-restore-transaction',
+      channel: 'Factory remote transaction',
+      consumerStepIds: [
+        'materialize-props-restore',
+        'materialize-scene-tree-restore'
+      ],
+      terminal: false
+    },
+    {
+      id: 'artifact:props-restored-state',
+      ownerStepId: 'materialize-props-restore',
+      channel: 'canonical Props state',
+      consumerStepIds: [
+        'materialize-scene-tree-restore',
+        'settle-remote-restore-transaction'
+      ],
+      terminal: false
+    },
+    {
+      id: 'artifact:scene-tree-restored-state',
+      ownerStepId: 'materialize-scene-tree-restore',
+      channel: 'canonical Scene Tree state',
+      consumerStepIds: ['settle-remote-restore-transaction'],
+      terminal: false
+    },
+    {
+      id: 'artifact:committed-remote-restore',
+      ownerStepId: 'settle-remote-restore-transaction',
+      channel: 'committed transaction outcome',
+      consumerStepIds: [
+        'project-preset-group-state',
+        'project-render-identities',
+        'project-layers-ui'
+      ],
+      terminal: false
+    },
+    {
+      id: 'artifact:rolled-back-remote-restore',
+      ownerStepId: 'settle-remote-restore-transaction',
+      channel: 'terminal rollback outcome',
+      consumerStepIds: [],
+      terminal: true
+    },
+    {
+      id: 'artifact:preset-canonical-projection',
+      ownerStepId: 'project-preset-group-state',
+      channel: 'ordinary Preset projection',
+      consumerStepIds: ['project-render-identities', 'project-layers-ui'],
+      terminal: false
+    },
+    {
+      id: 'artifact:rendered-restored-subtree',
+      ownerStepId: 'project-render-identities',
+      channel: 'terminal Render projection',
+      consumerStepIds: [],
+      terminal: true
+    },
+    {
+      id: 'artifact:layers-restored-subtree',
+      ownerStepId: 'project-layers-ui',
+      channel: 'terminal Layers projection',
+      consumerStepIds: [],
+      terminal: true
+    }
+  ]
+
+  const invariants = [
+    {
+      id: 'owner-partitioned-snapshot',
+      title: 'Delete evidence stays detached and owner-partitioned',
+      stepIds: [
+        'capture-scene-tree-delete-evidence',
+        'capture-props-delete-evidence',
+        'publish-local-restore-snapshot'
+      ],
+      artifactIds: [
+        'artifact:scene-tree-delete-evidence',
+        'artifact:props-delete-evidence',
+        'artifact:local-restore-publication'
+      ],
+      specRefs: ['#restore-snapshot', '#sender-behavior'],
+      assertion:
+        'Snapshot evidence is captured at delete time, detached, scoped to one subtree, and carried only by ordinary grouped owner deliveries.'
+    },
+    {
+      id: 'transport-remains-opaque',
+      title: 'Collaboration remains transport-only',
+      stepIds: [
+        'publish-local-restore-snapshot',
+        'transport-restore-publication',
+        'classify-and-authorize-remote-restore'
+      ],
+      artifactIds: [
+        'artifact:local-restore-publication',
+        'artifact:inbound-restore-publication',
+        'artifact:accepted-restore-publication'
+      ],
+      specRefs: ['#ownership-contract', '#receiver-classification-and-routing'],
+      assertion:
+        'Collaboration forwards the complete publication unchanged while all restore classification, stale, permission, and conflict policy remains app-owned.'
+    },
+    {
+      id: 'canonical-owner-materialization',
+      title: 'Canonical owners restore exact known data',
+      stepIds: [
+        'preflight-scene-tree-restore',
+        'preflight-props-restore',
+        'materialize-props-restore',
+        'materialize-scene-tree-restore'
+      ],
+      artifactIds: [
+        'artifact:scene-tree-restore-plan',
+        'artifact:props-restore-plan',
+        'artifact:props-restored-state',
+        'artifact:scene-tree-restored-state'
+      ],
+      specRefs: ['#canonical-restore', '#strict-stale-restore-policy'],
+      assertion:
+        'Scene Tree and Props each validate and materialize only their exact owner data, reusing compatible tombstones or creating isolated instances with stable ids.'
+    },
+    {
+      id: 'one-atomic-remote-transaction',
+      title: 'One accepted restore settles atomically',
+      stepIds: [
+        'classify-and-authorize-remote-restore',
+        'settle-remote-restore-transaction',
+        'materialize-props-restore',
+        'materialize-scene-tree-restore'
+      ],
+      artifactIds: [
+        'artifact:accepted-restore-publication',
+        'artifact:remote-restore-transaction-scope',
+        'artifact:committed-remote-restore',
+        'artifact:rolled-back-remote-restore'
+      ],
+      specRefs: ['#canonical-restore', '#strict-stale-restore-policy'],
+      assertion:
+        'The complete preflight passes before mutation and one rollbackable, non-undoable, no-echo Factory transaction commits all owner state or restores all of it.'
+    },
+    {
+      id: 'ordinary-projection-only',
+      title: 'Projection uses only ordinary canonical updates',
+      stepIds: [
+        'project-preset-group-state',
+        'project-render-identities',
+        'project-layers-ui'
+      ],
+      artifactIds: [
+        'artifact:committed-remote-restore',
+        'artifact:preset-canonical-projection',
+        'artifact:rendered-restored-subtree',
+        'artifact:layers-restored-subtree'
+      ],
+      specRefs: ['#ownership-contract', '#product-cases'],
+      assertion:
+        'Preset, Render, and Layers consume normal canonical state and never create restore-only fallback hierarchy, properties, geometry, or identity.'
+    }
+  ]
+
+  const acceptanceContracts = [
+    {
+      id: 'sender-snapshot-contract',
+      title: 'Detached exact sender evidence and grouping',
+      stepIds: [
+        'capture-scene-tree-delete-evidence',
+        'capture-props-delete-evidence',
+        'publish-local-restore-snapshot'
+      ],
+      specRefs: ['#restore-snapshot', '#sender-behavior', '#product-cases'],
+      assertions: [
+        'The original delete captures exact Scene Tree and Props evidence for exactly one subtree, detached from later caller and runtime mutation.',
+        'One local undo produces one grouped publication containing exact Props ADD deliveries followed by the typed Scene Tree RESTORE_SUBTREE delivery.'
+      ]
+    },
+    {
+      id: 'transport-app-core-contract',
+      title: 'Opaque transport, instance-safe facades, and strict app policy',
+      stepIds: [
+        'transport-restore-publication',
+        'expose-instance-safe-owner-facades',
+        'classify-and-authorize-remote-restore'
+      ],
+      specRefs: [
+        '#ownership-contract',
+        '#receiver-classification-and-routing',
+        '#strict-stale-restore-policy',
+        '#coreload-boundary'
+      ],
+      assertions: [
+        'Collaboration remains transport-only; Core exposes only instance-safe owner facades; the App validates the complete publication and owns permission, domain ordering, duplicate, stale, and conflict policy.',
+        'Two independent Core, Scene Tree, Props, and Factory compositions remain instance-isolated.'
+      ]
+    },
+    {
+      id: 'owner-materialization-contract',
+      title: 'Equivalent tombstone reuse and known-data materialization',
+      stepIds: [
+        'preflight-scene-tree-restore',
+        'preflight-props-restore',
+        'materialize-props-restore',
+        'materialize-scene-tree-restore'
+      ],
+      specRefs: [
+        '#canonical-restore',
+        '#strict-stale-restore-policy',
+        '#product-cases'
+      ],
+      assertions: [
+        'Tombstone-present and tombstone-absent restore are equivalent in ids, data, hierarchy, properties, save output, and projections.',
+        'Normal and empty Group restore preserves stable ids, exact parent, root sibling index, descendant child order, raw Group data, property components, and relations without defaults or replacement ids.'
+      ]
+    },
+    {
+      id: 'atomicity-redo-contract',
+      title: 'Atomic remote settlement, non-undo, no-echo, and redo',
+      stepIds: [
+        'settle-remote-restore-transaction',
+        'materialize-props-restore',
+        'materialize-scene-tree-restore'
+      ],
+      specRefs: [
+        '#canonical-restore',
+        '#strict-stale-restore-policy',
+        '#product-cases'
+      ],
+      assertions: [
+        'One local undo remains one grouped publication and one accepted remote restore remains one remote transaction that is non-undoable and emits no outbound echo; subsequent remote redo deletes the same exact subtree.',
+        'Id collision, incompatible tombstone, stale parent, stale order, duplicate ids, missing owner data, invalid registration, malformed relation, cycle, inconsistent child order, and permission rejection leave no partial Scene Tree or Props state.'
+      ]
+    },
+    {
+      id: 'projection-save-contract',
+      title: 'Exact save and ordinary canonical projection',
+      stepIds: [
+        'project-preset-group-state',
+        'project-render-identities',
+        'project-layers-ui'
+      ],
+      specRefs: ['#product-cases', '#definition-of-done'],
+      assertions: [
+        'Save after restore contains the exact canonical subtree; Render and Layers receive the same stable identities through ordinary canonical handoff.',
+        'Preset Group bounds, Render identity, and Layers hierarchy add no restore-only state or fallback.'
+      ]
+    },
+    {
+      id: 'bounded-exclusions-contract',
+      title: 'Bounded plan exclusions remain unchanged',
+      stepIds: [
+        'transport-restore-publication',
+        'expose-instance-safe-owner-facades',
+        'classify-and-authorize-remote-restore'
+      ],
+      specRefs: [
+        '#unsupported-and-deferred',
+        '#coreload-boundary',
+        '#definition-of-done'
+      ],
+      assertions: [
+        'Collaboration remains transport-only, core.load remains unrestricted, Group Context Menu does not start, and implementation closeout does not occur in this plan.'
+      ]
+    }
+  ]
+
+  const data = {
+    schema: { id: 'asyra.flow-inspector', version: 2 },
+    target: {
+      id: 'remote-subtree-restore-snapshot',
+      kind: 'system',
+      title: 'Remote Subtree Restore Snapshot Inspector',
+      subtitle:
+        'Detached delete evidence through one Factory publication, opaque Collaboration transport, strict App policy, tombstone-optional canonical owner materialization, atomic remote settlement, and ordinary Preset/Render/Layers projection.'
+    },
+    authority: {
+      specPath,
+      inspectorPath,
+      semanticOwner: 'Remote Subtree Restore Snapshot Plan',
+      inspectorOwner: 'Remote Subtree Restore Snapshot Inspector data'
+    },
+    links: [
+      {
+        id: 'product-contract',
+        label: 'Product Contract',
+        href: './remote-subtree-restore-snapshot-plan.md',
+        kind: 'authority'
+      },
+      {
+        id: 'gate-2-contract',
+        label: 'Gate 2 Transport Contract',
+        href: '../../../framework/plans/completed/network-collaboration-transport-plan.md',
+        kind: 'authority'
+      },
+      {
+        id: 'gate-3-inspector',
+        label: 'Gate 3 Hierarchy Inspector',
+        href: '../../../framework/plans/group-component-and-hierarchy-flow-inspector.html',
+        kind: 'authority'
+      },
+      {
+        id: 'flow-inspector-contract',
+        label: 'Flow Inspector Contract',
+        href: '../../../framework/FLOW_INSPECTOR.md',
+        kind: 'framework'
+      }
+    ],
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  }
+
+  const freeze = (value) => {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
+      return value
+    }
+    Object.freeze(value)
+    Object.values(value).forEach(freeze)
+    return value
+  }
+
+  freeze(data)
+  if (typeof globalThis !== 'undefined') globalThis.FLOW_INSPECTOR_DATA = data
+  if (typeof module !== 'undefined' && module.exports) module.exports = data
+})()

--- a/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
+++ b/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
@@ -2,7 +2,7 @@
   'use strict'
 
   const specPath =
-    'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-plan.md'
+    'docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md'
   const inspectorPath =
     'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs'
 
@@ -1317,7 +1317,7 @@
       {
         id: 'product-contract',
         label: 'Product Contract',
-        href: './remote-subtree-restore-snapshot-plan.md',
+        href: './completed/remote-subtree-restore-snapshot-plan.md',
         kind: 'authority'
       },
       {

--- a/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
+++ b/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.data.cjs
@@ -487,7 +487,8 @@
       conditions: [
         'Every component preserves its component id, exact data, and owner relation.',
         'Tombstone-present and tombstone-absent paths produce equivalent canonical Props state.',
-        'Materialization applies no defaults and allocates no replacement ids.'
+        'Materialization applies no defaults and allocates no replacement ids.',
+        'Materialized components retain the issuing Props Manager accessor for later child relation and value projection.'
       ],
       bypasses: [
         'An empty valid Props plan performs no component mutation and still permits the Scene Tree owner step.',
@@ -508,9 +509,11 @@
       ],
       cacheDimensions: [],
       implementationBoundary: [
+        'packages/props-manager/src/components/base.ts',
         'packages/props-manager/src/manager/props-manager.ts',
         'packages/props-manager/src/manager/subscribes.ts',
         'packages/props-manager/src/factories/create-property.ts',
+        'packages/props-manager/src/registries/declarative-property-type.ts',
         'packages/props-manager/src/__tests__'
       ],
       specRefs: [
@@ -589,7 +592,8 @@
       outputs: ['artifact:preset-canonical-projection'],
       conditions: [
         'Existing Scene Tree channel handling derives Group bounds and canonical UI-context values after commit.',
-        'Projection consumes the same stable ids and data used by local undo.'
+        'Projection consumes the same stable ids and data used by local undo.',
+        'Official children-map components retain their issuing Props Manager accessor when projecting restored child values.'
       ],
       bypasses: [
         'A rolled-back or rejected restore produces no final projection.',
@@ -610,6 +614,8 @@
       implementationBoundary: [
         'packages/preset/src/subscriptions/data-channel.ts',
         'packages/preset/src/components/group.ts',
+        'packages/preset/src/props/components/children-map-property-component.ts',
+        'packages/preset/src/__tests__/children-map-property-component.test.ts',
         'packages/preset/src/__tests__/selection-subscriptions.test.ts',
         'packages/preset/src/__tests__/group-operations.test.ts'
       ],

--- a/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.html
+++ b/docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.html
@@ -1,0 +1,799 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Asyra Design Remote Subtree Restore Snapshot Inspector</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #101418;
+        --panel: #151b22;
+        --panel-2: #1d2530;
+        --line: #334155;
+        --text: #e5edf5;
+        --muted: #9caab8;
+        --accent: #59b7ff;
+        --card-w: 270px;
+        --card-h: 118px;
+        --gap-x: 220px;
+        --gap-y: 100px;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--text);
+        background: var(--bg);
+        font:
+          14px/1.5 ui-sans-serif,
+          system-ui,
+          sans-serif;
+      }
+      .app {
+        display: grid;
+        grid-template-columns: minmax(980px, 1fr) 430px;
+        height: 100vh;
+        overflow: hidden;
+      }
+      .main {
+        min-width: 0;
+        overflow: auto;
+        padding: 24px;
+      }
+      .header {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 18px;
+      }
+      h1 {
+        margin: 0 0 6px;
+        font-size: 24px;
+      }
+      .subtitle,
+      .detail-summary {
+        color: var(--muted);
+      }
+      .header-links,
+      .filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 12px 0 18px;
+      }
+      .header-link,
+      .filter-button {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        padding: 6px 10px;
+        color: var(--accent);
+        background: var(--panel);
+      }
+      .filter-button.active {
+        border-color: var(--accent);
+      }
+      .guide-panel {
+        margin-bottom: 18px;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 12px 16px;
+        background: var(--panel);
+      }
+      .guide-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(240px, 1fr));
+        gap: 12px;
+      }
+      .guide-card {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 12px;
+        background: var(--panel-2);
+      }
+      .flow {
+        position: relative;
+        min-width: 100%;
+        min-height: 620px;
+      }
+      .flow-svg {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+      }
+      .step-card {
+        position: absolute;
+        width: var(--card-w);
+        min-height: var(--card-h);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 14px;
+        color: var(--text);
+        background: var(--panel);
+        text-align: left;
+      }
+      .step-card.selected {
+        border-color: var(--accent);
+      }
+      .step-card h2 {
+        margin: 0 0 6px;
+        font-size: 15px;
+      }
+      .detail {
+        height: 100vh;
+        overflow: auto;
+        border-left: 1px solid var(--line);
+        padding: 24px;
+        background: #0f1720;
+      }
+      .detail-section {
+        margin-bottom: 16px;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 14px;
+        background: var(--panel);
+      }
+      .detail-section h3 {
+        margin: 0 0 8px;
+        font-size: 12px;
+        text-transform: uppercase;
+      }
+      code {
+        color: #dbeafe;
+      }
+      a {
+        color: var(--accent);
+      }
+      .hidden {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <main class="main">
+        <div class="header">
+          <div>
+            <h1 id="inspector-title">Flow Inspector</h1>
+            <p id="inspector-subtitle" class="subtitle">
+              Loading target contract.
+            </p>
+            <div id="inspector-links" class="header-links"></div>
+          </div>
+        </div>
+        <div id="filters" class="filters"></div>
+        <details class="guide-panel">
+          <summary>Viewer controls and contract</summary>
+          <section class="guide-grid">
+            <article class="guide-card">
+              <h2>Viewer controls</h2>
+              <p>
+                Filter by owner lane and select a card to inspect its exact
+                inputs, outputs, boundaries, and failure owner.
+              </p>
+            </article>
+            <article class="guide-card">
+              <h2>Target contract</h2>
+              <p id="target-contract-summary">Loading target contract.</p>
+            </article>
+          </section>
+        </details>
+        <section
+          id="flow"
+          class="flow"
+          aria-label="Asyra Design Remote Subtree Restore Snapshot flow"
+        ></section>
+      </main>
+      <aside id="detail" class="detail" aria-label="step detail"></aside>
+    </div>
+    <script src="./remote-subtree-restore-snapshot-flow-inspector.data.cjs"></script>
+    <script data-flow-inspector-renderer>
+/* global console, document, window */
+
+;(function () {
+  'use strict'
+
+  const data = globalThis.FLOW_INSPECTOR_DATA
+  if (!data) {
+    throw new Error(
+      'Missing FLOW_INSPECTOR_DATA. Load the target data file before the shared viewer.'
+    )
+  }
+
+  const {
+    schema,
+    target,
+    authority,
+    links = [],
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  } = data
+
+  const requiredCollections = {
+    links,
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  }
+  const invalidCollections = Object.entries(requiredCollections)
+    .filter(([, value]) => !Array.isArray(value))
+    .map(([name]) => name)
+  if (invalidCollections.length) {
+    throw new Error(
+      `Flow Inspector target has invalid collections: ${invalidCollections.join(', ')}`
+    )
+  }
+  if (schema?.id !== 'asyra.flow-inspector' || schema.version !== 2) {
+    throw new Error('Flow Inspector requires schema asyra.flow-inspector/v2.')
+  }
+
+  const flow = document.getElementById('flow')
+  const detail = document.getElementById('detail')
+  const filters = document.getElementById('filters')
+  const title = document.getElementById('inspector-title')
+  const subtitle = document.getElementById('inspector-subtitle')
+  const headerLinks = document.getElementById('inspector-links')
+  const targetSummary = document.getElementById('target-contract-summary')
+
+  const requiredElements = {
+    flow,
+    detail,
+    filters,
+    title,
+    subtitle,
+    headerLinks,
+    targetSummary
+  }
+  const missingElements = Object.entries(requiredElements)
+    .filter(([, element]) => !element)
+    .map(([name]) => name)
+  if (missingElements.length) {
+    throw new Error(
+      `Flow Inspector shell is missing: ${missingElements.join(', ')}`
+    )
+  }
+
+  const escapeHtml = (value) =>
+    String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;')
+
+  const specLink = links.find((link) => link.kind === 'authority')
+
+  const formatItem = (value) => {
+    if (value && typeof value === 'object' && value.href && value.label) {
+      return `<a href="${escapeHtml(value.href)}">${escapeHtml(value.label)}</a>`
+    }
+    const text = String(value)
+    if (text.startsWith('#') && specLink) {
+      return `<a href="${escapeHtml(`${specLink.href}${text}`)}"><code>${escapeHtml(text)}</code></a>`
+    }
+    return escapeHtml(text).replace(/`([^`]+)`/g, '<code>$1</code>')
+  }
+
+  const section = (heading, items, className = '') => {
+    const values = items && items.length ? items : ['None']
+    return `
+      <section class="detail-section ${className}">
+        <h3>${escapeHtml(heading)}</h3>
+        <ul>${values.map((item) => `<li>${formatItem(item)}</li>`).join('')}</ul>
+      </section>`
+  }
+
+  const laneById = new Map(lanes.map((lane) => [lane.id, lane]))
+  const stepById = new Map(steps.map((step) => [step.id, step]))
+  const artifactById = new Map(
+    artifacts.map((artifact) => [artifact.id, artifact])
+  )
+  const stepsByLane = new Map(
+    lanes.map((lane) => [
+      lane.id,
+      steps
+        .filter((step) => step.laneId === lane.id)
+        .sort((left, right) => left.order - right.order)
+    ])
+  )
+
+  const layout = {
+    left: 28,
+    top: 68,
+    cardW: 270,
+    cardH: 118,
+    gapX: 220,
+    gapY: 100
+  }
+
+  let selectedId = steps[0]?.id ?? null
+  let selectedLaneId = 'All'
+
+  const isVisible = (step) =>
+    selectedLaneId === 'All' || step.laneId === selectedLaneId
+
+  const getStepLane = (step) =>
+    lanes.findIndex((lane) => lane.id === step.laneId)
+
+  const getStepRow = (step) =>
+    stepsByLane.get(step.laneId)?.findIndex((item) => item.id === step.id) ?? 0
+
+  const stepPosition = (step) => ({
+    x: layout.left + getStepLane(step) * (layout.cardW + layout.gapX),
+    y: layout.top + getStepRow(step) * (layout.cardH + layout.gapY)
+  })
+
+  const getFlowBounds = () => {
+    const visibleSteps = steps.filter(isVisible)
+    const laneIndexes = visibleSteps.map(getStepLane)
+    const rowIndexes = visibleSteps.map(getStepRow)
+    const maxLane = laneIndexes.length ? Math.max(...laneIndexes) : 0
+    const maxRow = rowIndexes.length ? Math.max(...rowIndexes) : 0
+    return {
+      width:
+        layout.left * 2 + (maxLane + 1) * layout.cardW + maxLane * layout.gapX,
+      height:
+        layout.top * 2 + (maxRow + 1) * layout.cardH + maxRow * layout.gapY
+    }
+  }
+
+  const toSvgPoint = (svg, x, y) => {
+    const point = svg.createSVGPoint()
+    point.x = x
+    point.y = y
+    const matrix = svg.getScreenCTM()
+    return matrix ? point.matrixTransform(matrix.inverse()) : { x, y }
+  }
+
+  const getEdgePath = (svg, fromCard, toCard, fromStep, toStep) => {
+    const fromBox = fromCard.getBoundingClientRect()
+    const toBox = toCard.getBoundingClientRect()
+    if (fromStep.laneId === toStep.laneId) {
+      const start = toSvgPoint(
+        svg,
+        fromBox.left + fromBox.width / 2,
+        fromBox.bottom
+      )
+      const end = toSvgPoint(svg, toBox.left + toBox.width / 2, toBox.top)
+      const midpointY = fromBox.bottom + (toBox.top - fromBox.bottom) * 0.5
+      const controlStart = toSvgPoint(
+        svg,
+        fromBox.left + fromBox.width / 2,
+        midpointY
+      )
+      const controlEnd = toSvgPoint(
+        svg,
+        toBox.left + toBox.width / 2,
+        midpointY
+      )
+      return `M ${start.x} ${start.y} C ${controlStart.x} ${controlStart.y}, ${controlEnd.x} ${controlEnd.y}, ${end.x} ${end.y}`
+    }
+
+    const direction = toBox.left >= fromBox.left ? 1 : -1
+    const startX = direction > 0 ? fromBox.right : fromBox.left
+    const startY = fromBox.top + fromBox.height / 2
+    const endX = direction > 0 ? toBox.left : toBox.right
+    const endY = toBox.top + toBox.height / 2
+    const distanceX = Math.abs(endX - startX)
+    const curve = Math.max(120, Math.min(distanceX * 0.46, layout.gapX * 0.92))
+    const start = toSvgPoint(svg, startX, startY)
+    const end = toSvgPoint(svg, endX, endY)
+    const controlStart = toSvgPoint(svg, startX + direction * curve, startY)
+    const controlEnd = toSvgPoint(svg, endX - direction * curve, endY)
+    return `M ${start.x} ${start.y} C ${controlStart.x} ${controlStart.y}, ${controlEnd.x} ${controlEnd.y}, ${end.x} ${end.y}`
+  }
+
+  const routeClass = (kind) => {
+    if (kind === 'bypass') return 'route-bypass'
+    if (kind === 'coexecute' || kind === 'fanout') return 'route-parallel'
+    return `route-${kind}`
+  }
+
+  const renderEdges = (svg) => {
+    svg.querySelectorAll('.edge-path').forEach((node) => node.remove())
+    routes.forEach((route) => {
+      if (!route.to) return
+      const from = stepById.get(route.from)
+      const to = stepById.get(route.to)
+      if (!from || !to || !isVisible(from) || !isVisible(to)) return
+      const fromCard = flow.querySelector(`[data-step-id="${route.from}"]`)
+      const toCard = flow.querySelector(`[data-step-id="${route.to}"]`)
+      if (!fromCard || !toCard) return
+
+      const path = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path'
+      )
+      path.setAttribute('d', getEdgePath(svg, fromCard, toCard, from, to))
+      path.setAttribute(
+        'class',
+        `edge-path ${routeClass(route.kind)}${route.from === selectedId || route.to === selectedId ? ' is-active' : ''}`
+      )
+      path.setAttribute('data-route-id', route.id)
+      path.setAttribute('marker-end', 'url(#arrow)')
+      const tooltip = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'title'
+      )
+      tooltip.textContent = `${route.id}: ${route.kind}; ${route.predicate}`
+      path.appendChild(tooltip)
+      svg.appendChild(path)
+    })
+  }
+
+  const routesForStep = (stepId, direction) =>
+    routes
+      .filter((route) => route[direction] === stepId)
+      .map(
+        (route) =>
+          `${route.id} [${route.kind}]: ${route.predicate}; ${route.from} -> ${route.to ?? 'terminal'}; artifacts ${route.producedArtifacts.join(', ')}`
+      )
+
+  const artifactsOwnedBy = (stepId) =>
+    artifacts
+      .filter((artifact) => artifact.ownerStepId === stepId)
+      .map(
+        (artifact) =>
+          `${artifact.id}: ${artifact.channel}; consumers ${artifact.consumerStepIds.join(', ') || 'terminal'}`
+      )
+
+  const artifactsConsumedBy = (stepId) =>
+    artifacts
+      .filter((artifact) => artifact.consumerStepIds.includes(stepId))
+      .map(
+        (artifact) =>
+          `${artifact.id}: owner ${artifact.ownerStepId}; ${artifact.channel}`
+      )
+
+  const invariantsForStep = (stepId) =>
+    invariants
+      .filter((invariant) => invariant.stepIds.includes(stepId))
+      .map(
+        (invariant) =>
+          `${invariant.id}: ${invariant.statement}; refs ${invariant.specRefs.join(', ')}`
+      )
+
+  const acceptanceForStep = (stepId) =>
+    acceptanceContracts
+      .filter((contract) => contract.stepIds.includes(stepId))
+      .map(
+        (contract) =>
+          `${contract.id}: ${contract.assertions.join('; ')}; refs ${contract.specRefs.join(', ')}`
+      )
+
+  const renderHeader = () => {
+    document.title = target.title
+    title.textContent = target.title
+    subtitle.textContent = target.subtitle
+    headerLinks.innerHTML = links
+      .map(
+        (link) =>
+          `<a class="header-link" href="${escapeHtml(link.href)}" data-link-kind="${escapeHtml(link.kind)}">${escapeHtml(link.label)}</a>`
+      )
+      .join('')
+    targetSummary.innerHTML = [
+      `Target: <code>${escapeHtml(target.kind)}:${escapeHtml(target.id)}</code>`,
+      `Schema: <code>${escapeHtml(schema.id)}/v${escapeHtml(schema.version)}</code>`,
+      `Semantic authority: <code>${escapeHtml(authority.specPath)}</code>`,
+      `Inspector data: <code>${escapeHtml(authority.inspectorPath)}</code>`
+    ].join('<br />')
+  }
+
+  const renderFilters = () => {
+    filters.innerHTML = ''
+    ;[{ id: 'All', title: 'All' }, ...lanes].forEach((lane) => {
+      const button = document.createElement('button')
+      button.className = `filter-button${lane.id === selectedLaneId ? ' is-active' : ''}`
+      button.type = 'button'
+      button.textContent = lane.title
+      button.addEventListener('click', () => {
+        selectedLaneId = lane.id
+        const selectedStep = stepById.get(selectedId)
+        if (selectedStep && !isVisible(selectedStep)) {
+          selectedId = steps.find(isVisible)?.id ?? steps[0]?.id ?? null
+        }
+        render()
+      })
+      filters.appendChild(button)
+    })
+  }
+
+  const renderDetail = () => {
+    const selected = stepById.get(selectedId) ?? steps[0]
+    if (!selected) {
+      detail.innerHTML = '<p>No steps are declared.</p>'
+      return
+    }
+    const lane = laneById.get(selected.laneId)
+    detail.innerHTML = `
+      <div class="detail-group">${escapeHtml(lane?.title ?? selected.laneId)}</div>
+      <div class="detail-heading">
+        <span class="step-number">Step ${escapeHtml(selected.order)}</span>
+        <h2>${escapeHtml(selected.title)}</h2>
+      </div>
+      <p class="detail-summary">${escapeHtml(selected.purpose)}</p>
+      ${section('Target links', links, 'rule-box')}
+      ${section('Owner package', [selected.ownerPackage], 'alignment-box')}
+      ${section('Inputs', selected.inputs)}
+      ${section('Outputs', selected.outputs)}
+      ${section('Conditions', selected.conditions, 'trace-box')}
+      ${section('Bypasses', selected.bypasses, 'trace-box')}
+      ${section('Allowed contributors', selected.allowedContributors, 'evidence-box')}
+      ${section('Forbidden contributors', selected.forbiddenContributors, 'risk-box')}
+      ${section('Cache dimensions', selected.cacheDimensions, 'trace-box')}
+      ${section('Implementation boundary', selected.implementationBoundary)}
+      ${section('Spec references', selected.specRefs, 'rule-box')}
+      ${section('Failure owner step', [selected.failureOwnerStepId], 'risk-box')}
+      ${section('Incoming routes', routesForStep(selected.id, 'to'), 'trace-box')}
+      ${section('Outgoing routes', routesForStep(selected.id, 'from'), 'trace-box')}
+      ${section('Owned artifacts', artifactsOwnedBy(selected.id), 'trace-box')}
+      ${section('Consumed artifacts', artifactsConsumedBy(selected.id), 'trace-box')}
+      ${section('Invariants', invariantsForStep(selected.id), 'evidence-box')}
+      ${section('Acceptance contracts', acceptanceForStep(selected.id), 'test-box')}`
+  }
+
+  const renderFlow = () => {
+    flow.innerHTML = ''
+    const bounds = getFlowBounds()
+    flow.style.minWidth = `${bounds.width}px`
+    flow.style.minHeight = `${bounds.height}px`
+
+    lanes.forEach((lane, laneIndex) => {
+      const label = document.createElement('div')
+      label.className = 'lane-label'
+      label.style.left = `${layout.left + laneIndex * (layout.cardW + layout.gapX)}px`
+      label.textContent = lane.title
+      flow.appendChild(label)
+    })
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('class', 'flow-svg')
+    svg.setAttribute('viewBox', `0 0 ${bounds.width} ${bounds.height}`)
+    svg.style.width = `${bounds.width}px`
+    svg.style.height = `${bounds.height}px`
+    svg.innerHTML = `
+      <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(148, 163, 184, 0.62)"></path>
+        </marker>
+      </defs>`
+    flow.appendChild(svg)
+
+    steps.filter(isVisible).forEach((step) => {
+      const position = stepPosition(step)
+      const lane = laneById.get(step.laneId)
+      const tags = step.tags ?? []
+      const card = document.createElement('button')
+      card.type = 'button'
+      card.className = [
+        'step-card',
+        step.id === selectedId ? 'is-selected' : '',
+        tags.includes('risk') ? 'is-risk' : '',
+        tags.includes('critical') ? 'is-critical' : '',
+        tags.includes('blocker') ? 'is-blocker' : ''
+      ]
+        .filter(Boolean)
+        .join(' ')
+      card.style.left = `${position.x}px`
+      card.style.top = `${position.y}px`
+      card.dataset.stepId = step.id
+      card.innerHTML = `
+        <div class="step-kicker">
+          <span class="step-number">Step ${escapeHtml(step.order)}</span>
+          <span>${escapeHtml(lane?.title ?? step.laneId)}</span>
+        </div>
+        <div class="step-title">${escapeHtml(step.title)}</div>
+        <div class="step-summary">${escapeHtml(step.purpose)}</div>
+        <div class="badge-row">
+          <span class="badge truth">${escapeHtml(step.ownerPackage)}</span>
+          ${tags
+            .slice(0, 2)
+            .map((tag) => `<span class="badge">${escapeHtml(tag)}</span>`)
+            .join('')}
+        </div>`
+      card.addEventListener('click', () => {
+        selectedId = step.id
+        render()
+      })
+      flow.appendChild(card)
+    })
+
+    renderEdges(svg)
+  }
+
+  const runStaticChecks = () => {
+    const errors = []
+    const uniqueIds = (label, items) => {
+      const seen = new Set()
+      items.forEach((item) => {
+        if (seen.has(item.id)) errors.push(`${label}:duplicate:${item.id}`)
+        seen.add(item.id)
+      })
+    }
+    uniqueIds('lane', lanes)
+    uniqueIds('step', steps)
+    uniqueIds('route', routes)
+    uniqueIds('artifact', artifacts)
+    uniqueIds('invariant', invariants)
+    uniqueIds('acceptance', acceptanceContracts)
+
+    if (!target?.id || !target?.kind || !target?.title) {
+      errors.push('target:incomplete')
+    }
+
+    const requiredStepFields = [
+      'id',
+      'order',
+      'laneId',
+      'title',
+      'ownerPackage',
+      'purpose',
+      'inputs',
+      'outputs',
+      'conditions',
+      'bypasses',
+      'allowedContributors',
+      'forbiddenContributors',
+      'cacheDimensions',
+      'implementationBoundary',
+      'specRefs',
+      'failureOwnerStepId'
+    ]
+    steps.forEach((step) => {
+      requiredStepFields.forEach((field) => {
+        if (step[field] === undefined)
+          errors.push(`${step.id}:missing:${field}`)
+      })
+      if (!laneById.has(step.laneId)) errors.push(`${step.id}:lane`)
+      if (!stepById.has(step.failureOwnerStepId)) {
+        errors.push(`${step.id}:failureOwnerStepId`)
+      }
+      step.inputs
+        .filter((input) => input.startsWith('artifact:'))
+        .forEach((artifactId) => {
+          if (!artifactById.has(artifactId)) {
+            errors.push(`${step.id}:input:${artifactId}`)
+          }
+        })
+      step.outputs.forEach((artifactId) => {
+        if (!artifactById.has(artifactId)) {
+          errors.push(`${step.id}:output:${artifactId}`)
+        }
+      })
+    })
+
+    routes.forEach((route) => {
+      if (!stepById.has(route.from)) errors.push(`${route.id}:from`)
+      if (route.to && !stepById.has(route.to)) errors.push(`${route.id}:to`)
+      route.producedArtifacts.forEach((artifactId) => {
+        const artifact = artifactById.get(artifactId)
+        if (!artifact) {
+          errors.push(`${route.id}:artifact:${artifactId}`)
+          return
+        }
+        if (artifact.ownerStepId !== route.from) {
+          errors.push(`${route.id}:artifact-owner:${artifactId}`)
+        }
+        if (route.to && !artifact.consumerStepIds.includes(route.to)) {
+          errors.push(`${route.id}:artifact-consumer:${artifactId}`)
+        }
+      })
+    })
+
+    artifacts.forEach((artifact) => {
+      const owner = stepById.get(artifact.ownerStepId)
+      if (!owner) {
+        errors.push(`${artifact.id}:owner`)
+      } else if (!owner.outputs.includes(artifact.id)) {
+        errors.push(`${artifact.id}:owner-output`)
+      }
+      artifact.consumerStepIds.forEach((stepId) => {
+        const consumer = stepById.get(stepId)
+        if (!consumer) {
+          errors.push(`${artifact.id}:consumer:${stepId}`)
+        } else if (!consumer.inputs.includes(artifact.id)) {
+          errors.push(`${artifact.id}:consumer-input:${stepId}`)
+        }
+      })
+      if (!artifact.terminal && !artifact.consumerStepIds.length) {
+        errors.push(`${artifact.id}:missing-consumer`)
+      }
+    })
+
+    invariants.forEach((invariant) => {
+      invariant.stepIds.forEach((stepId) => {
+        if (!stepById.has(stepId)) {
+          errors.push(`${invariant.id}:step:${stepId}`)
+        }
+      })
+      invariant.artifactIds.forEach((artifactId) => {
+        if (!artifactById.has(artifactId)) {
+          errors.push(`${invariant.id}:artifact:${artifactId}`)
+        }
+      })
+    })
+
+    acceptanceContracts.forEach((contract) => {
+      contract.stepIds.forEach((stepId) => {
+        if (!stepById.has(stepId)) {
+          errors.push(`${contract.id}:step:${stepId}`)
+        }
+      })
+    })
+
+    if (errors.length) {
+      console.error('Flow Inspector static check failed', {
+        target: target.id,
+        errors
+      })
+    } else {
+      console.info('Flow Inspector static check passed', {
+        target: target.id,
+        lanes: lanes.length,
+        steps: steps.length,
+        routes: routes.length,
+        artifacts: artifacts.length,
+        invariants: invariants.length,
+        acceptanceContracts: acceptanceContracts.length
+      })
+    }
+  }
+
+  const runLayoutChecks = () => {
+    const cards = [...flow.querySelectorAll('.step-card')].map((card) => {
+      const rect = card.getBoundingClientRect()
+      return {
+        id: card.dataset.stepId,
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom
+      }
+    })
+    const overlaps = []
+    cards.forEach((card, index) => {
+      cards.slice(index + 1).forEach((other) => {
+        const overlapX =
+          Math.min(card.right, other.right) - Math.max(card.left, other.left)
+        const overlapY =
+          Math.min(card.bottom, other.bottom) - Math.max(card.top, other.top)
+        if (overlapX > 8 && overlapY > 8) {
+          overlaps.push(`${card.id}:${other.id}`)
+        }
+      })
+    })
+    if (overlaps.length) {
+      console.error('Flow Inspector layout check failed', { overlaps })
+    } else {
+      console.info('Flow Inspector layout check passed', {
+        cards: cards.length
+      })
+    }
+  }
+
+  const render = () => {
+    renderHeader()
+    renderFilters()
+    renderFlow()
+    renderDetail()
+    runLayoutChecks()
+  }
+
+  runStaticChecks()
+  render()
+  window.addEventListener('resize', () => {
+    const svg = flow.querySelector('.flow-svg')
+    if (svg) renderEdges(svg)
+  })
+})()
+    </script>
+  </body>
+</html>

--- a/packages/core/src/__tests__/restore-owner-facades.test.ts
+++ b/packages/core/src/__tests__/restore-owner-facades.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  ElementPropertyOwnerRelation,
+  PropsRestorePlan,
+  PropsRestoreSnapshot,
+  SceneTreeRestorePlan,
+  SceneTreeRestoreSnapshot
+} from '@asyra/utils'
+import { createSceneTreeAPIs } from '../apis/scene-tree'
+import { createPropsAPIs } from '../apis/props'
+
+describe('remote restore owner facades', () => {
+  it('delegates Scene Tree plans only to the supplied owner requests', () => {
+    const snapshot = {
+      elementId: 'group-1',
+      removed: [],
+      rootParentChildrenAfter: []
+    } as unknown as SceneTreeRestoreSnapshot
+    const plan = Object.freeze({
+      kind: 'scene-tree-restore-plan',
+      elementId: 'group-1',
+      entries: Object.freeze([]),
+      propertyOwnerRelations: Object.freeze([])
+    }) as SceneTreeRestorePlan
+    const firstPreflight = vi.fn(() => plan)
+    const firstApply = vi.fn(() => ({
+      elementId: 'group-1',
+      removed: [],
+      rootParentChildrenAfter: []
+    }))
+    const secondPreflight = vi.fn()
+    const requests = {
+      sceneTreeSaveData: () => ({
+        workspace: '',
+        workspaceList: [],
+        elements: {}
+      }),
+      getElementComputedData: () => undefined,
+      moveElements: () => ({ elementIds: [], moves: [] }),
+      removeSubtree: () => ({
+        elementId: 'group-1',
+        removed: [],
+        rootParentChildrenAfter: []
+      }),
+      preflightRestoreSubtree: firstPreflight,
+      applyRestoreSubtree: firstApply,
+      refreshComputedDataFromProperty: () => undefined,
+      getAllElementsBounds: () => null,
+      isContainerType: () => false
+    }
+    const first = createSceneTreeAPIs(requests as never) as unknown as {
+      preflightRestoreSubtree: (
+        input: SceneTreeRestoreSnapshot
+      ) => SceneTreeRestorePlan
+      applyRestoreSubtree: (input: SceneTreeRestorePlan) => unknown
+    }
+    createSceneTreeAPIs({
+      ...requests,
+      preflightRestoreSubtree: secondPreflight
+    } as never)
+
+    expect(first.preflightRestoreSubtree(snapshot)).toBe(plan)
+    expect(first.applyRestoreSubtree(plan)).toEqual({
+      elementId: 'group-1',
+      removed: [],
+      rootParentChildrenAfter: []
+    })
+    expect(firstPreflight).toHaveBeenCalledWith(snapshot)
+    expect(firstApply).toHaveBeenCalledWith(plan, undefined)
+    expect(secondPreflight).not.toHaveBeenCalled()
+  })
+
+  it('delegates Props plans only to the supplied owner requests', () => {
+    const snapshot: PropsRestoreSnapshot = { components: [] }
+    const relations: readonly ElementPropertyOwnerRelation[] = []
+    const plan = Object.freeze({
+      kind: 'props-restore-plan',
+      entries: Object.freeze([]),
+      ownerRelations: Object.freeze([])
+    }) as PropsRestorePlan
+    const firstPreflight = vi.fn(() => plan)
+    const firstApply = vi.fn(() => Object.freeze([] as string[]))
+    const secondPreflight = vi.fn()
+    const requests = {
+      updatePropertyById: () => undefined,
+      commitPropertyChanges: () => undefined,
+      propsLoadData: () => undefined,
+      propsSaveData: () => ({}),
+      preflightRestoreProperties: firstPreflight,
+      applyRestoreProperties: firstApply
+    }
+    const first = createPropsAPIs(requests as never) as unknown as {
+      preflightRestoreProperties: (
+        input: PropsRestoreSnapshot,
+        ownerRelations: readonly ElementPropertyOwnerRelation[]
+      ) => PropsRestorePlan
+      applyRestoreProperties: (input: PropsRestorePlan) => readonly string[]
+    }
+    createPropsAPIs({
+      ...requests,
+      preflightRestoreProperties: secondPreflight
+    } as never)
+
+    expect(first.preflightRestoreProperties(snapshot, relations)).toBe(plan)
+    expect(first.applyRestoreProperties(plan)).toEqual([])
+    expect(firstPreflight).toHaveBeenCalledWith(snapshot, relations)
+    expect(firstApply).toHaveBeenCalledWith(plan, undefined)
+    expect(secondPreflight).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/__tests__/scene-tree-api.test.ts
+++ b/packages/core/src/__tests__/scene-tree-api.test.ts
@@ -13,8 +13,11 @@ const createRequests = (): SceneTreeRequests => ({
   moveElements: vi.fn(() => ({ elementIds: [], moves: [] })),
   removeSubtree: vi.fn((elementId: string) => ({
     elementId,
-    removed: []
+    removed: [],
+    rootParentChildrenAfter: []
   })),
+  preflightRestoreSubtree: vi.fn(),
+  applyRestoreSubtree: vi.fn(),
   refreshComputedDataFromProperty: () => undefined,
   getAllElementsBounds: () => null,
   isContainerType: () => false

--- a/packages/core/src/apis/create-apis.ts
+++ b/packages/core/src/apis/create-apis.ts
@@ -18,7 +18,7 @@ import {
 
 import { createPropsAPIs, type PropsRequests } from './props'
 import { createRenderAPIs, type RenderRequests } from './render'
-import { createSceneTreeAPIs } from './scene-tree'
+import { createSceneTreeAPIs, type SceneTreeRequests } from './scene-tree'
 import { createElementSelectionAPIs } from './element-selection'
 import { createInputSystemAPIs } from './input-system'
 import { createFeatureSystemAPIs } from './feature-system'
@@ -34,7 +34,7 @@ export const createAPIs = (
   props: PropsManager,
   factory: Factory
 ): CoreAPIs => {
-  const sceneTreeRequests = {
+  const sceneTreeRequests: SceneTreeRequests = {
     sceneTreeSaveData: () => sceneTree.save(),
     getElementComputedData: (elementId: string) =>
       sceneTree.getElementById(elementId)?.getAllComputedData() as
@@ -44,6 +44,10 @@ export const createAPIs = (
       sceneTree.moveElements(request, options),
     removeSubtree: (elementId: string, options?: EVENT_OPTIONS) =>
       sceneTree.removeSubtree(elementId, options),
+    preflightRestoreSubtree: (snapshot) =>
+      sceneTree.preflightRestoreSubtree(snapshot),
+    applyRestoreSubtree: (plan, options) =>
+      sceneTree.applyRestoreSubtree(plan, options),
     refreshComputedDataFromProperty: (
       elementId: string,
       propertyName: string,
@@ -107,7 +111,11 @@ export const createAPIs = (
     commitPropertyChanges: (options) => props.commitChanges(options),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     propsLoadData: (data: unknown) => props.load(data as any),
-    propsSaveData: () => props.save() as PropsComponentRawData
+    propsSaveData: () => props.save() as PropsComponentRawData,
+    preflightRestoreProperties: (snapshot, ownerRelations) =>
+      props.preflightRestoreProperties(snapshot, ownerRelations),
+    applyRestoreProperties: (plan, options) =>
+      props.applyRestoreProperties(plan, options)
   }
 
   return {

--- a/packages/core/src/apis/props.ts
+++ b/packages/core/src/apis/props.ts
@@ -1,7 +1,10 @@
 import type {
+  ElementPropertyOwnerRelation,
   EVENT_OPTIONS,
   PropertyComponentInstanceDataTypes,
-  PropsComponentRawData
+  PropsComponentRawData,
+  PropsRestorePlan,
+  PropsRestoreSnapshot
 } from '@asyra/utils'
 import type { PropertyFieldUpdate, PropertyOwnerRef } from '../types/props'
 
@@ -16,6 +19,14 @@ export interface PropsRequests {
   commitPropertyChanges: (options?: EVENT_OPTIONS) => void
   propsLoadData: (data: unknown) => void
   propsSaveData: () => PropsComponentRawData
+  preflightRestoreProperties: (
+    snapshot: PropsRestoreSnapshot,
+    ownerRelations: readonly ElementPropertyOwnerRelation[]
+  ) => PropsRestorePlan
+  applyRestoreProperties: (
+    plan: PropsRestorePlan,
+    options?: EVENT_OPTIONS
+  ) => readonly string[]
 }
 
 export const createPropsAPIs = (requests: PropsRequests) => ({
@@ -33,5 +44,14 @@ export const createPropsAPIs = (requests: PropsRequests) => ({
   },
   propsSaveData() {
     return requests.propsSaveData()
+  },
+  preflightRestoreProperties(
+    snapshot: PropsRestoreSnapshot,
+    ownerRelations: readonly ElementPropertyOwnerRelation[]
+  ) {
+    return requests.preflightRestoreProperties(snapshot, ownerRelations)
+  },
+  applyRestoreProperties(plan: PropsRestorePlan, options?: EVENT_OPTIONS) {
+    return requests.applyRestoreProperties(plan, options)
   }
 })

--- a/packages/core/src/apis/scene-tree.ts
+++ b/packages/core/src/apis/scene-tree.ts
@@ -19,7 +19,9 @@ import {
   id,
   MoveHierarchyRequest,
   MoveHierarchyResult,
-  RemoveSubtreeResult
+  RemoveSubtreeResult,
+  SceneTreeRestorePlan,
+  SceneTreeRestoreSnapshot
 } from '@asyra/utils'
 import { SceneTreeAPIs } from '../types'
 
@@ -41,6 +43,13 @@ export interface SceneTreeRequests {
   ) => MoveHierarchyResult
   removeSubtree: (
     elementId: string,
+    options?: EVENT_OPTIONS
+  ) => RemoveSubtreeResult
+  preflightRestoreSubtree: (
+    snapshot: SceneTreeRestoreSnapshot
+  ) => SceneTreeRestorePlan
+  applyRestoreSubtree: (
+    plan: SceneTreeRestorePlan,
     options?: EVENT_OPTIONS
   ) => RemoveSubtreeResult
 }
@@ -112,6 +121,12 @@ export const createSceneTreeAPIs = (
     },
     removeSubtree(elementId: string, options?: EVENT_OPTIONS) {
       return sceneTreeRequests.removeSubtree(elementId, options)
+    },
+    preflightRestoreSubtree(snapshot: SceneTreeRestoreSnapshot) {
+      return sceneTreeRequests.preflightRestoreSubtree(snapshot)
+    },
+    applyRestoreSubtree(plan: SceneTreeRestorePlan, options?: EVENT_OPTIONS) {
+      return sceneTreeRequests.applyRestoreSubtree(plan, options)
     },
     getAllElementsBounds() {
       return sceneTreeRequests.getAllElementsBounds()

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -204,6 +204,8 @@ class Core implements CoreAPIs {
   commitPropertyChanges!: CoreAPIs['commitPropertyChanges']
   propsLoadData!: CoreAPIs['propsLoadData']
   propsSaveData!: CoreAPIs['propsSaveData']
+  preflightRestoreProperties!: CoreAPIs['preflightRestoreProperties']
+  applyRestoreProperties!: CoreAPIs['applyRestoreProperties']
 
   sceneTreeInit!: SceneTreeAPIs['sceneTreeInit']
   sceneTreeLoadData!: SceneTreeAPIs['sceneTreeLoadData']
@@ -213,6 +215,8 @@ class Core implements CoreAPIs {
   getElementComputedData!: SceneTreeAPIs['getElementComputedData']
   moveElements!: SceneTreeAPIs['moveElements']
   removeSubtree!: SceneTreeAPIs['removeSubtree']
+  preflightRestoreSubtree!: SceneTreeAPIs['preflightRestoreSubtree']
+  applyRestoreSubtree!: SceneTreeAPIs['applyRestoreSubtree']
   changeComputedData!: SceneTreeAPIs['changeComputedData']
   changeComputedDataPatch!: SceneTreeAPIs['changeComputedDataPatch']
   refreshComputedDataFromProperty!: SceneTreeAPIs['refreshComputedDataFromProperty']

--- a/packages/core/src/types/props.ts
+++ b/packages/core/src/types/props.ts
@@ -1,5 +1,8 @@
 import {
+  ElementPropertyOwnerRelation,
   PropsComponentRawData,
+  PropsRestorePlan,
+  PropsRestoreSnapshot,
   type EVENT_OPTIONS,
   type PropertyComponentInstanceDataTypes
 } from '@asyra/utils'
@@ -30,6 +33,14 @@ export interface PropsRawAPIs {
     ...update: PropertyFieldUpdate<TFields>
   ) => void
   commitPropertyChanges: (options?: EVENT_OPTIONS) => void
+  preflightRestoreProperties: (
+    snapshot: PropsRestoreSnapshot,
+    ownerRelations: readonly ElementPropertyOwnerRelation[]
+  ) => PropsRestorePlan
+  applyRestoreProperties: (
+    plan: PropsRestorePlan,
+    options?: EVENT_OPTIONS
+  ) => readonly string[]
 }
 
 export type PropsAPIs = PropsRawAPIs

--- a/packages/core/src/types/scene-tree.ts
+++ b/packages/core/src/types/scene-tree.ts
@@ -8,7 +8,9 @@ import {
   EVENT_OPTIONS,
   MoveHierarchyRequest,
   MoveHierarchyResult,
-  RemoveSubtreeResult
+  RemoveSubtreeResult,
+  SceneTreeRestorePlan,
+  SceneTreeRestoreSnapshot
 } from '@asyra/utils'
 
 export interface SceneTreeRawAPIs {
@@ -36,6 +38,13 @@ export interface SceneTreeRawAPIs {
   ) => MoveHierarchyResult
   removeSubtree: (
     elementId: string,
+    options?: EVENT_OPTIONS
+  ) => RemoveSubtreeResult
+  preflightRestoreSubtree: (
+    snapshot: SceneTreeRestoreSnapshot
+  ) => SceneTreeRestorePlan
+  applyRestoreSubtree: (
+    plan: SceneTreeRestorePlan,
     options?: EVENT_OPTIONS
   ) => RemoveSubtreeResult
   changeComputedData: (

--- a/packages/factory/src/__tests__/data-transact.test.ts
+++ b/packages/factory/src/__tests__/data-transact.test.ts
@@ -102,6 +102,7 @@ describe('DataTransact hierarchy replay', () => {
         }
       }
     ]
+    const rootParentChildrenAfter = ['element-a']
 
     runWithOwnedTransact(transact, () => {
       transact.start()
@@ -122,7 +123,8 @@ describe('DataTransact hierarchy replay', () => {
           undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
           eventName: EventTypes.CHANGE_SUBTREE,
           elementId: 'group-b',
-          removed
+          removed,
+          rootParentChildrenAfter
         }
       })
       transact.end()
@@ -137,7 +139,8 @@ describe('DataTransact hierarchy replay', () => {
         payload: expect.objectContaining({
           action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
           undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
-          removed
+          removed,
+          rootParentChildrenAfter
         })
       },
       {
@@ -161,7 +164,8 @@ describe('DataTransact hierarchy replay', () => {
         payload: expect.objectContaining({
           action: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
           undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
-          removed
+          removed,
+          rootParentChildrenAfter
         })
       }
     ])

--- a/packages/factory/src/__tests__/factory.test.ts
+++ b/packages/factory/src/__tests__/factory.test.ts
@@ -11,7 +11,11 @@ import {
   UpdateTransactionEvent,
   TransactionEventTypes
 } from '@asyra/reactive-events'
-import { SCENE_TREE_ACTIONS, SharedDataChannelNames } from '@asyra/utils'
+import {
+  PROPS_ACTIONS,
+  SCENE_TREE_ACTIONS,
+  SharedDataChannelNames
+} from '@asyra/utils'
 
 describe('Factory', () => {
   let factory: Factory
@@ -73,6 +77,185 @@ describe('Factory', () => {
         rollbackableChangeCount: 1
       })
     ])
+  })
+
+  it('settles Props before Scene without undo history or outbound publication', () => {
+    const projections: string[] = []
+    const publications: unknown[] = []
+    const statuses: unknown[] = []
+    const propsChannel = new LocalSharedDataChannel()
+    const sceneChannel = new LocalSharedDataChannel()
+    factory.registerSharedDataChannel(
+      SharedDataChannelNames.PROPS,
+      propsChannel
+    )
+    factory.registerSharedDataChannel(
+      SharedDataChannelNames.SCENE_TREE,
+      sceneChannel
+    )
+    propsChannel.observe(() => projections.push('props'))
+    sceneChannel.observe(() => projections.push('scene'))
+    factory.subscribeToSharedPublication((value) => publications.push(value))
+    factory.subscribeToTransactionStatus((value) => statuses.push(value))
+    const replay = vi.fn(() => true)
+    factory.registerTransactionReplayHandler(EventTypes.REMOVE_PROPERTY, replay)
+    factory.registerTransactionReplayHandler(EventTypes.CHANGE_SUBTREE, replay)
+
+    factory.runRemoteTransaction(() => {
+      updateTransaction(
+        EventTypes.ADD_PROPERTY,
+        {
+          action: PROPS_ACTIONS.ADD_PROPERTY,
+          undoType: EventTypes.REMOVE_PROPERTY,
+          undoAction: PROPS_ACTIONS.REMOVE_PROPERTY,
+          eventName: EventTypes.ADD_PROPERTY,
+          data: [{ id: 'position-group-a', type: 'position' }]
+        },
+        {
+          shared: SharedDataChannelNames.PROPS,
+          undoable: true,
+          rollbackable: false
+        }
+      )
+      updateTransaction(
+        EventTypes.CHANGE_SUBTREE,
+        {
+          action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+          undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
+          eventName: EventTypes.CHANGE_SUBTREE,
+          elementId: 'group-a',
+          removed: [
+            {
+              elementId: 'group-a',
+              parentId: 'workspace-a',
+              index: 0,
+              data: {
+                id: 'group-a',
+                type: 'group',
+                parentId: 'workspace-a',
+                children: []
+              }
+            }
+          ],
+          rootParentChildrenAfter: []
+        },
+        {
+          shared: SharedDataChannelNames.SCENE_TREE,
+          undoable: true,
+          rollbackable: false
+        }
+      )
+    })
+
+    expect(projections).toEqual(['props', 'scene'])
+    expect(publications).toEqual([])
+    expect(statuses).toEqual([
+      expect.objectContaining({
+        origin: 'remote',
+        status: 'committed',
+        undoableChangeCount: 0,
+        rollbackableChangeCount: 2
+      })
+    ])
+
+    factory.undo()
+    expect(replay).not.toHaveBeenCalled()
+    expect(publications).toEqual([])
+  })
+
+  it('rolls back both restored owners when remote settlement fails', () => {
+    let propsActive = false
+    let sceneActive = false
+    const rollbackOrder: string[] = []
+    const projections: string[] = []
+    const publications: unknown[] = []
+    const propsChannel = new LocalSharedDataChannel()
+    const sceneChannel = new LocalSharedDataChannel()
+    factory.registerSharedDataChannel(
+      SharedDataChannelNames.PROPS,
+      propsChannel
+    )
+    factory.registerSharedDataChannel(
+      SharedDataChannelNames.SCENE_TREE,
+      sceneChannel
+    )
+    propsChannel.observe(() => projections.push('props'))
+    sceneChannel.observe(() => projections.push('scene'))
+    factory.subscribeToSharedPublication((value) => publications.push(value))
+    factory.registerTransactionReplayHandler(
+      EventTypes.REMOVE_PROPERTY,
+      (_event, mode) => {
+        expect(mode).toBe('rollback')
+        propsActive = false
+        rollbackOrder.push('props')
+        return true
+      }
+    )
+    factory.registerTransactionReplayHandler(
+      EventTypes.CHANGE_SUBTREE,
+      (event, mode) => {
+        expect(mode).toBe('rollback')
+        expect((event as { payload: unknown }).payload).toEqual(
+          expect.objectContaining({
+            action: SCENE_TREE_ACTIONS.REMOVE_SUBTREE
+          })
+        )
+        sceneActive = false
+        rollbackOrder.push('scene')
+        return true
+      }
+    )
+
+    expect(() =>
+      factory.runRemoteTransaction(() => {
+        propsActive = true
+        updateTransaction(
+          EventTypes.ADD_PROPERTY,
+          {
+            action: PROPS_ACTIONS.ADD_PROPERTY,
+            undoType: EventTypes.REMOVE_PROPERTY,
+            undoAction: PROPS_ACTIONS.REMOVE_PROPERTY,
+            eventName: EventTypes.ADD_PROPERTY,
+            data: [{ id: 'position-group-a', type: 'position' }]
+          },
+          { shared: SharedDataChannelNames.PROPS }
+        )
+        sceneActive = true
+        updateTransaction(
+          EventTypes.CHANGE_SUBTREE,
+          {
+            action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+            undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
+            eventName: EventTypes.CHANGE_SUBTREE,
+            elementId: 'group-a',
+            removed: [
+              {
+                elementId: 'group-a',
+                parentId: 'workspace-a',
+                index: 0,
+                data: {
+                  id: 'group-a',
+                  type: 'group',
+                  parentId: 'workspace-a',
+                  children: []
+                }
+              }
+            ],
+            rootParentChildrenAfter: []
+          },
+          { shared: SharedDataChannelNames.SCENE_TREE }
+        )
+        throw new Error('remote restore settlement failed')
+      })
+    ).toThrow('remote restore settlement failed')
+
+    expect({ propsActive, sceneActive }).toEqual({
+      propsActive: false,
+      sceneActive: false
+    })
+    expect(rollbackOrder).toEqual(['scene', 'props'])
+    expect(projections).toEqual([])
+    expect(publications).toEqual([])
   })
 
   it('publishes the remote transaction end after shared projections settle', () => {

--- a/packages/factory/src/__tests__/shared-publication.test.ts
+++ b/packages/factory/src/__tests__/shared-publication.test.ts
@@ -4,7 +4,11 @@ import {
   TransactionEventTypes,
   subscribeToUserActionCompleted
 } from '@asyra/reactive-events'
-import { SCENE_TREE_ACTIONS, SharedDataChannelNames } from '@asyra/utils'
+import {
+  PROPS_ACTIONS,
+  SCENE_TREE_ACTIONS,
+  SharedDataChannelNames
+} from '@asyra/utils'
 import { Factory, LocalSharedDataChannel, type SharedPublication } from '..'
 
 const update = (
@@ -71,7 +75,8 @@ describe('Factory action-level shared publication', () => {
         undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
         eventName: EventTypes.CHANGE_SUBTREE,
         elementId: 'group-b',
-        removed: []
+        removed: [],
+        rootParentChildrenAfter: []
       },
       options: { shared: SharedDataChannelNames.SCENE_TREE }
     })
@@ -216,6 +221,109 @@ describe('Factory action-level shared publication', () => {
           }),
           expect.objectContaining({
             payload: expect.objectContaining({ id: 'element-a' })
+          })
+        ]
+      })
+    )
+  })
+
+  it('publishes exact Props-before-Scene subtree restore evidence in one undo batch', () => {
+    const { factory, publications } = createHarness()
+    factory.registerSharedDataChannel(
+      SharedDataChannelNames.PROPS,
+      new LocalSharedDataChannel()
+    )
+    factory.registerTransactionReplayHandler(
+      EventTypes.ADD_PROPERTY,
+      () => true
+    )
+    factory.registerTransactionReplayHandler(
+      EventTypes.CHANGE_SUBTREE,
+      () => true
+    )
+    const propertyData = {
+      id: 'position-b',
+      type: 'position',
+      x: 12,
+      y: 24
+    }
+    const rootParentChildrenAfter = ['element-a', 'element-c']
+
+    factory.startTransaction()
+    factory.updateTransaction({
+      type: TransactionEventTypes.UPDATE_TRANSACTION,
+      eventName: EventTypes.CHANGE_SUBTREE,
+      payload: {
+        action: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
+        undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+        eventName: EventTypes.CHANGE_SUBTREE,
+        elementId: 'group-b',
+        removed: [
+          {
+            elementId: 'group-b',
+            parentId: 'workspace',
+            index: 1,
+            data: {
+              id: 'group-b',
+              type: 'group',
+              name: 'Group B',
+              parentId: 'workspace',
+              visible: true,
+              lock: false,
+              children: [],
+              props: { position: 'position-b' }
+            }
+          }
+        ],
+        rootParentChildrenAfter
+      },
+      options: { shared: SharedDataChannelNames.SCENE_TREE }
+    })
+    factory.updateTransaction({
+      type: TransactionEventTypes.UPDATE_TRANSACTION,
+      eventName: EventTypes.REMOVE_PROPERTY,
+      payload: {
+        action: PROPS_ACTIONS.REMOVE_PROPERTY,
+        undoType: EventTypes.ADD_PROPERTY,
+        undoAction: PROPS_ACTIONS.ADD_PROPERTY,
+        eventName: EventTypes.REMOVE_PROPERTY,
+        data: [propertyData]
+      },
+      options: { shared: SharedDataChannelNames.PROPS }
+    })
+    factory.endTransaction()
+    publications.length = 0
+
+    propertyData.x = 999
+    rootParentChildrenAfter.push('later-runtime-element')
+    factory.undo()
+
+    expect(publications).toHaveLength(1)
+    expect(publications[0]).toEqual(
+      expect.objectContaining({
+        origin: 'undo',
+        deliveries: [
+          expect.objectContaining({
+            channel: SharedDataChannelNames.PROPS,
+            eventName: EventTypes.ADD_PROPERTY,
+            payload: expect.objectContaining({
+              action: PROPS_ACTIONS.ADD_PROPERTY,
+              data: [
+                expect.objectContaining({
+                  id: 'position-b',
+                  x: 12,
+                  y: 24
+                })
+              ]
+            })
+          }),
+          expect.objectContaining({
+            channel: SharedDataChannelNames.SCENE_TREE,
+            eventName: EventTypes.CHANGE_SUBTREE,
+            payload: expect.objectContaining({
+              action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+              rootParentChildrenAfter: ['element-a', 'element-c']
+            })
           })
         ]
       })

--- a/packages/factory/src/__tests__/shared-publication.test.ts
+++ b/packages/factory/src/__tests__/shared-publication.test.ts
@@ -308,6 +308,7 @@ describe('Factory action-level shared publication', () => {
             eventName: EventTypes.ADD_PROPERTY,
             payload: expect.objectContaining({
               action: PROPS_ACTIONS.ADD_PROPERTY,
+              eventName: EventTypes.ADD_PROPERTY,
               data: [
                 expect.objectContaining({
                   id: 'position-b',

--- a/packages/factory/src/data-transact.ts
+++ b/packages/factory/src/data-transact.ts
@@ -674,6 +674,9 @@ class DataTransact {
       const originalType = replayEvent.type
       replayEvent.type = payload.undoType as AllEvent['type']
       ;(payload as { undoType?: unknown }).undoType = originalType
+      if ('eventName' in payload) {
+        ;(payload as { eventName?: unknown }).eventName = replayEvent.type
+      }
     }
     if ('undoAction' in payload && payload.undoAction !== undefined) {
       const originalAction = (payload as { action?: unknown }).action

--- a/packages/preset/src/__tests__/children-map-property-component.test.ts
+++ b/packages/preset/src/__tests__/children-map-property-component.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import core from '@asyra/core'
 import { PropertyTypes, type SetterChangeRecord } from '@asyra/utils'
 import { vectorPointsPropertyComponentDefinition } from '../props/components/vector-points-component'
 
@@ -29,5 +30,45 @@ describe('children-map property component', () => {
         after: ['vector-point-a']
       })
     ])
+  })
+
+  it('projects child values from the issuing Props Manager', () => {
+    const PropsManager = core.deps.props
+      .constructor as new () => typeof core.deps.props
+    const createChild = (value: number) =>
+      ({
+        get: (key: string) => {
+          if (key === 'id') return 'shared-point'
+          if (key === 'type') return PropertyTypes.VECTOR_POINT
+          if (key === 'kind') return 'anchor'
+          if (key === 'x') return value
+          if (key === 'y') return 0
+          if (key === 'anchorType') return 'sharp'
+          if (key === 'handleMode') return 'none'
+        },
+        on: () => () => undefined
+      }) as never
+    const createComposition = (value: number) => {
+      const manager = new PropsManager()
+      manager.addToMap(createChild(value))
+      const parent = createVectorPointsComponent()
+      parent.load({
+        id: 'vector-points-parent',
+        type: PropertyTypes.VECTOR_POINTS,
+        points: ['shared-point']
+      })
+      manager.addToMap(parent)
+      manager.cleanChanges()
+      return { manager, parent }
+    }
+    const first = createComposition(1)
+    const second = createComposition(2)
+
+    expect(first.parent.getValue().points).toEqual({
+      'shared-point': expect.objectContaining({ id: 'shared-point', x: 1 })
+    })
+    expect(second.parent.getValue().points).toEqual({
+      'shared-point': expect.objectContaining({ id: 'shared-point', x: 2 })
+    })
   })
 })

--- a/packages/preset/src/__tests__/selection-subscriptions.test.ts
+++ b/packages/preset/src/__tests__/selection-subscriptions.test.ts
@@ -336,6 +336,7 @@ describe('Preset Selection Subscriptions', () => {
         undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
         eventName: EventTypes.CHANGE_SUBTREE,
         elementId: 'group-1',
+        rootParentChildrenAfter: [],
         removed: [
           {
             elementId: 'group-1',
@@ -346,6 +347,12 @@ describe('Preset Selection Subscriptions', () => {
         ]
       }
       observer?.onChange(subtreeChange)
+      const restoreSubtreeChange = {
+        ...subtreeChange,
+        action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+        undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE
+      }
+      observer?.onChange(restoreSubtreeChange)
 
       expect(add).toHaveBeenCalledWith('vector-1', 'group-1', 1)
       expect(scalar).toHaveBeenCalledWith(
@@ -383,7 +390,8 @@ describe('Preset Selection Subscriptions', () => {
         1
       )
       expect(move).toHaveBeenCalledWith(moves)
-      expect(subtree).toHaveBeenCalledWith(subtreeChange)
+      expect(subtree).toHaveBeenNthCalledWith(1, subtreeChange)
+      expect(subtree).toHaveBeenNthCalledWith(2, restoreSubtreeChange)
       expect(counters).toEqual([
         'render-projection-outcome-applied',
         'render-projection-outcome-resynced',
@@ -391,6 +399,7 @@ describe('Preset Selection Subscriptions', () => {
         'render-projection-outcome-failed',
         'render-projection-outcome-removed',
         'render-projection-outcome-applied',
+        'render-projection-outcome-removed',
         'render-projection-outcome-removed'
       ])
     } finally {
@@ -545,6 +554,7 @@ describe('Preset Selection Subscriptions', () => {
         undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
         eventName: EventTypes.CHANGE_SUBTREE,
         elementId: 'group-1',
+        rootParentChildrenAfter: [],
         removed: [
           {
             elementId: 'rect-1',
@@ -589,6 +599,7 @@ describe('Preset Selection Subscriptions', () => {
         undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
         eventName: EventTypes.CHANGE_SUBTREE,
         elementId: 'group-1',
+        rootParentChildrenAfter: [],
         removed: [
           {
             elementId: 'rect-1',

--- a/packages/preset/src/props/components/children-map-property-component.ts
+++ b/packages/preset/src/props/components/children-map-property-component.ts
@@ -1,6 +1,5 @@
 import {
   BasePropertyComponent,
-  getPropertyComponentAccessor,
   type PropertyComponentDefinition
 } from '@asyra/core'
 import {
@@ -136,7 +135,7 @@ export const createChildrenMapPropertyComponentDefinition = (
     }
 
     private upsertChildren(entries: ChildEntry[]): string[] {
-      const accessor = getPropertyComponentAccessor()
+      const accessor = this.propertyComponentAccessor
       const nextIds: string[] = []
 
       entries.forEach((entry) => {
@@ -212,7 +211,7 @@ export const createChildrenMapPropertyComponentDefinition = (
         this.childSubscriptions.delete(childId)
       })
 
-      const accessor = getPropertyComponentAccessor()
+      const accessor = this.propertyComponentAccessor
       nextIds.forEach((childId) => {
         if (this.childSubscriptions.has(childId)) {
           return
@@ -292,7 +291,7 @@ export const createChildrenMapPropertyComponentDefinition = (
     }
 
     getValue(): Record<string, DataTypes> {
-      const accessor = getPropertyComponentAccessor()
+      const accessor = this.propertyComponentAccessor
       const value: Record<string, unknown> = {}
 
       this.getChildIds().forEach((childId) => {

--- a/packages/props-manager/src/__tests__/property-type-redefinition.test.ts
+++ b/packages/props-manager/src/__tests__/property-type-redefinition.test.ts
@@ -578,6 +578,33 @@ describe('declarative property type definition owner', () => {
     ])
   })
 
+  it('keeps declarative child projection on the issuing Props Manager', () => {
+    registerDeclarativeType()
+    registerPropertyComponent(CHILD_TYPE, ChildComponent)
+    commitDeclarativePropertyTypeDefinition(TYPE, nextDefinition())
+    const firstManager = new PropsManager()
+    const secondManager = new PropsManager()
+    const createParent = (manager: PropsManager, childValue: number) => {
+      const parent = manager.createProperty({
+        id: 'shared-parent',
+        type: TYPE,
+        children: [{ id: 'shared-child', value: childValue }]
+      })
+      manager.addProperty([parent])
+      manager.cleanChanges()
+      return parent
+    }
+    const firstParent = createParent(firstManager, 1)
+    const secondParent = createParent(secondManager, 2)
+
+    expect(firstParent.getValue().children).toEqual([
+      { id: 'shared-child', value: 1 }
+    ])
+    expect(secondParent.getValue().children).toEqual([
+      { id: 'shared-child', value: 2 }
+    ])
+  })
+
   it('treats validator exceptions as invalid runtime and load values', () => {
     registerDeclarativeType()
     const throwingDefinition: PropertyTypeDefinition = {

--- a/packages/props-manager/src/__tests__/props-manager.test.ts
+++ b/packages/props-manager/src/__tests__/props-manager.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@asyra/utils'
 import { PropsManager } from '../manager/props-manager'
 import { createProperty } from '../factories/create-property'
+import elementPropertyRegistry from '../registries/property-definition'
 import {
   propertySchemaRegistry,
   registerPropertySchema
@@ -126,7 +127,15 @@ const registerTestPropertyComponents = () => {
   propertyComponentRegistry.clear()
   registerPropertyComponent(PropertyTypes.POSITION, PositionComponent)
   registerPropertyComponent(PropertyTypes.DIMENSION, DimensionComponent)
-  registerPropertyComponent(PropertyTypes.CUSTOM, CustomComponent)
+  registerPropertyComponent(PropertyTypes.CUSTOM, CustomComponent, undefined, {
+    type: PropertyTypes.CUSTOM,
+    persistKeys: ['children'],
+    children: {
+      key: 'children',
+      childType: PropertyTypes.POSITION,
+      mode: 'ids'
+    }
+  })
   registerPropertyComponent(PropertyTypes.ANCHOR_POINT, AnchorPointComponent)
   registerPropertyComponent(PropertyTypes.ANCHOR_POINTS, AnchorPointsComponent)
 }
@@ -138,6 +147,14 @@ describe('PropsManager', () => {
     vi.clearAllMocks()
     registerTestPropertyComponents()
     registerTestSchemas()
+    elementPropertyRegistry.unregisterComponent('restore-test-element')
+    elementPropertyRegistry.register(
+      {
+        name: 'custom',
+        type: PropertyTypes.CUSTOM
+      },
+      'restore-test-element'
+    )
 
     propsManager = new PropsManager()
   })
@@ -503,6 +520,132 @@ describe('PropsManager', () => {
         data: [expect.objectContaining({ id: 'pp-2' })]
       })
     ])
+  })
+
+  describe('restore preflight', () => {
+    const ownerRelations = [
+      {
+        ownerElementId: 'element-restore',
+        ownerElementType: 'restore-test-element',
+        ownerPropertyName: 'custom',
+        componentId: 'custom-restore'
+      }
+    ]
+    const preflight = (
+      manager: PropsManager,
+      components: readonly unknown[],
+      relations: readonly unknown[] = ownerRelations
+    ) =>
+      (
+        manager as unknown as {
+          preflightRestoreProperties: (
+            snapshot: unknown,
+            ownerRelations: unknown
+          ) => {
+            entries: readonly {
+              componentId: string
+              strategy: 'reuse' | 'materialize'
+            }[]
+          }
+        }
+      ).preflightRestoreProperties({ components }, relations)
+
+    it('prepares exact known-data materialization including registered child relations', () => {
+      const components = [
+        {
+          id: 'position-child',
+          type: PropertyTypes.POSITION,
+          x: 10,
+          y: 20,
+          xUnit: Unit.PX,
+          yUnit: Unit.PX
+        },
+        {
+          id: 'custom-restore',
+          type: PropertyTypes.CUSTOM,
+          children: ['position-child'],
+          nested: { value: 42 }
+        }
+      ]
+      const before = propsManager.save()
+
+      const plan = preflight(propsManager, components)
+
+      expect(plan.entries).toEqual([
+        { componentId: 'position-child', strategy: 'materialize' },
+        { componentId: 'custom-restore', strategy: 'materialize' }
+      ])
+      expect(propsManager.save()).toEqual(before)
+    })
+
+    it('selects an exact tombstone and accepts an explicit property-free snapshot', () => {
+      const component = new CustomComponent({
+        id: 'custom-restore',
+        type: PropertyTypes.CUSTOM,
+        children: []
+      } as Partial<PropertyComponentInstanceDataTypes>)
+      propsManager.addToMap(component)
+      const exactData = component.save()
+      propsManager.removeProperty(['custom-restore'])
+      propsManager.cleanChanges()
+      const before = propsManager.save()
+
+      expect(preflight(propsManager, [exactData]).entries).toEqual([
+        { componentId: 'custom-restore', strategy: 'reuse' }
+      ])
+      expect(preflight(propsManager, [], []).entries).toEqual([])
+      expect(propsManager.save()).toEqual(before)
+    })
+
+    it('rejects duplicate, active, incompatible, unregistered, and malformed relation evidence without mutation', () => {
+      const exact = {
+        id: 'custom-restore',
+        type: PropertyTypes.CUSTOM,
+        children: []
+      }
+      const expectRejected = (
+        manager: PropsManager,
+        components: readonly unknown[],
+        pattern: RegExp,
+        relations: readonly unknown[] = ownerRelations
+      ) => {
+        const before = manager.save()
+        expect(() => preflight(manager, components, relations)).toThrow(pattern)
+        expect(manager.save()).toEqual(before)
+      }
+
+      expectRejected(propsManager, [exact, exact], /duplicate/i)
+      expectRejected(
+        propsManager,
+        [{ ...exact, type: 'missing-property-type' }],
+        /unregistered/i
+      )
+      expectRejected(
+        propsManager,
+        [{ ...exact, children: ['missing-child'] }],
+        /missing.*child/i
+      )
+      expectRejected(propsManager, [exact], /missing owner relation/i, [])
+
+      const activeManager = new PropsManager()
+      activeManager.addToMap(
+        new CustomComponent(
+          exact as Partial<PropertyComponentInstanceDataTypes>
+        )
+      )
+      activeManager.cleanChanges()
+      expectRejected(activeManager, [exact], /active property/i)
+
+      const tombstoneManager = new PropsManager()
+      const tombstone = new CustomComponent({
+        ...exact,
+        nested: { value: 1 }
+      } as Partial<PropertyComponentInstanceDataTypes>)
+      tombstoneManager.addToMap(tombstone)
+      tombstoneManager.removeProperty(['custom-restore'])
+      tombstoneManager.cleanChanges()
+      expectRejected(tombstoneManager, [exact], /incompatible tombstone/i)
+    })
   })
 
   // Test updatePropsData

--- a/packages/props-manager/src/__tests__/props-manager.test.ts
+++ b/packages/props-manager/src/__tests__/props-manager.test.ts
@@ -11,6 +11,7 @@ import {
   PropsChange
 } from '@asyra/utils'
 import { PropsManager } from '../manager/props-manager'
+import { getPropertyComponentAccessor } from '../manager/component-accessor'
 import { createProperty } from '../factories/create-property'
 import elementPropertyRegistry from '../registries/property-definition'
 import {
@@ -549,6 +550,14 @@ describe('PropsManager', () => {
           }
         }
       ).preflightRestoreProperties({ components }, relations)
+    const apply = (manager: PropsManager, plan: ReturnType<typeof preflight>) =>
+      (
+        manager as unknown as {
+          applyRestoreProperties: (
+            artifact: ReturnType<typeof preflight>
+          ) => readonly string[]
+        }
+      ).applyRestoreProperties(plan)
 
     it('prepares exact known-data materialization including registered child relations', () => {
       const components = [
@@ -645,6 +654,163 @@ describe('PropsManager', () => {
       tombstoneManager.removeProperty(['custom-restore'])
       tombstoneManager.cleanChanges()
       expectRejected(tombstoneManager, [exact], /incompatible tombstone/i)
+    })
+
+    it('materializes exact data only in the issuing manager and consumes the plan once', () => {
+      const exact = {
+        id: 'custom-restore',
+        type: PropertyTypes.CUSTOM,
+        children: [],
+        nested: { value: 42 }
+      }
+      const plan = preflight(propsManager, [exact])
+      const otherManager = new PropsManager()
+
+      expect(() => apply(otherManager, plan)).toThrow(/owner-issued one-shot/i)
+      expect(otherManager.save()).toEqual({})
+
+      expect(apply(propsManager, plan)).toEqual(['custom-restore'])
+      expect(propsManager.save()).toEqual({
+        'custom-restore': exact
+      })
+      expect(() => apply(propsManager, plan)).toThrow(/owner-issued one-shot/i)
+    })
+
+    it('reuses the compatible tombstone identity without creating a replacement id', () => {
+      const tombstone = new CustomComponent({
+        id: 'custom-restore',
+        type: PropertyTypes.CUSTOM,
+        children: [],
+        nested: { value: 42 }
+      } as Partial<PropertyComponentInstanceDataTypes>)
+      propsManager.addToMap(tombstone)
+      const exact = tombstone.save()
+      propsManager.removeProperty(['custom-restore'])
+      propsManager.cleanChanges()
+      const plan = preflight(propsManager, [exact])
+
+      apply(propsManager, plan)
+
+      expect(propsManager.getPropertyById('custom-restore')).toBe(tombstone)
+      expect(propsManager.save()).toEqual({
+        'custom-restore': exact
+      })
+    })
+
+    it('constructs every materialization candidate before canonical map mutation', () => {
+      const throwingType = 'throwing-restore-property'
+      class ThrowingRestoreComponent extends CustomComponent {
+        constructor(data: Partial<PropertyComponentInstanceDataTypes>) {
+          super(data)
+          throw new Error('restore constructor failed')
+        }
+      }
+      registerPropertyComponent(throwingType, ThrowingRestoreComponent)
+      elementPropertyRegistry.register(
+        {
+          name: 'throwing',
+          type: throwingType
+        },
+        'restore-test-element'
+      )
+      const relations = [
+        ...ownerRelations,
+        {
+          ownerElementId: 'element-restore',
+          ownerElementType: 'restore-test-element',
+          ownerPropertyName: 'throwing',
+          componentId: 'throwing-restore'
+        }
+      ]
+      const plan = preflight(
+        propsManager,
+        [
+          {
+            id: 'custom-restore',
+            type: PropertyTypes.CUSTOM,
+            children: []
+          },
+          {
+            id: 'throwing-restore',
+            type: throwingType
+          }
+        ],
+        relations
+      )
+
+      expect(() => apply(propsManager, plan)).toThrow(
+        /restore constructor failed/i
+      )
+      expect(propsManager.save()).toEqual({})
+    })
+
+    it('constructs materialized components with the issuing manager accessor', () => {
+      const probeType = 'restore-accessor-probe'
+      class RestoreAccessorProbe extends CustomComponent {
+        constructor(data: Partial<PropertyComponentInstanceDataTypes>) {
+          super(data)
+          ;(this.data as unknown as Record<string, unknown>).type = probeType
+          const sharedPosition = getPropertyComponentAccessor().getPropertyById(
+            'shared-position'
+          ) as unknown as { get: (key: string) => unknown } | undefined
+          ;(this.data as unknown as Record<string, unknown>).resolvedX =
+            sharedPosition?.get('x')
+        }
+      }
+      registerPropertyComponent(probeType, RestoreAccessorProbe)
+      elementPropertyRegistry.register(
+        { name: 'probe', type: probeType },
+        'restore-test-element'
+      )
+      propsManager.addToMap(
+        new PositionComponent({
+          id: 'shared-position',
+          type: PropertyTypes.POSITION,
+          x: 1,
+          y: 0,
+          xUnit: Unit.PX,
+          yUnit: Unit.PX
+        })
+      )
+      propsManager.cleanChanges()
+
+      const otherManager = new PropsManager()
+      otherManager.addToMap(
+        new PositionComponent({
+          id: 'shared-position',
+          type: PropertyTypes.POSITION,
+          x: 2,
+          y: 0,
+          xUnit: Unit.PX,
+          yUnit: Unit.PX
+        })
+      )
+      const plan = preflight(
+        propsManager,
+        [
+          {
+            id: 'probe-restore',
+            type: probeType,
+            resolvedX: 1
+          }
+        ],
+        [
+          {
+            ownerElementId: 'element-restore',
+            ownerElementType: 'restore-test-element',
+            ownerPropertyName: 'probe',
+            componentId: 'probe-restore'
+          }
+        ]
+      )
+
+      expect(apply(propsManager, plan)).toEqual(['probe-restore'])
+      expect(propsManager.save()['probe-restore']).toEqual({
+        id: 'probe-restore',
+        type: probeType,
+        resolvedX: 1
+      })
+      expect(otherManager.getPropertyById('probe-restore')).toBeUndefined()
     })
   })
 

--- a/packages/props-manager/src/__tests__/props-manager.test.ts
+++ b/packages/props-manager/src/__tests__/props-manager.test.ts
@@ -298,7 +298,7 @@ describe('PropsManager', () => {
 
     const evidence = (
       propsManager.changes[0] as PropsChange & {
-        data: Array<Record<string, unknown>>
+        data: Record<string, unknown>[]
       }
     ).data[0]
     expect(evidence).toEqual({

--- a/packages/props-manager/src/__tests__/props-manager.test.ts
+++ b/packages/props-manager/src/__tests__/props-manager.test.ts
@@ -265,6 +265,39 @@ describe('PropsManager', () => {
     expect(propsManager.changes[0].action).toBe(PROPS_ACTIONS.REMOVE_PROPERTY)
   })
 
+  it('captures detached exact remove evidence before later runtime mutation', () => {
+    const nestedValue = {
+      points: [{ x: 10, y: 20 }]
+    }
+    const component = new CustomComponent({
+      id: 'pp-detached',
+      type: PropertyTypes.CUSTOM,
+      nestedValue
+    } as Partial<PropertyComponentInstanceDataTypes>)
+    propsManager.addToMap(component)
+
+    propsManager.removeProperty(['pp-detached'])
+
+    const evidence = (
+      propsManager.changes[0] as PropsChange & {
+        data: Array<Record<string, unknown>>
+      }
+    ).data[0]
+    expect(evidence).toEqual({
+      id: 'pp-detached',
+      type: PropertyTypes.CUSTOM,
+      nestedValue: {
+        points: [{ x: 10, y: 20 }]
+      }
+    })
+    expect(evidence.nestedValue).not.toBe(nestedValue)
+
+    nestedValue.points[0].x = 99
+    expect(evidence.nestedValue).toEqual({
+      points: [{ x: 10, y: 20 }]
+    })
+  })
+
   // Test component management
   it('should get a component by ID', () => {
     const p1Data = {

--- a/packages/props-manager/src/__tests__/subscribes.test.ts
+++ b/packages/props-manager/src/__tests__/subscribes.test.ts
@@ -2,10 +2,19 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   endTransaction,
   EventTypes,
-  startTransaction
+  publishEvent,
+  runInTransactionReplayMode,
+  startTransaction,
+  subscribeToEvents
 } from '@asyra/reactive-events'
-import type { PropsChange } from '@asyra/utils'
+import {
+  PROPS_ACTIONS,
+  PropertyTypes,
+  Unit,
+  type PropsChange
+} from '@asyra/utils'
 import propsManager from '..'
+import { PositionComponent } from './helpers/test-property-components'
 
 describe('props-manager subscribes', () => {
   beforeEach(() => {
@@ -29,5 +38,64 @@ describe('props-manager subscribes', () => {
     endTransaction()
 
     expect(propsManager.changes).toHaveLength(0)
+  })
+
+  it('records the exact tombstone snapshot restored by an ADD_PROPERTY replay', () => {
+    const restored = new PositionComponent({
+      id: 'group-position',
+      type: PropertyTypes.POSITION,
+      x: 220,
+      y: 0,
+      xUnit: Unit.PX,
+      yUnit: Unit.PX
+    })
+    propsManager.addToMap(restored)
+    propsManager.removeProperty(['group-position'])
+    propsManager.cleanChanges()
+
+    const committedChanges: PropsChange[] = []
+    const subscription = subscribeToEvents((event) => {
+      if (event.type === EventTypes.UPDATE_TRANSACTION) {
+        committedChanges.push(
+          (event as unknown as { payload: PropsChange }).payload
+        )
+      }
+    })
+    committedChanges.length = 0
+
+    try {
+      runInTransactionReplayMode('redo', () =>
+        publishEvent({
+          type: EventTypes.ADD_PROPERTY,
+          payload: {
+            eventName: EventTypes.ADD_PROPERTY,
+            data: [
+              {
+                id: 'group-position',
+                type: PropertyTypes.POSITION,
+                x: 0,
+                y: 0,
+                xUnit: Unit.PX,
+                yUnit: Unit.PX
+              }
+            ],
+            action: PROPS_ACTIONS.ADD_PROPERTY,
+            undoType: EventTypes.REMOVE_PROPERTY,
+            undoAction: PROPS_ACTIONS.REMOVE_PROPERTY
+          }
+        })
+      )
+
+      expect(propsManager.getPropertyById('group-position')).toBe(restored)
+      expect(committedChanges).toEqual([
+        expect.objectContaining({
+          eventName: EventTypes.ADD_PROPERTY,
+          action: PROPS_ACTIONS.ADD_PROPERTY,
+          data: [restored.save()]
+        })
+      ])
+    } finally {
+      subscription.unsubscribe()
+    }
   })
 })

--- a/packages/props-manager/src/components/base.ts
+++ b/packages/props-manager/src/components/base.ts
@@ -12,6 +12,10 @@ import { acknowledgeTransactionReplayApplied } from '@asyra/reactive-events'
 import { Setter, Unit, isNil } from '@asyra/utils'
 import { getPropertySchema } from '../registries/property-schema'
 import { matchesPropertyValueKind } from '../registries/property-value-kind'
+import {
+  getPropertyComponentAccessor,
+  type PropertyComponentAccessor
+} from '../manager/component-accessor'
 import PropsChangeHandler from './props-change-handler'
 
 const propsChangeHandler = new PropsChangeHandler()
@@ -41,9 +45,11 @@ abstract class BaseComponent<
   implements IProperty
 {
   propNames!: string[]
+  protected readonly propertyComponentAccessor: PropertyComponentAccessor
 
   constructor() {
     super(propsChangeHandler.addChange, acknowledgeTransactionReplayApplied)
+    this.propertyComponentAccessor = getPropertyComponentAccessor()
   }
 
   private getFieldSchema(key: keyof T): PropertyFieldSchema | undefined {

--- a/packages/props-manager/src/index.ts
+++ b/packages/props-manager/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { BasePropertyComponent } from './components'
 import {
   getPropertyComponentAccessor,
+  runWithPropertyComponentAccessor,
   type PropertyComponentAccessor
 } from './manager/component-accessor'
 
@@ -30,7 +31,8 @@ export {
   getPropertyComponentConfigDefinition,
   unregisterPropertyComponent,
   BasePropertyComponent,
-  getPropertyComponentAccessor
+  getPropertyComponentAccessor,
+  runWithPropertyComponentAccessor
 }
 export type { PropertyDefinition } from './registries/property-definition'
 export type { PropertyComponentConstructor } from './components'

--- a/packages/props-manager/src/manager/component-accessor.ts
+++ b/packages/props-manager/src/manager/component-accessor.ts
@@ -17,11 +17,25 @@ const noopAccessor: ComponentAccessor = {
 }
 
 let accessor: ComponentAccessor = noopAccessor
+let scopedAccessor: ComponentAccessor | undefined
 
 export const setComponentAccessor = (nextAccessor: ComponentAccessor) => {
   accessor = nextAccessor
 }
 
-export const getPropertyComponentAccessor = () => accessor
+export const getPropertyComponentAccessor = () => scopedAccessor ?? accessor
+
+export const runWithPropertyComponentAccessor = <T>(
+  nextAccessor: ComponentAccessor,
+  callback: () => T
+): T => {
+  const previousAccessor = scopedAccessor
+  scopedAccessor = nextAccessor
+  try {
+    return callback()
+  } finally {
+    scopedAccessor = previousAccessor
+  }
+}
 
 export type { ComponentAccessor as PropertyComponentAccessor }

--- a/packages/props-manager/src/manager/props-manager.ts
+++ b/packages/props-manager/src/manager/props-manager.ts
@@ -26,13 +26,16 @@ export interface PropsLoadValidationResult {
   diagnostics: PropsLoadDiagnostic[]
 }
 
-const cloneLoadData = (data: PropsComponentRawData): PropsComponentRawData => {
+const clonePropsValue = <T>(data: T): T => {
   if (typeof globalThis.structuredClone === 'function') {
     return globalThis.structuredClone(data)
   }
 
-  return JSON.parse(JSON.stringify(data)) as PropsComponentRawData
+  return JSON.parse(JSON.stringify(data)) as T
 }
+
+const cloneLoadData = (data: PropsComponentRawData): PropsComponentRawData =>
+  clonePropsValue(data)
 
 class PropsManager {
   _components: Map<string, PropertyComponentInstanceTypes> = new Map()
@@ -215,7 +218,7 @@ class PropsManager {
   addChangeForAddProperty(property: PropertyComponentInstanceTypes) {
     this.addChange({
       eventName: EventTypes.ADD_PROPERTY,
-      data: [property.save()],
+      data: [clonePropsValue(property.save())],
       action: PROPS_ACTIONS.ADD_PROPERTY,
       undoType: EventTypes.REMOVE_PROPERTY,
       undoAction: EventTypes.REMOVE_PROPERTY
@@ -225,7 +228,7 @@ class PropsManager {
   addChangeForRemoveProperty(property: PropertyComponentInstanceTypes) {
     this.addChange({
       eventName: EventTypes.REMOVE_PROPERTY,
-      data: [property.save()],
+      data: [clonePropsValue(property.save())],
       action: PROPS_ACTIONS.REMOVE_PROPERTY,
       undoType: EventTypes.ADD_PROPERTY,
       undoAction: EventTypes.ADD_PROPERTY

--- a/packages/props-manager/src/manager/props-manager.ts
+++ b/packages/props-manager/src/manager/props-manager.ts
@@ -18,7 +18,11 @@ import type {
   PropsComponentRawData,
   EvnetOptions
 } from '@asyra/utils'
-import { EventTypes, updateTransaction } from '@asyra/reactive-events'
+import {
+  acknowledgeTransactionReplayApplied,
+  EventTypes,
+  updateTransaction
+} from '@asyra/reactive-events'
 import { isEqual } from 'lodash'
 import { createProperty } from '../factories/create-property'
 import {
@@ -26,7 +30,11 @@ import {
   getPropertyComponentConfigDefinition
 } from '../registries/property-component'
 import elementPropertyRegistry from '../registries/property-definition'
-import { setComponentAccessor } from './component-accessor'
+import {
+  runWithPropertyComponentAccessor,
+  setComponentAccessor,
+  type PropertyComponentAccessor
+} from './component-accessor'
 
 export type PropsLoadDiagnostic = LoadDiagnostic
 
@@ -60,14 +68,16 @@ class PropsManager {
       snapshot: PropsRestoreSnapshot
     }
   >()
+  private readonly componentAccessor: PropertyComponentAccessor
 
   constructor() {
-    setComponentAccessor({
+    this.componentAccessor = {
       getPropertyById: (propertyId) => this.getPropertyById(propertyId),
       addToMap: (component) => this.addToMap(component),
       createComponent: (data) =>
         this.createProperty(data as Partial<PropertyComponentRawData>)
-    })
+    }
+    setComponentAccessor(this.componentAccessor)
   }
 
   private createLoadValidationResult(
@@ -399,6 +409,122 @@ class PropsManager {
     return plan
   }
 
+  applyRestoreProperties(
+    plan: PropsRestorePlan,
+    options?: EVENT_OPTIONS
+  ): readonly string[] {
+    const artifact = this.validatedRestoreArtifacts.get(plan)
+    if (!artifact) {
+      throw new Error(
+        '[PropsManager] Expected an owner-issued one-shot property restore plan'
+      )
+    }
+    this.validatedRestoreArtifacts.delete(plan)
+
+    const snapshotById = new Map(
+      artifact.snapshot.components.map(
+        (component) => [component.id, component] as const
+      )
+    )
+    const materialized = new Map<string, PropertyComponentInstanceTypes>()
+    try {
+      plan.entries.forEach(({ componentId, strategy }) => {
+        const data = snapshotById.get(componentId)
+        if (!data || this.getPropertyById(componentId)) {
+          throw new Error(
+            `[PropsManager] Cannot apply property restore: stale component "${componentId}"`
+          )
+        }
+        if (strategy === 'reuse') {
+          const tombstone = this.getRestoreComponentById(componentId)
+          if (
+            !tombstone ||
+            tombstone.get('type') !== data.type ||
+            !isEqual(tombstone.save(), data)
+          ) {
+            throw new Error(
+              `[PropsManager] Cannot apply property restore: stale tombstone "${componentId}"`
+            )
+          }
+          materialized.set(componentId, tombstone)
+          return
+        }
+        if (strategy !== 'materialize') {
+          throw new Error(
+            `[PropsManager] Cannot apply property restore: invalid strategy for "${componentId}"`
+          )
+        }
+        const component = runWithPropertyComponentAccessor(
+          this.componentAccessor,
+          () => createProperty(data)
+        )
+        if (
+          component.get('id') !== componentId ||
+          !isEqual(component.save(), data)
+        ) {
+          ;(component as unknown as { dispose?: () => void }).dispose?.()
+          throw new Error(
+            `[PropsManager] Cannot apply property restore: exact materialization failed for "${componentId}"`
+          )
+        }
+        materialized.set(componentId, component)
+      })
+    } catch (error) {
+      materialized.forEach((component, componentId) => {
+        if (!this._deletedMap.has(componentId)) {
+          ;(component as unknown as { dispose?: () => void }).dispose?.()
+        }
+      })
+      throw error
+    }
+
+    const appliedIds: string[] = []
+    const changeStart = this.changes.length
+    try {
+      plan.entries.forEach(({ componentId }) => {
+        const component = materialized.get(componentId)
+        const data = snapshotById.get(componentId)
+        if (!component || !data) {
+          throw new Error(
+            `[PropsManager] Cannot apply property restore: missing prepared component "${componentId}"`
+          )
+        }
+        this.addToMap(component)
+        runWithPropertyComponentAccessor(this.componentAccessor, () =>
+          component.load(data)
+        )
+        if (!isEqual(component.save(), data)) {
+          throw new Error(
+            `[PropsManager] Cannot apply property restore: exact data changed for "${componentId}"`
+          )
+        }
+        this.addChangeForAddProperty(component)
+        appliedIds.push(componentId)
+      })
+    } catch (error) {
+      this.changes.splice(changeStart)
+      appliedIds.reverse().forEach((componentId) => {
+        const component = this._components.get(componentId)
+        this._components.delete(componentId)
+        const strategy = plan.entries.find(
+          (entry) => entry.componentId === componentId
+        )?.strategy
+        if (component && strategy === 'reuse') {
+          this._deletedMap.set(componentId, component)
+        } else {
+          ;(component as unknown as { dispose?: () => void }).dispose?.()
+        }
+      })
+      throw error
+    }
+
+    if (appliedIds.length > 0) {
+      acknowledgeTransactionReplayApplied()
+      this.commitChanges(options)
+    }
+    return Object.freeze([...appliedIds])
+  }
+
   addChangeForAddProperty(property: PropertyComponentInstanceTypes) {
     this.addChange({
       eventName: EventTypes.ADD_PROPERTY,
@@ -424,10 +550,14 @@ class PropsManager {
       throw new Error('Type is required!')
     }
 
-    const newProperty = createProperty({
-      ...propData,
-      type: propData.type as PropertyType
-    }) as PropertyComponentInstanceTypes
+    const newProperty = runWithPropertyComponentAccessor(
+      this.componentAccessor,
+      () =>
+        createProperty({
+          ...propData,
+          type: propData.type as PropertyType
+        }) as PropertyComponentInstanceTypes
+    )
     this.addChangeForAddProperty(newProperty)
     return newProperty
   }
@@ -472,14 +602,16 @@ class PropsManager {
       return
     }
 
-    if (options) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      component.set(key as any, data as any, options)
-      return
-    }
+    runWithPropertyComponentAccessor(this.componentAccessor, () => {
+      if (options) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        component.set(key as any, data as any, options)
+        return
+      }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    component.set(key as any, data as any)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      component.set(key as any, data as any)
+    })
   }
 
   updatePropertyById(

--- a/packages/props-manager/src/manager/props-manager.ts
+++ b/packages/props-manager/src/manager/props-manager.ts
@@ -10,13 +10,22 @@ import type {
   UpdatePropertyChange,
   PropertyComponentInstanceTypes,
   PropertyComponentRawData,
+  PropsRestorePlan,
+  PropsRestoreSnapshot,
+  PropsRestoreStrategy,
+  ElementPropertyOwnerRelation,
   PropsChange,
   PropsComponentRawData,
   EvnetOptions
 } from '@asyra/utils'
 import { EventTypes, updateTransaction } from '@asyra/reactive-events'
+import { isEqual } from 'lodash'
 import { createProperty } from '../factories/create-property'
-import { getPropertyComponent } from '../registries/property-component'
+import {
+  getPropertyComponent,
+  getPropertyComponentConfigDefinition
+} from '../registries/property-component'
+import elementPropertyRegistry from '../registries/property-definition'
 import { setComponentAccessor } from './component-accessor'
 
 export type PropsLoadDiagnostic = LoadDiagnostic
@@ -44,6 +53,12 @@ class PropsManager {
   private validatedLoadArtifacts = new WeakMap<
     PropsLoadValidationResult,
     PropsComponentRawData
+  >()
+  private validatedRestoreArtifacts = new WeakMap<
+    PropsRestorePlan,
+    {
+      snapshot: PropsRestoreSnapshot
+    }
   >()
 
   constructor() {
@@ -213,6 +228,175 @@ class PropsManager {
 
   getRestoreComponentById(componentId: string) {
     return this._deletedMap.get(componentId)
+  }
+
+  preflightRestoreProperties(
+    snapshot: unknown,
+    ownerRelations: unknown
+  ): PropsRestorePlan {
+    if (
+      !isRecord(snapshot) ||
+      !Array.isArray(snapshot.components) ||
+      !Array.isArray(ownerRelations)
+    ) {
+      throw new Error(
+        '[PropsManager] Invalid property restore: exact snapshot and owner relations are required'
+      )
+    }
+
+    const validatedSnapshot = clonePropsValue(
+      snapshot as unknown as PropsRestoreSnapshot
+    )
+    const validatedRelations = clonePropsValue(
+      ownerRelations as ElementPropertyOwnerRelation[]
+    )
+    const components = validatedSnapshot.components
+    const componentIds = components.map(({ id }) => id)
+    if (
+      componentIds.some((componentId) => typeof componentId !== 'string') ||
+      new Set(componentIds).size !== componentIds.length
+    ) {
+      throw new Error(
+        '[PropsManager] Invalid property restore: duplicate or invalid component id'
+      )
+    }
+
+    const componentById = new Map(
+      components.map((component) => [component.id, component] as const)
+    )
+    components.forEach((component) => {
+      if (
+        !isRecord(component) ||
+        typeof component.id !== 'string' ||
+        component.id.length === 0 ||
+        typeof component.type !== 'string' ||
+        component.type.length === 0
+      ) {
+        throw new Error(
+          '[PropsManager] Invalid property restore: malformed component data'
+        )
+      }
+      if (!getPropertyComponent(component.type)) {
+        throw new Error(
+          `[PropsManager] Invalid property restore: unregistered property type "${component.type}"`
+        )
+      }
+      if (this.getPropertyById(component.id)) {
+        throw new Error(
+          `[PropsManager] Invalid property restore: active property "${component.id}" already exists`
+        )
+      }
+    })
+
+    const relationKeys = new Set<string>()
+    validatedRelations.forEach((relation) => {
+      if (
+        !isRecord(relation) ||
+        typeof relation.ownerElementId !== 'string' ||
+        typeof relation.ownerElementType !== 'string' ||
+        typeof relation.ownerPropertyName !== 'string' ||
+        typeof relation.componentId !== 'string'
+      ) {
+        throw new Error(
+          '[PropsManager] Invalid property restore: malformed owner relation'
+        )
+      }
+      const relationKey = `${relation.ownerElementId}:${relation.ownerPropertyName}`
+      if (relationKeys.has(relationKey)) {
+        throw new Error(
+          `[PropsManager] Invalid property restore: duplicate owner relation "${relationKey}"`
+        )
+      }
+      relationKeys.add(relationKey)
+      const component = componentById.get(relation.componentId)
+      if (!component) {
+        throw new Error(
+          `[PropsManager] Invalid property restore: missing owner data for "${relation.componentId}"`
+        )
+      }
+      const definition = elementPropertyRegistry.getForComponent(
+        relation.ownerElementType,
+        relation.ownerPropertyName
+      )
+      if (!definition || definition.type !== component.type) {
+        throw new Error(
+          `[PropsManager] Invalid property restore: malformed owner relation for "${relation.componentId}"`
+        )
+      }
+    })
+
+    const reachableSnapshotIds = new Set<string>()
+    const visit = (componentId: string): void => {
+      if (reachableSnapshotIds.has(componentId)) return
+      const component = componentById.get(componentId)
+      if (!component) return
+      reachableSnapshotIds.add(componentId)
+      const config = getPropertyComponentConfigDefinition(component.type)
+      const childRelation = config?.children
+      if (!childRelation) return
+      const childIds = (component as unknown as Record<string, unknown>)[
+        childRelation.key
+      ]
+      if (
+        !Array.isArray(childIds) ||
+        childIds.some((childId) => typeof childId !== 'string') ||
+        new Set(childIds).size !== childIds.length
+      ) {
+        throw new Error(
+          `[PropsManager] Invalid property restore: malformed child relation for "${componentId}"`
+        )
+      }
+      childIds.forEach((childId) => {
+        const snapshotChild = componentById.get(childId)
+        const activeChild = this.getPropertyById(childId)
+        const childType = snapshotChild?.type ?? activeChild?.get('type')
+        if (!childType) {
+          throw new Error(
+            `[PropsManager] Invalid property restore: missing relation child "${childId}"`
+          )
+        }
+        if (childType !== childRelation.childType) {
+          throw new Error(
+            `[PropsManager] Invalid property restore: malformed child relation type for "${childId}"`
+          )
+        }
+        if (snapshotChild) visit(childId)
+      })
+    }
+    validatedRelations.forEach(({ componentId }) => visit(componentId))
+    if (reachableSnapshotIds.size !== components.length) {
+      throw new Error(
+        '[PropsManager] Invalid property restore: missing owner relation for snapshot component data'
+      )
+    }
+
+    const planEntries = components.map((component) => {
+      const tombstone = this._deletedMap.get(component.id)
+      let strategy: PropsRestoreStrategy = 'materialize'
+      if (tombstone) {
+        if (
+          tombstone.get('type') !== component.type ||
+          !isEqual(tombstone.save(), component)
+        ) {
+          throw new Error(
+            `[PropsManager] Invalid property restore: incompatible tombstone for "${component.id}"`
+          )
+        }
+        strategy = 'reuse'
+      }
+      return Object.freeze({ componentId: component.id, strategy })
+    })
+    const plan: PropsRestorePlan = Object.freeze({
+      kind: 'props-restore-plan',
+      entries: Object.freeze(planEntries),
+      ownerRelations: Object.freeze(
+        validatedRelations.map((relation) => Object.freeze(relation))
+      )
+    })
+    this.validatedRestoreArtifacts.set(plan, {
+      snapshot: validatedSnapshot
+    })
+    return plan
   }
 
   addChangeForAddProperty(property: PropertyComponentInstanceTypes) {

--- a/packages/props-manager/src/manager/subscribes.ts
+++ b/packages/props-manager/src/manager/subscribes.ts
@@ -43,6 +43,9 @@ export const initPropXSubscribes = () => {
           newProperty = propsManager.getRestoreComponentById(
             propData.id as string
           )
+          if (newProperty) {
+            propsManager.addChangeForAddProperty(newProperty)
+          }
         }
 
         if (!newProperty) {

--- a/packages/props-manager/src/registries/declarative-property-type.ts
+++ b/packages/props-manager/src/registries/declarative-property-type.ts
@@ -13,7 +13,7 @@ import {
 import { BasePropertyComponent } from '../components'
 import type { PropertyComponentConstructor } from '../components'
 import propsManager, { PropsManager } from '../manager/props-manager'
-import { getPropertyComponentAccessor } from '../manager/component-accessor'
+import type { PropertyComponentAccessor } from '../manager/component-accessor'
 import {
   getPropertyComponent,
   getPropertyComponentConfigDefinition,
@@ -496,13 +496,15 @@ export const createPropertyComponentFromConfig = (
   const isAllowedDynamicKey = (key: string) => !reservedDynamicKeys.has(key)
   const { persistKeys, valueKeys, unitKeys } = getConfigRoles(definition)
 
-  const normalizeChildrenValue = (value: unknown): string[] | null => {
+  const normalizeChildrenValue = (
+    value: unknown,
+    accessor: PropertyComponentAccessor
+  ): string[] | null => {
     if (!children || !Array.isArray(value)) return null
     const mode = children.mode ?? 'ids'
     if (mode === 'ids') return value.every(isString) ? value : null
 
     const childIds: string[] = []
-    const accessor = getPropertyComponentAccessor()
     value.forEach((item) => {
       if (isString(item)) {
         childIds.push(item)
@@ -556,9 +558,11 @@ export const createPropertyComponentFromConfig = (
     return childIds
   }
 
-  const toChildrenValue = (value: unknown): unknown => {
+  const toChildrenValue = (
+    value: unknown,
+    accessor: PropertyComponentAccessor
+  ): unknown => {
     if (!children?.toValue || !Array.isArray(value)) return value
-    const accessor = getPropertyComponentAccessor()
     return value
       .filter(isString)
       .map((childId) => {
@@ -595,10 +599,9 @@ export const createPropertyComponentFromConfig = (
         this.childSubscriptions.delete(childId)
       })
 
-      const accessor = getPropertyComponentAccessor()
       nextIds.forEach((childId) => {
         if (this.childSubscriptions.has(childId)) return
-        const child = accessor.getPropertyById(childId)
+        const child = this.propertyComponentAccessor.getPropertyById(childId)
         if (!child || child.get('type') !== children.childType) return
         const unsubscribe = child.on((change) => {
           this.emitChange({
@@ -619,7 +622,10 @@ export const createPropertyComponentFromConfig = (
       let nextChildIds: string[] | null = null
       persistKeys.forEach((key) => {
         if (children && key === children.key) {
-          const normalized = normalizeChildrenValue(rawData[key])
+          const normalized = normalizeChildrenValue(
+            rawData[key],
+            this.propertyComponentAccessor
+          )
           if (normalized) {
             this.data[key as keyof PropertyComponentInstanceDataTypes] =
               normalized as never
@@ -678,7 +684,10 @@ export const createPropertyComponentFromConfig = (
           key as keyof PropertyComponentInstanceDataTypes
         )
         if (current !== undefined) {
-          value[key] = toChildrenValue(current) as DataTypes
+          value[key] = toChildrenValue(
+            current,
+            this.propertyComponentAccessor
+          ) as DataTypes
         }
       })
       return value
@@ -701,7 +710,10 @@ export const createPropertyComponentFromConfig = (
       options?: EvnetOptions
     ): void {
       if (children && key === (children.key as K)) {
-        const normalized = normalizeChildrenValue(value)
+        const normalized = normalizeChildrenValue(
+          value,
+          this.propertyComponentAccessor
+        )
         if (!normalized) return
         super.set(
           key,

--- a/packages/render/src/__tests__/scene-tree-store.test.ts
+++ b/packages/render/src/__tests__/scene-tree-store.test.ts
@@ -417,6 +417,69 @@ describe('RenderSceneTree computed data mirror', () => {
     expect(renderMock.removeElement).not.toHaveBeenCalled()
   })
 
+  it('projects moved children into the workspace when the settled source parent is already removed', async () => {
+    const { RenderSceneTree } = await import('../stores/scene-tree')
+    const store = new RenderSceneTree()
+    const workspaceRaw = {
+      id: 'workspace-1',
+      type: EntityTypes.WORKSPACE,
+      children: ['group']
+    }
+    const groupRaw = {
+      type: EntityTypes.GROUP,
+      parentId: 'workspace-1',
+      children: ['first', 'second']
+    }
+    const firstRaw = {
+      type: 'rectangle',
+      parentId: 'group'
+    }
+    const secondRaw = {
+      type: 'rectangle',
+      parentId: 'group'
+    }
+    const elements = new Map([
+      ['workspace-1', createElement('workspace-1', workspaceRaw, {})],
+      ['group', createElement('group', groupRaw, {})],
+      ['first', createElement('first', firstRaw, {})],
+      ['second', createElement('second', secondRaw, {})]
+    ])
+    currentWorkspace = { save: () => ({ ...workspaceRaw }) }
+    sceneTreeMock.getAllElements.mockReturnValue(elements as never)
+    sceneTreeMock.getElementById.mockImplementation(
+      (elementId) => elements.get(elementId) as never
+    )
+    store.reload()
+    renderMock.addElement.mockClear()
+    renderMock.removeElement.mockClear()
+    renderMock.projectHierarchy.mockClear()
+
+    workspaceRaw.children = ['first', 'second']
+    firstRaw.parentId = 'workspace-1'
+    secondRaw.parentId = 'workspace-1'
+    elements.delete('group')
+
+    expect(
+      store.moveElements([
+        {
+          elementId: 'first',
+          before: { parentId: 'group', index: 0 },
+          after: { parentId: 'workspace-1', index: 1 }
+        },
+        {
+          elementId: 'second',
+          before: { parentId: 'group', index: 1 },
+          after: { parentId: 'workspace-1', index: 2 }
+        }
+      ])
+    ).toEqual({ status: 'applied', elementId: 'first' })
+    expect(renderMock.projectHierarchy.mock.calls).toEqual([
+      ['workspace-1', ['first', 'second']]
+    ])
+    expect(renderMock.addElement).not.toHaveBeenCalled()
+    expect(renderMock.removeElement).not.toHaveBeenCalled()
+  })
+
   it('projects subtree removal descendant-first and restoration parent-first', async () => {
     const { RenderSceneTree } = await import('../stores/scene-tree')
     const store = new RenderSceneTree()

--- a/packages/render/src/__tests__/scene-tree-store.test.ts
+++ b/packages/render/src/__tests__/scene-tree-store.test.ts
@@ -476,6 +476,7 @@ describe('RenderSceneTree computed data mirror', () => {
         undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
         eventName: 'changeSubtree',
         elementId: 'group',
+        rootParentChildrenAfter: [],
         removed
       })
     ).toEqual({ status: 'removed', elementId: 'group' })
@@ -494,6 +495,7 @@ describe('RenderSceneTree computed data mirror', () => {
         undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
         eventName: 'changeSubtree',
         elementId: 'group',
+        rootParentChildrenAfter: [],
         removed
       })
     ).toEqual({ status: 'applied', elementId: 'group' })

--- a/packages/render/src/stores/scene-tree.ts
+++ b/packages/render/src/stores/scene-tree.ts
@@ -814,8 +814,9 @@ class RenderSceneTree {
     }
 
     const canonicalParents = new Map<string, readonly string[]>()
+    const targetParentId = moves[0].after.parentId
     const affectedParentIds = [
-      moves[0].after.parentId,
+      targetParentId,
       ...moves.map((move) => move.before.parentId)
     ].filter(
       (parentId, index, parentIds) => parentIds.indexOf(parentId) === index
@@ -823,6 +824,9 @@ class RenderSceneTree {
 
     for (const parentId of affectedParentIds) {
       const parent = sceneTree.getElementById(parentId)
+      if (!parent && parentId !== targetParentId) {
+        continue
+      }
       const parentData = parent?.save() as
         | (ElementRawData & { children?: unknown })
         | undefined
@@ -862,8 +866,8 @@ class RenderSceneTree {
       (move) =>
         sceneTree.getElementById(move.elementId)?.get('parentId') ===
           move.after.parentId &&
-        canonicalParents.get(move.after.parentId)?.[move.after.index] ===
-          move.elementId
+        canonicalParents.get(move.after.parentId)?.includes(move.elementId) ===
+          true
     )
     if ((!mirrorsMatchBefore && !mirrorsMatchAfter) || !canonicalMatchesAfter) {
       return this.projectionOutcome(elementId, 'failed')
@@ -871,10 +875,8 @@ class RenderSceneTree {
 
     const affectedElementIds = new Set(moves.map((move) => move.elementId))
     affectedParentIds.forEach((parentId) => {
-      if (
-        sceneTree.getElementById(parentId)?.get('type') !==
-        EntityTypes.WORKSPACE
-      ) {
+      const parent = sceneTree.getElementById(parentId)
+      if (parent && parent.get('type') !== EntityTypes.WORKSPACE) {
         affectedElementIds.add(parentId)
       }
     })
@@ -887,11 +889,8 @@ class RenderSceneTree {
           )
         }
       })
-      affectedParentIds.forEach((parentId) => {
-        render.projectHierarchy(
-          parentId,
-          canonicalParents.get(parentId) as readonly string[]
-        )
+      canonicalParents.forEach((childIds, parentId) => {
+        render.projectHierarchy(parentId, childIds)
       })
       return this.projectionOutcome(elementId, 'applied')
     } catch {

--- a/packages/scene-tree/src/__tests__/hierarchy-operations.test.ts
+++ b/packages/scene-tree/src/__tests__/hierarchy-operations.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import propsManager, {
   BasePropertyComponent,
+  PropsManager,
   propertyComponentRegistry,
   registerPropertyComponent
 } from '@asyra/props-manager'
@@ -423,6 +424,26 @@ describe('Scene Tree restore preflight', () => {
         }
       }
     ).preflightRestoreSubtree(snapshot)
+  const apply = (owner: SceneTree, plan: ReturnType<typeof preflight>) =>
+    (
+      owner as unknown as {
+        applyRestoreSubtree: (
+          artifact: ReturnType<typeof preflight>
+        ) => ReturnType<typeof sceneTree.removeSubtree>
+      }
+    ).applyRestoreSubtree(plan)
+  const restorePropertyTombstones = (
+    manager: PropsManager,
+    snapshot: ReturnType<typeof sceneTree.removeSubtree>
+  ) => {
+    snapshot.removed.forEach(({ data }) => {
+      Object.values(data.props ?? {}).forEach((componentId) => {
+        const component = manager.getRestoreComponentById(componentId)
+        if (component) manager.addToMap(component)
+      })
+    })
+    manager.cleanChanges()
+  }
 
   it('prepares exact materialization when no deleted runtime instances exist', () => {
     const beforeSiblingId = addElement(new HierarchyTestElement())
@@ -535,6 +556,104 @@ describe('Scene Tree restore preflight', () => {
 
     expect(() => preflight(snapshot)).toThrow(/active element/i)
     expect(snapshotHierarchy()).toEqual(before)
+  })
+
+  it('materializes the exact tombstone-free subtree once after Props are active', () => {
+    const beforeSiblingId = addElement(new HierarchyTestElement())
+    const group = new HierarchyTestGroup()
+    const groupId = addElement(group)
+    const childId = addElement(new HierarchyTestElement(), group)
+    const afterSiblingId = addElement(new HierarchyTestElement())
+    const expectedHierarchy = snapshotHierarchy()
+    const snapshot = sceneTree.removeSubtree(groupId)
+    restorePropertyTombstones(propsManager, snapshot)
+    sceneTree._deletedMap.clear()
+    const plan = preflight(snapshot)
+
+    expect(apply(sceneTree, plan)).toEqual(snapshot)
+    expect(snapshotHierarchy()).toEqual(expectedHierarchy)
+    expect(childrenOf(sceneTree.workspace)).toEqual([
+      beforeSiblingId,
+      groupId,
+      afterSiblingId
+    ])
+    expect(childrenOf(groupId)).toEqual([childId])
+    snapshot.removed.forEach(({ elementId, data }) => {
+      expect(sceneTree.getElementById(elementId)?.save()).toEqual(data)
+    })
+    expect(() => apply(sceneTree, plan)).toThrow(/owner-issued one-shot/i)
+  })
+
+  it('reuses compatible Scene Tree tombstone identities', () => {
+    const group = new HierarchyTestGroup()
+    const groupId = addElement(group)
+    const child = new HierarchyTestElement()
+    const childId = addElement(child, group)
+    const snapshot = sceneTree.removeSubtree(groupId)
+    restorePropertyTombstones(propsManager, snapshot)
+    const plan = preflight(snapshot)
+
+    apply(sceneTree, plan)
+
+    expect(sceneTree.getElementById(groupId)).toBe(group)
+    expect(sceneTree.getElementById(childId)).toBe(child)
+  })
+
+  it('rejects a foreign or stale plan without partial hierarchy', () => {
+    const groupId = addElement(new HierarchyTestGroup())
+    const snapshot = sceneTree.removeSubtree(groupId)
+    restorePropertyTombstones(propsManager, snapshot)
+    sceneTree._deletedMap.clear()
+    const plan = preflight(snapshot)
+    const foreignTree = new SceneTree(new PropsManager())
+    foreignTree.init()
+
+    expect(() => apply(foreignTree, plan)).toThrow(/owner-issued one-shot/i)
+    const staleSiblingId = addElement(new HierarchyTestElement())
+    const before = snapshotHierarchy()
+    expect(() => apply(sceneTree, plan)).toThrow(/stale.*root-parent order/i)
+    expect(snapshotHierarchy()).toEqual(before)
+    expect(sceneTree.getElementById(staleSiblingId)).toBeDefined()
+  })
+
+  it('materializes only inside the issuing Scene Tree and Props composition', () => {
+    const firstProps = new PropsManager()
+    const secondProps = new PropsManager()
+    const firstTree = new SceneTree(firstProps)
+    const secondTree = new SceneTree(secondProps)
+    firstTree.init()
+    secondTree.init()
+    const sharedData = {
+      id: 'shared-group',
+      type: EntityTypes.GROUP,
+      name: 'Shared Group',
+      visible: true,
+      lock: false,
+      x: 0,
+      y: 0
+    }
+    firstTree.addNewElement(sharedData)
+    secondTree.addNewElement(sharedData)
+    const secondIdentity = secondTree.getElementById('shared-group')
+    const secondPropsBefore = secondProps.save()
+    const snapshot = firstTree.removeSubtree('shared-group')
+    restorePropertyTombstones(firstProps, snapshot)
+    firstTree._deletedMap.clear()
+    const plan = firstTree.preflightRestoreSubtree(snapshot)
+
+    firstTree.applyRestoreSubtree(plan)
+
+    expect(firstTree.getElementById('shared-group')?.save()).toEqual(
+      snapshot.removed[0].data
+    )
+    expect(secondTree.getElementById('shared-group')).toBe(secondIdentity)
+    expect(secondProps.save()).toEqual(secondPropsBefore)
+    Object.values(snapshot.removed[0].data.props ?? {}).forEach(
+      (componentId) => {
+        expect(firstProps.getPropertyById(componentId)).toBeDefined()
+        expect(secondProps.getPropertyById(componentId)).toBeUndefined()
+      }
+    )
   })
 })
 

--- a/packages/scene-tree/src/__tests__/hierarchy-operations.test.ts
+++ b/packages/scene-tree/src/__tests__/hierarchy-operations.test.ts
@@ -289,6 +289,50 @@ describe('canonical hierarchy move', () => {
 })
 
 describe('canonical subtree removal', () => {
+  it('captures detached post-delete root-parent order evidence at mutation time', () => {
+    const beforeSiblingId = addElement(new HierarchyTestElement())
+    const groupId = addElement(new HierarchyTestGroup())
+    const afterSiblingId = addElement(new HierarchyTestElement())
+    const updates: UpdateTransactionEvent[] = []
+    const subscription = subscribeToUpdateTransaction((event) =>
+      updates.push(event)
+    )
+
+    const result = sceneTree.removeSubtree(groupId)
+    const published = updates.find(
+      ({ eventName, payload }) =>
+        eventName === EventTypes.CHANGE_SUBTREE &&
+        (payload as { elementId?: string }).elementId === groupId
+    )?.payload as
+      | {
+          rootParentChildrenAfter: readonly string[]
+        }
+      | undefined
+    subscription.unsubscribe()
+
+    expect(result.rootParentChildrenAfter).toEqual([
+      beforeSiblingId,
+      afterSiblingId
+    ])
+    expect(published?.rootParentChildrenAfter).toEqual([
+      beforeSiblingId,
+      afterSiblingId
+    ])
+    expect(published?.rootParentChildrenAfter).not.toBe(
+      result.rootParentChildrenAfter
+    )
+
+    addElement(new HierarchyTestElement())
+    expect(result.rootParentChildrenAfter).toEqual([
+      beforeSiblingId,
+      afterSiblingId
+    ])
+    expect(published?.rootParentChildrenAfter).toEqual([
+      beforeSiblingId,
+      afterSiblingId
+    ])
+  })
+
   it('removes descendants before their containers and keeps exact instances available for restoration', () => {
     const group = new HierarchyTestGroup()
     const groupId = addElement(group)
@@ -324,7 +368,11 @@ describe('canonical subtree removal', () => {
       grandchild
     )
     expect(
-      updates.filter(({ eventName }) => eventName === EventTypes.CHANGE_SUBTREE)
+      updates.filter(
+        ({ eventName, payload }) =>
+          eventName === EventTypes.CHANGE_SUBTREE &&
+          (payload as { elementId?: string }).elementId === groupId
+      )
     ).toHaveLength(1)
 
     sceneTree.restoreSubtree(result.removed)

--- a/packages/scene-tree/src/__tests__/hierarchy-operations.test.ts
+++ b/packages/scene-tree/src/__tests__/hierarchy-operations.test.ts
@@ -26,6 +26,7 @@ import {
 import sceneTree, { SceneTree } from '../sceneTree'
 import Element from '../components/element'
 import Group from '../components/group'
+import componentRegistry from '../component-registry'
 
 class HierarchyTestElement extends Element {
   _init(): void {
@@ -139,6 +140,27 @@ beforeEach(() => {
   propertyComponentRegistry.clear()
   registerPropertyComponent(PropertyTypes.POSITION, HierarchyTestPosition)
   registerPropertyComponent(PropertyTypes.DIMENSION, HierarchyTestDimension)
+  if (!componentRegistry.has('hierarchy-test-element')) {
+    componentRegistry.register({
+      type: 'hierarchy-test-element',
+      idPrefix: 'hierarchy-test-element',
+      namePrefix: 'Hierarchy Test Element',
+      constructor: HierarchyTestElement,
+      properties: [],
+      defaults: {}
+    })
+  }
+  if (!componentRegistry.has(EntityTypes.GROUP)) {
+    componentRegistry.register({
+      type: EntityTypes.GROUP,
+      idPrefix: 'group',
+      namePrefix: 'Group',
+      constructor: HierarchyTestGroup,
+      properties: [],
+      defaults: {},
+      isContainer: true
+    })
+  }
   sceneTree.init()
   sceneTree.cleanChanges()
 })
@@ -383,6 +405,136 @@ describe('canonical subtree removal', () => {
     expect(sceneTree.getElementById(nestedId)).toBe(nested)
     expect(sceneTree.getElementById(grandchildId)).toBe(grandchild)
     subscription.unsubscribe()
+  })
+})
+
+describe('Scene Tree restore preflight', () => {
+  const preflight = (snapshot: ReturnType<typeof sceneTree.removeSubtree>) =>
+    (
+      sceneTree as unknown as {
+        preflightRestoreSubtree: (
+          input: ReturnType<typeof sceneTree.removeSubtree>
+        ) => {
+          elementId: string
+          entries: readonly {
+            elementId: string
+            strategy: 'reuse' | 'materialize'
+          }[]
+        }
+      }
+    ).preflightRestoreSubtree(snapshot)
+
+  it('prepares exact materialization when no deleted runtime instances exist', () => {
+    const beforeSiblingId = addElement(new HierarchyTestElement())
+    const group = new HierarchyTestGroup()
+    const groupId = addElement(group)
+    const childId = addElement(new HierarchyTestElement(), group)
+    const afterSiblingId = addElement(new HierarchyTestElement())
+    const snapshot = sceneTree.removeSubtree(groupId)
+    sceneTree._deletedMap.clear()
+    const before = snapshotHierarchy()
+
+    const plan = preflight(snapshot)
+
+    expect(plan.elementId).toBe(groupId)
+    expect(plan.entries).toEqual([
+      { elementId: childId, strategy: 'materialize' },
+      { elementId: groupId, strategy: 'materialize' }
+    ])
+    expect(snapshot.rootParentChildrenAfter).toEqual([
+      beforeSiblingId,
+      afterSiblingId
+    ])
+    expect(snapshotHierarchy()).toEqual(before)
+  })
+
+  it('selects compatible tombstones and rejects incompatible owner state without mutation', () => {
+    const group = new HierarchyTestGroup()
+    const groupId = addElement(group)
+    const childId = addElement(new HierarchyTestElement(), group)
+    const snapshot = sceneTree.removeSubtree(groupId)
+    const before = snapshotHierarchy()
+
+    expect(preflight(snapshot).entries).toEqual([
+      { elementId: childId, strategy: 'reuse' },
+      { elementId: groupId, strategy: 'reuse' }
+    ])
+
+    sceneTree
+      .getRestoreElementById(childId, false)
+      .set('visible', false, { undoable: false })
+    const incompatibleBefore = snapshotHierarchy()
+    expect(() => preflight(snapshot)).toThrow(/incompatible tombstone/i)
+    expect(snapshotHierarchy()).toEqual(incompatibleBefore)
+    expect(snapshotHierarchy()).toEqual(before)
+  })
+
+  it('rejects malformed, stale, and colliding snapshots before hierarchy mutation', () => {
+    const beforeSiblingId = addElement(new HierarchyTestElement())
+    const group = new HierarchyTestGroup()
+    const groupId = addElement(group)
+    const childId = addElement(new HierarchyTestElement(), group)
+    const afterSiblingId = addElement(new HierarchyTestElement())
+    const snapshot = sceneTree.removeSubtree(groupId)
+    const before = snapshotHierarchy()
+    const clone = () => structuredClone(snapshot)
+    const expectRejected = (
+      invalid: ReturnType<typeof sceneTree.removeSubtree>,
+      pattern: RegExp
+    ) => {
+      expect(() => preflight(invalid)).toThrow(pattern)
+      expect(snapshotHierarchy()).toEqual(before)
+    }
+
+    const duplicate = clone()
+    duplicate.removed = [...duplicate.removed, duplicate.removed[0]]
+    expectRejected(duplicate, /duplicate/i)
+
+    const inconsistentChildren = clone()
+    const inconsistentRoot = inconsistentChildren.removed.find(
+      ({ elementId }) => elementId === groupId
+    )
+    if (inconsistentRoot && 'children' in inconsistentRoot.data) {
+      inconsistentRoot.data.children = ['missing-child']
+    }
+    expectRejected(inconsistentChildren, /child order/i)
+
+    const missingParent = clone()
+    const missingRoot = missingParent.removed.find(
+      ({ elementId }) => elementId === groupId
+    )
+    if (missingRoot) {
+      missingRoot.parentId = 'missing-parent'
+      missingRoot.data.parentId = 'missing-parent'
+    }
+    expectRejected(missingParent, /missing.*parent/i)
+
+    const invalidRegistration = clone()
+    const invalidChild = invalidRegistration.removed.find(
+      ({ elementId }) => elementId === childId
+    )
+    if (invalidChild) invalidChild.data.type = 'unregistered-element'
+    expectRejected(invalidRegistration, /unregistered/i)
+
+    expect(snapshot.rootParentChildrenAfter).toEqual([
+      beforeSiblingId,
+      afterSiblingId
+    ])
+    addElement(new HierarchyTestElement())
+    const staleBefore = snapshotHierarchy()
+    expect(() => preflight(snapshot)).toThrow(/stale.*root-parent order/i)
+    expect(snapshotHierarchy()).toEqual(staleBefore)
+  })
+
+  it('rejects an active stable-id collision before hierarchy mutation', () => {
+    const group = new HierarchyTestGroup()
+    const groupId = addElement(group)
+    const snapshot = sceneTree.removeSubtree(groupId)
+    addElement(new HierarchyTestGroup({ id: groupId }))
+    const before = snapshotHierarchy()
+
+    expect(() => preflight(snapshot)).toThrow(/active element/i)
+    expect(snapshotHierarchy()).toEqual(before)
   })
 })
 

--- a/packages/scene-tree/src/components/computed.ts
+++ b/packages/scene-tree/src/components/computed.ts
@@ -1,4 +1,4 @@
-import propsManager from '@asyra/props-manager'
+import propsManager, { type PropsManager } from '@asyra/props-manager'
 import { acknowledgeTransactionReplayApplied } from '@asyra/reactive-events'
 import {
   ComputedAttrs,
@@ -21,7 +21,12 @@ class Computed<T extends ComputedAttrs>
   _nameType!: string
   private subscriptions = new Map<string, () => void>()
 
-  constructor(elementId: string, props: IProps, propertyNames: string[]) {
+  constructor(
+    elementId: string,
+    props: IProps,
+    propertyNames: string[],
+    private readonly propsManagerOwner: PropsManager = propsManager
+  ) {
     super(elementChangeHandler.addChange, acknowledgeTransactionReplayApplied)
 
     this._init()
@@ -86,7 +91,7 @@ class Computed<T extends ComputedAttrs>
       const propId = props.getPropId(propName)
       if (!propId) return
 
-      const propComponent = propsManager.getPropertyById(propId)
+      const propComponent = this.propsManagerOwner.getPropertyById(propId)
       if (!propComponent) {
         return
       }

--- a/packages/scene-tree/src/components/element.ts
+++ b/packages/scene-tree/src/components/element.ts
@@ -22,6 +22,8 @@ import {
 import Props from './props'
 import Computed from './computed'
 import ElementChangeHandler from './element-change-handler'
+import type { PropsManager } from '@asyra/props-manager'
+import { getSceneTreePropsManager } from '../props-manager-context'
 
 const elementChangeHandler = new ElementChangeHandler('raw')
 
@@ -49,7 +51,8 @@ class Element<T extends ElementAttrs = ElementAttrs>
   constructor(
     data?: Partial<ElementRawData>,
     idPrefix?: string,
-    namePrefix?: string
+    namePrefix?: string,
+    protected readonly propsManagerOwner: PropsManager = getSceneTreePropsManager()
   ) {
     super(elementChangeHandler.addChange, acknowledgeTransactionReplayApplied)
     this._idType = idPrefix || IDTypes.ELEMENT
@@ -131,15 +134,16 @@ class Element<T extends ElementAttrs = ElementAttrs>
     const elementId = this.get('id') as string
     if (this.data.type !== EntityTypes.WORKSPACE) {
       if (propsData) {
-        this.props = new Props(elementId, propsData)
+        this.props = new Props(elementId, propsData, this.propsManagerOwner)
       } else {
-        this.props = new Props(elementId)
+        this.props = new Props(elementId, undefined, this.propsManagerOwner)
       }
 
       this.computed = new Computed(
         elementId,
         this.props,
-        this.computedPropertyNames
+        this.computedPropertyNames,
+        this.propsManagerOwner
       )
     }
   }

--- a/packages/scene-tree/src/components/group.ts
+++ b/packages/scene-tree/src/components/group.ts
@@ -6,6 +6,7 @@ import type {
   ElementRawData
 } from '@asyra/utils'
 import { IDTypes, NameTypes } from '@asyra/utils'
+import type { PropsManager } from '@asyra/props-manager'
 import Element from './element'
 
 type GroupDataType = Partial<GroupRawData>
@@ -17,9 +18,15 @@ class Group<T extends GroupAttrs = GroupAttrs>
   constructor(
     data?: Partial<ElementRawData>,
     idPrefix?: string,
-    namePrefix?: string
+    namePrefix?: string,
+    propsManager?: PropsManager
   ) {
-    super(data, idPrefix || IDTypes.GROUP, namePrefix || NameTypes.GROUP)
+    super(
+      data,
+      idPrefix || IDTypes.GROUP,
+      namePrefix || NameTypes.GROUP,
+      propsManager
+    )
   }
 
   _init(): void {

--- a/packages/scene-tree/src/components/props.ts
+++ b/packages/scene-tree/src/components/props.ts
@@ -9,7 +9,7 @@ import type {
   PropsRawData
 } from '@asyra/utils'
 import { removeProperty } from '@asyra/reactive-events'
-import propsManager from '@asyra/props-manager'
+import propsManager, { type PropsManager } from '@asyra/props-manager'
 
 type PropsDataType = Partial<PropsRawData>
 
@@ -31,7 +31,11 @@ class Props implements IProps {
   elementId: string
   private propertyIds: Map<string, string> = new Map()
 
-  constructor(elementId: string, data?: PropsDataType) {
+  constructor(
+    elementId: string,
+    data?: PropsDataType,
+    private readonly propsManagerOwner: PropsManager = propsManager
+  ) {
     this.elementId = elementId
 
     if (data) {
@@ -54,9 +58,9 @@ class Props implements IProps {
 
   init() {
     const propertyComponents = PROP_NAMES.map((propName) =>
-      propsManager.createProperty({ type: propName })
+      this.propsManagerOwner.createProperty({ type: propName })
     )
-    const propIdsMap = propsManager.addProperty(propertyComponents)
+    const propIdsMap = this.propsManagerOwner.addProperty(propertyComponents)
     if (!propIdsMap) {
       return
     }
@@ -73,16 +77,18 @@ class Props implements IProps {
     const dataObj = data as Record<string, string | undefined>
     const propertyComponents = PROP_NAMES.map((propName) => {
       const propId = dataObj[propName]
-      const propComponent = propId ? propsManager.getPropertyById(propId) : null
+      const propComponent = propId
+        ? this.propsManagerOwner.getPropertyById(propId)
+        : null
       if (propComponent) {
         // Restore existing prop component
         return propComponent
       } else {
         // Create new prop component
-        return propsManager.createProperty({ type: propName })
+        return this.propsManagerOwner.createProperty({ type: propName })
       }
     })
-    const propIdsMap = propsManager.addProperty(propertyComponents)
+    const propIdsMap = this.propsManagerOwner.addProperty(propertyComponents)
     if (!propIdsMap) {
       return
     }
@@ -114,7 +120,7 @@ class Props implements IProps {
       return
     }
 
-    propsManager.updatePropsData(propComponentId, key, data, options)
+    this.propsManagerOwner.updatePropsData(propComponentId, key, data, options)
   }
 
   cleanup(options?: EvnetOptions) {

--- a/packages/scene-tree/src/create-dynamic-component.ts
+++ b/packages/scene-tree/src/create-dynamic-component.ts
@@ -56,15 +56,24 @@ export function createDynamicComponent(
         this.computedPropertyNames = properties.map((p) => p.name)
 
         if (propsData) {
-          this.props = new DynamicPropsClass(elementId, propsData)
+          this.props = new DynamicPropsClass(
+            elementId,
+            propsData,
+            this.propsManagerOwner
+          )
         } else {
-          this.props = new DynamicPropsClass(elementId)
+          this.props = new DynamicPropsClass(
+            elementId,
+            undefined,
+            this.propsManagerOwner
+          )
         }
 
         this.computed = new Computed(
           elementId,
           this.props,
-          properties.map((p) => p.name)
+          properties.map((p) => p.name),
+          this.propsManagerOwner
         )
       }
     }

--- a/packages/scene-tree/src/create-dynamic-props.ts
+++ b/packages/scene-tree/src/create-dynamic-props.ts
@@ -4,22 +4,15 @@ import type {
   PropsRawData,
   IProps
 } from '@asyra/utils'
-import propsManager from '@asyra/props-manager'
-import type { PropertyDefinition } from '@asyra/props-manager'
+import propsManager, {
+  type PropertyDefinition,
+  type PropsManager
+} from '@asyra/props-manager'
 
 export function createDynamicPropsClass(properties: PropertyDefinition[]) {
   // Build maps for efficient lookup
   const propNameToType = new Map<string, string>()
   const aliasToProperty = new Map<string, string>()
-
-  const createProperty = (prop: PropertyDefinition, id?: string) =>
-    propsManager.createProperty({
-      ...(id ? { id } : {}),
-      type: prop.type,
-      ...(prop.defaultValue === undefined
-        ? {}
-        : { [prop.name]: prop.defaultValue })
-    })
 
   properties.forEach((prop) => {
     propNameToType.set(prop.name, prop.type)
@@ -35,7 +28,11 @@ export function createDynamicPropsClass(properties: PropertyDefinition[]) {
     elementId: string;
     [key: string]: unknown // Generic index for class methods and properties
 
-    constructor(elementId: string, data?: Partial<PropsRawData>) {
+    constructor(
+      elementId: string,
+      data?: Partial<PropsRawData>,
+      private readonly propsManagerOwner: PropsManager = propsManager
+    ) {
       this.elementId = elementId
 
       if (data) {
@@ -50,11 +47,21 @@ export function createDynamicPropsClass(properties: PropertyDefinition[]) {
       return typeof val === 'string' ? val : undefined
     }
 
+    private createProperty(prop: PropertyDefinition, id?: string) {
+      return this.propsManagerOwner.createProperty({
+        ...(id ? { id } : {}),
+        type: prop.type,
+        ...(prop.defaultValue === undefined
+          ? {}
+          : { [prop.name]: prop.defaultValue })
+      })
+    }
+
     init() {
       // Create property components for each property and store by name
       properties.forEach((prop) => {
-        const component = createProperty(prop)
-        propsManager.addToMap(component)
+        const component = this.createProperty(prop)
+        this.propsManagerOwner.addToMap(component)
         this[prop.name] = component.get('id')
       })
     }
@@ -64,15 +71,15 @@ export function createDynamicPropsClass(properties: PropertyDefinition[]) {
       properties.forEach((prop) => {
         const propId = dataObj[prop.name]
         const propComponent = propId
-          ? propsManager.getPropertyById(propId)
+          ? this.propsManagerOwner.getPropertyById(propId)
           : null
 
         if (propComponent) {
           this[prop.name] = propId
-          propsManager.addToMap(propComponent)
+          this.propsManagerOwner.addToMap(propComponent)
         } else {
-          const component = createProperty(prop, propId)
-          propsManager.addToMap(component)
+          const component = this.createProperty(prop, propId)
+          this.propsManagerOwner.addToMap(component)
           this[prop.name] = component.get('id')
         }
       })
@@ -103,19 +110,20 @@ export function createDynamicPropsClass(properties: PropertyDefinition[]) {
       }
 
       // Update the property component data
-      propsManager.updatePropsData(propId, key, data, options)
+      this.propsManagerOwner.updatePropsData(propId, key, data, options)
     }
 
     cleanup(options?: EvnetOptions) {
       properties.forEach((prop) => {
         const propId = this.getPropId(prop.name)
         if (propId) {
-          propsManager.removeProperty([propId], options)
+          this.propsManagerOwner.removeProperty([propId], options)
         }
       })
     }
   } as unknown as new (
     elementId: string,
-    data?: Partial<PropsRawData>
+    data?: Partial<PropsRawData>,
+    propsManager?: PropsManager
   ) => IProps
 }

--- a/packages/scene-tree/src/entity-data.ts
+++ b/packages/scene-tree/src/entity-data.ts
@@ -7,6 +7,8 @@ import {
 import Workspace from './components/workspace'
 import componentRegistry from './component-registry'
 import type { ISceneTreeRegistry } from './types'
+import propsManager, { type PropsManager } from '@asyra/props-manager'
+import { runWithSceneTreePropsManager } from './props-manager-context'
 
 const initWorkspaceData = {
   type: EntityTypes.WORKSPACE
@@ -26,7 +28,8 @@ export const isGroupEntity = (type: string): boolean => {
 }
 
 export const createElement = (
-  elementData: Partial<ElementRawData>
+  elementData: Partial<ElementRawData>,
+  propsManagerOwner: PropsManager = propsManager
 ): ElementInstanceTypes | null => {
   if (
     elementData.type === EntityTypes.WORKSPACE ||
@@ -42,13 +45,13 @@ export const createElement = (
   const registration = componentRegistry.get(elementType)
   if (registration) {
     const EntityClass = registration.constructor
-    // Make a shallow copy to avoid modifying original object if reference is shared
-    // but here we modify the passed object as per original logic?
-    // Original logic: delete elementData.type
-    // We should follow that.
-    delete elementData.type
+    const constructorData = { ...elementData }
+    delete constructorData.type
 
-    return new EntityClass(elementData)
+    return runWithSceneTreePropsManager(
+      propsManagerOwner,
+      () => new EntityClass(constructorData)
+    )
   }
 
   throw new Error(`No component registered for type: ${elementType}`)

--- a/packages/scene-tree/src/props-manager-context.ts
+++ b/packages/scene-tree/src/props-manager-context.ts
@@ -1,0 +1,19 @@
+import propsManager, { type PropsManager } from '@asyra/props-manager'
+
+let scopedPropsManager: PropsManager | undefined
+
+export const getSceneTreePropsManager = (): PropsManager =>
+  scopedPropsManager ?? propsManager
+
+export const runWithSceneTreePropsManager = <T>(
+  owner: PropsManager,
+  callback: () => T
+): T => {
+  const previousOwner = scopedPropsManager
+  scopedPropsManager = owner
+  try {
+    return callback()
+  } finally {
+    scopedPropsManager = previousOwner
+  }
+}

--- a/packages/scene-tree/src/sceneTree.ts
+++ b/packages/scene-tree/src/sceneTree.ts
@@ -1310,10 +1310,22 @@ class SceneTree {
       }
       return Object.freeze({ elementId: entry.elementId, strategy })
     })
+    const propertyOwnerRelations = entries.flatMap((entry) =>
+      Object.entries(entry.data.props ?? {}).map(
+        ([ownerPropertyName, componentId]) =>
+          Object.freeze({
+            ownerElementId: entry.elementId,
+            ownerElementType: entry.data.type,
+            ownerPropertyName,
+            componentId
+          })
+      )
+    )
     const plan: SceneTreeRestorePlan = Object.freeze({
       kind: 'scene-tree-restore-plan',
       elementId: rootEntry.elementId,
-      entries: Object.freeze(planEntries)
+      entries: Object.freeze(planEntries),
+      propertyOwnerRelations: Object.freeze(propertyOwnerRelations)
     })
     this.validatedRestoreArtifacts.set(plan, {
       snapshot: validated

--- a/packages/scene-tree/src/sceneTree.ts
+++ b/packages/scene-tree/src/sceneTree.ts
@@ -13,6 +13,9 @@ import type {
   MoveHierarchyRequest,
   MoveHierarchyResult,
   RemoveSubtreeResult,
+  SceneTreeRestorePlan,
+  SceneTreeRestoreSnapshot,
+  SceneTreeRestoreStrategy,
   SceneTreeChange,
   SubtreeChange,
   SubtreeRemovalEntry,
@@ -180,6 +183,12 @@ class SceneTree {
     {
       data: SceneTreeRawData
       valid: boolean
+    }
+  >()
+  private validatedRestoreArtifacts = new WeakMap<
+    SceneTreeRestorePlan,
+    {
+      snapshot: SceneTreeRestoreSnapshot
     }
   >()
 
@@ -1085,6 +1094,231 @@ class SceneTree {
       removed,
       rootParentChildrenAfter: cloneSceneTreeValue(rootParentChildrenAfter)
     }
+  }
+
+  preflightRestoreSubtree(snapshot: unknown): SceneTreeRestorePlan {
+    this.validateCanonicalHierarchy()
+    if (!isRecord(snapshot)) {
+      throw new Error(
+        '[SceneTree] Invalid subtree restore: snapshot must be a record'
+      )
+    }
+    if (
+      typeof snapshot.elementId !== 'string' ||
+      snapshot.elementId.length === 0 ||
+      !Array.isArray(snapshot.removed) ||
+      snapshot.removed.length === 0 ||
+      !Array.isArray(snapshot.rootParentChildrenAfter) ||
+      snapshot.rootParentChildrenAfter.some(
+        (childId) => typeof childId !== 'string'
+      )
+    ) {
+      throw new Error(
+        '[SceneTree] Invalid subtree restore: exact hierarchy evidence is required'
+      )
+    }
+
+    const validated = cloneSceneTreeValue(
+      snapshot as unknown as SceneTreeRestoreSnapshot
+    )
+    const rootParentChildrenAfter = [...validated.rootParentChildrenAfter]
+    if (
+      new Set(rootParentChildrenAfter).size !== rootParentChildrenAfter.length
+    ) {
+      throw new Error(
+        '[SceneTree] Invalid subtree restore: duplicate root-parent order evidence'
+      )
+    }
+
+    const entries = validated.removed
+    const entryIds = entries.map(({ elementId }) => elementId)
+    if (
+      entryIds.some((elementId) => typeof elementId !== 'string') ||
+      new Set(entryIds).size !== entryIds.length
+    ) {
+      throw new Error(
+        '[SceneTree] Invalid subtree restore: duplicate or invalid element evidence'
+      )
+    }
+    entries.forEach((entry) => {
+      if (this.getElementById(entry.elementId)) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: active element "${entry.elementId}" already exists`
+        )
+      }
+      if (
+        typeof entry.parentId !== 'string' ||
+        !Number.isInteger(entry.index) ||
+        entry.index < 0 ||
+        !isRecord(entry.data) ||
+        entry.data.id !== entry.elementId ||
+        entry.data.parentId !== entry.parentId ||
+        typeof entry.data.type !== 'string'
+      ) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: malformed element evidence for "${entry.elementId}"`
+        )
+      }
+      if (!componentRegistry.has(entry.data.type)) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: unregistered element type "${entry.data.type}"`
+        )
+      }
+      if (
+        typeof entry.data.name !== 'string' ||
+        typeof entry.data.visible !== 'boolean' ||
+        typeof entry.data.lock !== 'boolean' ||
+        (entry.data.props !== undefined &&
+          (!isRecord(entry.data.props) ||
+            Object.values(entry.data.props).some(
+              (propertyId) => typeof propertyId !== 'string'
+            )))
+      ) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: malformed raw data for "${entry.elementId}"`
+        )
+      }
+    })
+
+    const entryById = new Map(
+      entries.map((entry) => [entry.elementId, entry] as const)
+    )
+    const rootEntry = entries[entries.length - 1]
+    if (rootEntry.elementId !== validated.elementId) {
+      throw new Error(
+        '[SceneTree] Invalid subtree restore: root evidence must be the final post-order entry'
+      )
+    }
+    const rootParent = this.getElementById(rootEntry.parentId)
+    if (!rootParent || !isGroupEntity(rootParent.get('type'))) {
+      throw new Error(
+        `[SceneTree] Invalid subtree restore: missing container parent "${rootEntry.parentId}"`
+      )
+    }
+    const currentRootParentChildren = this.getContainerChildren(
+      rootParent,
+      `Restore root parent "${rootEntry.parentId}"`
+    )
+    if (!isEqual(currentRootParentChildren, rootParentChildrenAfter)) {
+      throw new Error(
+        '[SceneTree] Invalid subtree restore: stale post-delete root-parent order evidence'
+      )
+    }
+    if (
+      rootEntry.index > rootParentChildrenAfter.length ||
+      rootParentChildrenAfter.includes(rootEntry.elementId)
+    ) {
+      throw new Error(
+        `[SceneTree] Invalid subtree restore: root index for "${rootEntry.elementId}" is outside the exact parent range`
+      )
+    }
+
+    const childrenByParent = new Map<string, SubtreeRemovalEntry[]>()
+    entries.forEach((entry) => {
+      if (entry.elementId === rootEntry.elementId) return
+      if (!entryById.has(entry.parentId)) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: missing snapshot parent "${entry.parentId}"`
+        )
+      }
+      const children = childrenByParent.get(entry.parentId) ?? []
+      children.push(entry)
+      childrenByParent.set(entry.parentId, children)
+    })
+
+    entries.forEach((entry) => {
+      const declaredChildren = isGroupEntity(entry.data.type)
+        ? (entry.data as GroupRawData).children
+        : undefined
+      const childEntries = (childrenByParent.get(entry.elementId) ?? []).sort(
+        (left, right) => left.index - right.index
+      )
+      if (!isGroupEntity(entry.data.type)) {
+        if (childEntries.length > 0 || declaredChildren !== undefined) {
+          throw new Error(
+            `[SceneTree] Invalid subtree restore: inconsistent child order for "${entry.elementId}"`
+          )
+        }
+        return
+      }
+      if (
+        !Array.isArray(declaredChildren) ||
+        declaredChildren.some((childId) => typeof childId !== 'string') ||
+        new Set(declaredChildren).size !== declaredChildren.length ||
+        childEntries.some((child, index) => child.index !== index) ||
+        !isEqual(
+          declaredChildren,
+          childEntries.map(({ elementId }) => elementId)
+        )
+      ) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: inconsistent child order for "${entry.elementId}"`
+        )
+      }
+    })
+
+    const postOrder: string[] = []
+    const visiting = new Set<string>()
+    const visited = new Set<string>()
+    const visit = (elementId: string): void => {
+      if (visiting.has(elementId)) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: cycle at "${elementId}"`
+        )
+      }
+      if (visited.has(elementId)) return
+      const entry = entryById.get(elementId)
+      if (!entry) {
+        throw new Error(
+          `[SceneTree] Invalid subtree restore: inconsistent child order at "${elementId}"`
+        )
+      }
+      visiting.add(elementId)
+      if (isGroupEntity(entry.data.type)) {
+        ;(entry.data as GroupRawData).children.forEach(visit)
+      }
+      visiting.delete(elementId)
+      visited.add(elementId)
+      postOrder.push(elementId)
+    }
+    visit(rootEntry.elementId)
+    if (visited.size !== entries.length || !isEqual(postOrder, entryIds)) {
+      throw new Error(
+        '[SceneTree] Invalid subtree restore: inconsistent child order or disconnected hierarchy'
+      )
+    }
+
+    const planEntries = entries.map((entry) => {
+      const tombstone = this._deletedMap.get(entry.elementId)
+      let strategy: SceneTreeRestoreStrategy = 'materialize'
+      if (tombstone) {
+        const tombstoneData = cloneSceneTreeValue(tombstone.save())
+        const expectedTombstoneData = cloneSceneTreeValue(entry.data)
+        expectedTombstoneData.parentId = ''
+        if (isGroupEntity(entry.data.type)) {
+          ;(expectedTombstoneData as GroupRawData).children = []
+        }
+        if (
+          tombstone.get('type') !== entry.data.type ||
+          !isEqual(tombstoneData, expectedTombstoneData)
+        ) {
+          throw new Error(
+            `[SceneTree] Invalid subtree restore: incompatible tombstone for "${entry.elementId}"`
+          )
+        }
+        strategy = 'reuse'
+      }
+      return Object.freeze({ elementId: entry.elementId, strategy })
+    })
+    const plan: SceneTreeRestorePlan = Object.freeze({
+      kind: 'scene-tree-restore-plan',
+      elementId: rootEntry.elementId,
+      entries: Object.freeze(planEntries)
+    })
+    this.validatedRestoreArtifacts.set(plan, {
+      snapshot: validated
+    })
+    return plan
   }
 
   restoreSubtree(

--- a/packages/scene-tree/src/sceneTree.ts
+++ b/packages/scene-tree/src/sceneTree.ts
@@ -1039,6 +1039,22 @@ class SceneTree {
   ): RemoveSubtreeResult {
     this.validateCanonicalHierarchy()
     const removed = this.collectSubtreeRemovalEntries(elementId)
+    const rootEntry = removed[removed.length - 1]
+    const rootParent = this.getElementById(
+      rootEntry.parentId
+    ) as GroupInstanceTypes
+    const rootParentChildrenBefore = this.getContainerChildren(
+      rootParent,
+      `Subtree root parent "${rootEntry.parentId}"`
+    )
+    if (rootParentChildrenBefore[rootEntry.index] !== elementId) {
+      throw new Error(
+        `[SceneTree] Invalid subtree request: stale root membership for "${elementId}"`
+      )
+    }
+    const rootParentChildrenAfter = rootParentChildrenBefore.filter(
+      (_, index) => index !== rootEntry.index
+    )
 
     const workspace = this.currentWorkspace as Workspace
     const operationChangeStart = this.changes.length
@@ -1056,6 +1072,7 @@ class SceneTree {
       eventName: EventTypes.CHANGE_SUBTREE,
       elementId,
       removed: cloneSceneTreeValue(removed),
+      rootParentChildrenAfter: cloneSceneTreeValue(rootParentChildrenAfter),
       action: SCENE_TREE_ACTIONS.REMOVE_SUBTREE,
       undoAction: SCENE_TREE_ACTIONS.RESTORE_SUBTREE
     })
@@ -1063,7 +1080,11 @@ class SceneTree {
     this.commitSceneTreeTransaction(options)
     propsManager.commitChanges(options)
 
-    return { elementId, removed }
+    return {
+      elementId,
+      removed,
+      rootParentChildrenAfter: cloneSceneTreeValue(rootParentChildrenAfter)
+    }
   }
 
   restoreSubtree(
@@ -1163,6 +1184,11 @@ class SceneTree {
     }
 
     const workspace = this.currentWorkspace as Workspace
+    const rootEntry = removed[removed.length - 1]
+    const rootParentChildrenAfter = this.getContainerChildren(
+      this.getElementById(rootEntry.parentId) as GroupInstanceTypes,
+      `Restore root parent "${rootEntry.parentId}"`
+    )
     const operationChangeStart = this.changes.length
     restoreOrder.forEach(({ elementId, parentId, index }) => {
       const restored = this.getRestoreElementById(elementId, false)
@@ -1170,18 +1196,22 @@ class SceneTree {
       workspace.addNewElement(restored, parent, index)
     })
     this.changes.splice(operationChangeStart)
-    const rootEntry = removed[removed.length - 1]
     this.addChange({
       eventName: EventTypes.CHANGE_SUBTREE,
       elementId: rootEntry.elementId,
       removed,
+      rootParentChildrenAfter: cloneSceneTreeValue(rootParentChildrenAfter),
       action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
       undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE
     })
     acknowledgeTransactionReplayApplied()
     this.commitSceneTreeTransaction(options)
 
-    return { elementId: rootEntry.elementId, removed }
+    return {
+      elementId: rootEntry.elementId,
+      removed,
+      rootParentChildrenAfter: cloneSceneTreeValue(rootParentChildrenAfter)
+    }
   }
 
   applySubtreeChange(change: SubtreeChange, options?: EVENT_OPTIONS): boolean {

--- a/packages/scene-tree/src/sceneTree.ts
+++ b/packages/scene-tree/src/sceneTree.ts
@@ -39,7 +39,7 @@ import {
   EventTypes,
   updateTransaction
 } from '@asyra/reactive-events'
-import propsManager from '@asyra/props-manager'
+import propsManager, { type PropsManager } from '@asyra/props-manager'
 import { isEqual } from 'lodash'
 import componentRegistry from './component-registry'
 import {
@@ -191,6 +191,10 @@ class SceneTree {
       snapshot: SceneTreeRestoreSnapshot
     }
   >()
+
+  constructor(
+    private readonly propsManagerOwner: PropsManager = propsManager
+  ) {}
 
   _init(): void {
     if (!this.workspace && !this.workspaceList.length) {
@@ -558,7 +562,7 @@ class SceneTree {
       const element =
         elementData.type === EntityTypes.WORKSPACE
           ? createWorkspace(this, elementData)
-          : createElement(elementData)
+          : createElement(elementData, this.propsManagerOwner)
       if (!element) {
         throw new Error(
           `[SceneTree] Validated hierarchy element "${elementId}" could not be constructed`
@@ -1087,7 +1091,7 @@ class SceneTree {
     })
     acknowledgeTransactionReplayApplied()
     this.commitSceneTreeTransaction(options)
-    propsManager.commitChanges(options)
+    this.propsManagerOwner.commitChanges(options)
 
     return {
       elementId,
@@ -1333,6 +1337,163 @@ class SceneTree {
     return plan
   }
 
+  applyRestoreSubtree(
+    plan: SceneTreeRestorePlan,
+    options?: EVENT_OPTIONS
+  ): RemoveSubtreeResult {
+    const artifact = this.validatedRestoreArtifacts.get(plan)
+    if (!artifact) {
+      throw new Error(
+        '[SceneTree] Expected an owner-issued one-shot subtree restore plan'
+      )
+    }
+    this.validatedRestoreArtifacts.delete(plan)
+
+    const verificationPlan = this.preflightRestoreSubtree(artifact.snapshot)
+    const verificationArtifact =
+      this.validatedRestoreArtifacts.get(verificationPlan)
+    this.validatedRestoreArtifacts.delete(verificationPlan)
+    if (
+      !verificationArtifact ||
+      !isEqual(verificationPlan.entries, plan.entries)
+    ) {
+      throw new Error(
+        '[SceneTree] Cannot apply subtree restore: restore plan is stale'
+      )
+    }
+    const snapshot = verificationArtifact.snapshot
+    const entryById = new Map(
+      snapshot.removed.map((entry) => [entry.elementId, entry] as const)
+    )
+    const prepared = new Map<string, ElementInstanceTypes>()
+    try {
+      plan.entries.forEach(({ elementId, strategy }) => {
+        const entry = entryById.get(elementId)
+        if (!entry) {
+          throw new Error(
+            `[SceneTree] Cannot apply subtree restore: missing prepared evidence for "${elementId}"`
+          )
+        }
+        Object.values(entry.data.props ?? {}).forEach((componentId) => {
+          if (!this.propsManagerOwner.getPropertyById(componentId)) {
+            throw new Error(
+              `[SceneTree] Cannot apply subtree restore: property "${componentId}" is not active`
+            )
+          }
+        })
+        if (strategy === 'reuse') {
+          const tombstone = this._deletedMap.get(elementId)
+          if (!tombstone) {
+            throw new Error(
+              `[SceneTree] Cannot apply subtree restore: stale tombstone "${elementId}"`
+            )
+          }
+          prepared.set(elementId, tombstone)
+          return
+        }
+        if (strategy !== 'materialize') {
+          throw new Error(
+            `[SceneTree] Cannot apply subtree restore: invalid strategy for "${elementId}"`
+          )
+        }
+        const constructorData = cloneSceneTreeValue(entry.data)
+        if (isGroupEntity(constructorData.type)) {
+          ;(constructorData as GroupRawData).children = []
+        }
+        const element = createElement(constructorData, this.propsManagerOwner)
+        if (!element || element.get('id') !== elementId) {
+          throw new Error(
+            `[SceneTree] Cannot apply subtree restore: exact materialization failed for "${elementId}"`
+          )
+        }
+        const expectedPreparedData = cloneSceneTreeValue(entry.data)
+        if (isGroupEntity(expectedPreparedData.type)) {
+          ;(expectedPreparedData as GroupRawData).children = []
+        }
+        if (!isEqual(element.save(), expectedPreparedData)) {
+          ;(element.computed as unknown as { dispose?: () => void }).dispose?.()
+          throw new Error(
+            `[SceneTree] Cannot apply subtree restore: exact data changed for "${elementId}"`
+          )
+        }
+        prepared.set(elementId, element)
+      })
+    } catch (error) {
+      prepared.forEach((element, elementId) => {
+        if (!this._deletedMap.has(elementId)) {
+          ;(element.computed as unknown as { dispose?: () => void }).dispose?.()
+        }
+      })
+      throw error
+    }
+
+    const workspace = this.currentWorkspace as Workspace
+    const restoreOrder = [...snapshot.removed].reverse()
+    const addedIds: string[] = []
+    const operationChangeStart = this.changes.length
+    try {
+      restoreOrder.forEach(({ elementId, parentId, index }) => {
+        const element = prepared.get(elementId)
+        const parent = this.getElementById(parentId)
+        if (!element || !parent || !isGroupEntity(parent.get('type'))) {
+          throw new Error(
+            `[SceneTree] Cannot apply subtree restore: missing prepared hierarchy for "${elementId}"`
+          )
+        }
+        workspace.addNewElement(element, parent as GroupInstanceTypes, index)
+        addedIds.push(elementId)
+      })
+      this.validateCanonicalHierarchy()
+      snapshot.removed.forEach(({ elementId, data }) => {
+        if (!isEqual(this.getElementById(elementId)?.save(), data)) {
+          throw new Error(
+            `[SceneTree] Cannot apply subtree restore: final raw data changed for "${elementId}"`
+          )
+        }
+      })
+    } catch (error) {
+      this.changes.splice(operationChangeStart)
+      addedIds.reverse().forEach((elementId) => {
+        const element = this._elements.get(elementId)
+        if (!element) return
+        const parent = this.getElementById(element.get('parentId'))
+        if (parent && isGroupEntity(parent.get('type'))) {
+          ;(parent as GroupInstanceTypes).removeElement(element)
+        }
+        this._elements.delete(elementId)
+        const strategy = plan.entries.find(
+          (entry) => entry.elementId === elementId
+        )?.strategy
+        if (strategy === 'reuse') {
+          this._deletedMap.set(elementId, element)
+        } else {
+          ;(element.computed as unknown as { dispose?: () => void }).dispose?.()
+        }
+      })
+      prepared.forEach((element, elementId) => {
+        if (!addedIds.includes(elementId) && !this._deletedMap.has(elementId)) {
+          ;(element.computed as unknown as { dispose?: () => void }).dispose?.()
+        }
+      })
+      throw error
+    }
+
+    this.changes.splice(operationChangeStart)
+    this.addChange({
+      eventName: EventTypes.CHANGE_SUBTREE,
+      elementId: snapshot.elementId,
+      removed: cloneSceneTreeValue([...snapshot.removed]),
+      rootParentChildrenAfter: cloneSceneTreeValue([
+        ...snapshot.rootParentChildrenAfter
+      ]),
+      action: SCENE_TREE_ACTIONS.RESTORE_SUBTREE,
+      undoAction: SCENE_TREE_ACTIONS.REMOVE_SUBTREE
+    })
+    acknowledgeTransactionReplayApplied()
+    this.commitSceneTreeTransaction(options)
+    return cloneSceneTreeValue(snapshot)
+  }
+
   restoreSubtree(
     entries: readonly SubtreeRemovalEntry[],
     options?: EVENT_OPTIONS
@@ -1567,7 +1728,10 @@ class SceneTree {
       return null
     }
 
-    const newElement = createElement(elementData) as ElementInstanceTypes
+    const newElement = createElement(
+      elementData,
+      this.propsManagerOwner
+    ) as ElementInstanceTypes
     if (recordChange) {
       this.addChangeForAddElement(newElement)
     }
@@ -1622,7 +1786,7 @@ class SceneTree {
       )
 
       acknowledgeTransactionReplayApplied()
-      propsManager.commitChanges(options)
+      this.propsManagerOwner.commitChanges(options)
       this.commitSceneTreeTransaction(options)
 
       return newElement.get('id')
@@ -1690,7 +1854,7 @@ class SceneTree {
     }
     acknowledgeTransactionReplayApplied()
     this.commitSceneTreeTransaction(options)
-    propsManager.commitChanges(options)
+    this.propsManagerOwner.commitChanges(options)
     return true
   }
 
@@ -1875,7 +2039,7 @@ class SceneTree {
       return
     }
 
-    const propComponent = propsManager.getPropertyById(propId)
+    const propComponent = this.propsManagerOwner.getPropertyById(propId)
     if (!propComponent) {
       return
     }

--- a/packages/utils/src/types/props-manager.ts
+++ b/packages/utils/src/types/props-manager.ts
@@ -1,6 +1,7 @@
 import { PROPS_ACTIONS } from '../constants'
 import { PropertyComponentRawData } from '../propsManager'
 import { DataTypes } from './constants'
+import type { ElementPropertyOwnerRelation } from './scene-tree'
 import type { MutationOptions } from './change'
 import type { YjsChange } from './yjs'
 
@@ -27,5 +28,22 @@ export interface UpdatePropertyChange {
 }
 
 export type PropsChange = AddRemovePropertyChange | UpdatePropertyChange
+
+export type PropsRestoreStrategy = 'reuse' | 'materialize'
+
+export interface PropsRestoreSnapshot {
+  readonly components: readonly PropertyComponentRawData[]
+}
+
+export interface PropsRestorePlanEntry {
+  readonly componentId: string
+  readonly strategy: PropsRestoreStrategy
+}
+
+export interface PropsRestorePlan {
+  readonly kind: 'props-restore-plan'
+  readonly entries: readonly PropsRestorePlanEntry[]
+  readonly ownerRelations: readonly ElementPropertyOwnerRelation[]
+}
 
 export interface PropsYjsChange extends YjsChange<PropsChange> {}

--- a/packages/utils/src/types/scene-tree.ts
+++ b/packages/utils/src/types/scene-tree.ts
@@ -41,6 +41,25 @@ export interface RemoveSubtreeResult {
   rootParentChildrenAfter: readonly string[]
 }
 
+export type SceneTreeRestoreStrategy = 'reuse' | 'materialize'
+
+export interface SceneTreeRestorePlanEntry {
+  readonly elementId: string
+  readonly strategy: SceneTreeRestoreStrategy
+}
+
+export interface SceneTreeRestorePlan {
+  readonly kind: 'scene-tree-restore-plan'
+  readonly elementId: string
+  readonly entries: readonly SceneTreeRestorePlanEntry[]
+}
+
+export interface SceneTreeRestoreSnapshot {
+  readonly elementId: string
+  readonly removed: readonly SubtreeRemovalEntry[]
+  readonly rootParentChildrenAfter: readonly string[]
+}
+
 export interface AddRemoveElementChange {
   action: SCENE_TREE_ACTIONS
   undoType: string

--- a/packages/utils/src/types/scene-tree.ts
+++ b/packages/utils/src/types/scene-tree.ts
@@ -38,6 +38,7 @@ export interface SubtreeRemovalEntry {
 export interface RemoveSubtreeResult {
   elementId: string
   removed: readonly SubtreeRemovalEntry[]
+  rootParentChildrenAfter: readonly string[]
 }
 
 export interface AddRemoveElementChange {
@@ -66,6 +67,7 @@ export interface SubtreeChange {
   eventName: string
   elementId: string
   removed: SubtreeRemovalEntry[]
+  rootParentChildrenAfter: string[]
   options?: MutationOptions
 }
 

--- a/packages/utils/src/types/scene-tree.ts
+++ b/packages/utils/src/types/scene-tree.ts
@@ -48,10 +48,18 @@ export interface SceneTreeRestorePlanEntry {
   readonly strategy: SceneTreeRestoreStrategy
 }
 
+export interface ElementPropertyOwnerRelation {
+  readonly ownerElementId: string
+  readonly ownerElementType: string
+  readonly ownerPropertyName: string
+  readonly componentId: string
+}
+
 export interface SceneTreeRestorePlan {
   readonly kind: 'scene-tree-restore-plan'
   readonly elementId: string
   readonly entries: readonly SceneTreeRestorePlanEntry[]
+  readonly propertyOwnerRelations: readonly ElementPropertyOwnerRelation[]
 }
 
 export interface SceneTreeRestoreSnapshot {

--- a/tools/flow-inspector/__tests__/viewer-entry.test.cjs
+++ b/tools/flow-inspector/__tests__/viewer-entry.test.cjs
@@ -106,6 +106,15 @@ const createViewerDom = (entryPath, dataScript, data) => {
 
 const targets = [
   {
+    id: 'asyra-design-remote-subtree-restore-snapshot',
+    entryPath: path.join(
+      projectRoot,
+      'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.html'
+    ),
+    dataScript: './remote-subtree-restore-snapshot-flow-inspector.data.cjs',
+    filterLaneTitle: 'Canonical Owner Restore'
+  },
+  {
     id: 'asyra-design-group-interaction-mvp',
     entryPath: path.join(
       projectRoot,

--- a/tools/flow-inspector/embed-viewer.cjs
+++ b/tools/flow-inspector/embed-viewer.cjs
@@ -12,6 +12,10 @@ const rendererSource = fs
 const targetEntries = [
   path.join(
     projectRoot,
+    'docs/ai/apps/asyra-design/plans/remote-subtree-restore-snapshot-flow-inspector.html'
+  ),
+  path.join(
+    projectRoot,
     'docs/ai/apps/asyra-design/plans/group-interaction-mvp-flow-inspector.html'
   ),
   path.join(


### PR DESCRIPTION
## Summary

- capture exact detached Scene Tree and Props restore evidence in the existing Factory publication boundary
- validate and atomically materialize remote subtree restores with or without compatible receiver tombstones
- preserve transport-only Collaboration, no-undo/no-echo remote settlement, stable identities, hierarchy, properties, and ordinary Render/Layers projection
- publish exact Props snapshots during Group redo so receiving clients preserve canonical geometry
- close the approved Remote Subtree Restore Snapshot plan and advance the app plan queue

## Validation

- Remote Restore Inspector contract: 12/12
- root script tests: 21/21
- Props Manager: 80/80
- Factory: 114/114
- Core: 167/167
- Asyra Design: 167/167 plus Node contracts 18/18
- collaboration E2E: 6/6
- dependency validation, lint, root production build, app-template synchronization, and synchronized visual review passed