### PR TITLE
docs(asyra-design): close group context menu follow-up

### DIFF
--- a/docs/ai/apps/asyra-design/PLANS.md
+++ b/docs/ai/apps/asyra-design/PLANS.md
@@ -5,19 +5,17 @@ Never record completed plans here.
 ## Current Status
 
 - Ordered proposed next implementation plans: none.
-- Current active plan:
-  `plans/group-context-menu-plan.md`.
-- The plan was reopened on 2026-07-25 after post-closeout product review to
-  remove the superseded Layers/Contents Group and Ungroup buttons.
+- Current active plan: none.
 - Group Interaction MVP and Layer Tree Reparent/Reorder completed on
-  2026-07-24. Remote Subtree Restore Snapshot completed on 2026-07-25. Their
-  canonical records are:
+  2026-07-24. Remote Subtree Restore Snapshot and Group Context Menu completed
+  on 2026-07-25. Their canonical records are:
   1. `plans/completed/group-interaction-mvp-plan.md`
   2. `plans/completed/layer-tree-reparent-reorder-plan.md`
   3. `plans/completed/remote-subtree-restore-snapshot-plan.md`
+  4. `plans/completed/group-context-menu-plan.md`
 - The separately queued app/server plan after the completed network
-  collaboration transport Gate 2 remains sequenced behind the active Group
-  Context Menu follow-up and inactive until the user explicitly starts it:
+  collaboration transport Gate 2 is now the next queued plan, but remains
+  inactive until the user explicitly starts it:
   `plans/durable-collaboration-server-and-continuous-sync-plan.md`.
 - Deferred profiling candidate, neither active nor queued:
   `plans/vector-gradient-move-120fps-plan.md`.

--- a/docs/ai/apps/asyra-design/decisions/releases/unreleased.md
+++ b/docs/ai/apps/asyra-design/decisions/releases/unreleased.md
@@ -6835,3 +6835,33 @@ join` constrained dashed product path across:
     the earlier completion record is no longer the active canonical path.
 - Related Plan:
   - `docs/ai/apps/asyra-design/plans/group-context-menu-plan.md`
+
+## 2026-07-25 - Complete the Group Context Menu button-removal follow-up
+
+- Context:
+  - Post-closeout review reopened the Group Context Menu plan because the
+    Layers/Contents header still exposed Group and Ungroup buttons even though
+    Context Menu and operating-system shortcuts already owned those command
+    surfaces.
+  - The follow-up added formal absence oracles, removed the controls, and
+    migrated product E2E setup to the registered shortcuts.
+- Decision:
+  - Close the reopened plan after its corrected Group Context Menu and Group
+    Interaction Inspector contracts, Gherkin/BDD, app tests, affected ordinary
+    and collaboration E2E, template gates, builds, synchronized visual review,
+    and explicit user approval.
+  - Keep Context Menu and shortcuts as the only Group/Ungroup command surfaces
+    while retaining the existing feature, eligibility, transaction, selection,
+    hierarchy, and failure owners.
+  - Supersede the 2026-07-25 reopen state and its then-active plan path with the
+    completed canonical record below; retain both earlier entries as
+    append-only decision history.
+- Consequences:
+  - The Layers/Contents header contains no Group or Ungroup button or
+    command-specific test id.
+  - PR #97 remains open for integration checks and merge review; closeout does
+    not authorize merge.
+  - The durable collaboration server and continuous sync plan becomes the next
+    separately queued app plan and remains inactive until explicitly started.
+- Related Plan:
+  - `docs/ai/apps/asyra-design/plans/completed/group-context-menu-plan.md`

--- a/docs/ai/apps/asyra-design/plans/__tests__/group-context-menu-flow-inspector.contract.test.cjs
+++ b/docs/ai/apps/asyra-design/plans/__tests__/group-context-menu-flow-inspector.contract.test.cjs
@@ -37,7 +37,7 @@ test('Group Context Menu Inspector authorities resolve', () => {
   assert.equal(data.target.title, 'Asyra Design Group Context Menu Inspector')
   assert.equal(
     data.authority.specPath,
-    'docs/ai/apps/asyra-design/plans/group-context-menu-plan.md'
+    'docs/ai/apps/asyra-design/plans/completed/group-context-menu-plan.md'
   )
   assert.equal(
     data.authority.inspectorPath,

--- a/docs/ai/apps/asyra-design/plans/completed/group-context-menu-plan.md
+++ b/docs/ai/apps/asyra-design/plans/completed/group-context-menu-plan.md
@@ -1,16 +1,24 @@
 # Asyra Design Group Context Menu Plan
 
-## Status and Priority
+## Completion
 
-Reopened on 2026-07-25 after post-closeout product review. The prior closeout
-decision remains in append-only history but is superseded for this PR by the
-explicit requirement to remove the Group and Ungroup buttons from the
-Layers/Contents header.
+Completed again on 2026-07-25 after the post-closeout product follow-up passed
+its required gates and received explicit user closeout authorization.
 
-This plan is active until that follow-up passes its Inspector/readiness,
-formal, E2E, template, and synchronized visual gates and receives a new user
-review. Context Menu and operating-system shortcuts are the only Group/Ungroup
-command surfaces in scope.
+- Outcome: canvas right-click opens one accessible app-owned Context Menu with
+  fixed Group and Ungroup rows, accurate operating-system shortcuts, and no
+  Group or Ungroup buttons in the Layers/Contents header.
+- Final decision: Context Menu and registered shortcuts are the only
+  Group/Ungroup command surfaces; Asyra Design retains session, descriptor,
+  eligibility, and routing policy; Design System retains reusable
+  presentation; and the existing Group feature remains the sole transaction,
+  selection, hierarchy, and failure path.
+- Canonical record:
+  `docs/ai/apps/asyra-design/plans/completed/group-context-menu-plan.md`.
+- Exit criteria: Inspector/readiness and Gherkin contracts, the failing
+  button-absence regression, affected app and collaboration E2E, dependency,
+  lint, build, template synchronization/build, synchronized visual review, and
+  bounded direct-consumer review passed before this closeout.
 
 Architecture authority:
 

--- a/docs/ai/apps/asyra-design/plans/durable-collaboration-server-and-continuous-sync-plan.md
+++ b/docs/ai/apps/asyra-design/plans/durable-collaboration-server-and-continuous-sync-plan.md
@@ -4,9 +4,9 @@
 
 Queued behind
 `docs/ai/apps/asyra-design/plans/completed/remote-subtree-restore-snapshot-plan.md`
-and the active
-`docs/ai/apps/asyra-design/plans/group-context-menu-plan.md` follow-up as a
-later Asyra Design app/server implementation stage after the completed network
+and
+`docs/ai/apps/asyra-design/plans/completed/group-context-menu-plan.md` as the
+next Asyra Design app/server implementation stage after the completed network
 collaboration transport Gate 2. It remains inactive until the user explicitly
 starts it.
 

--- a/docs/ai/apps/asyra-design/plans/group-context-menu-flow-inspector.data.cjs
+++ b/docs/ai/apps/asyra-design/plans/group-context-menu-flow-inspector.data.cjs
@@ -1,7 +1,8 @@
 ;(function () {
   'use strict'
 
-  const specPath = 'docs/ai/apps/asyra-design/plans/group-context-menu-plan.md'
+  const specPath =
+    'docs/ai/apps/asyra-design/plans/completed/group-context-menu-plan.md'
   const inspectorPath =
     'docs/ai/apps/asyra-design/plans/group-context-menu-flow-inspector.data.cjs'
 
@@ -734,7 +735,7 @@
         id: 'group-context-menu-plan',
         kind: 'authority',
         label: 'Product contract',
-        href: './group-context-menu-plan.md'
+        href: './completed/group-context-menu-plan.md'
       },
       {
         id: 'existing-group-inspector',


### PR DESCRIPTION
## Summary

- move the completed Group Context Menu plan into completed records
- record the follow-up decision that Layers no longer owns Group/Ungroup controls
- align the Inspector contract test and metadata with the completed plan path
- mark Durable Collaboration Server and Continuous Sync as the next queued app/server plan

## Validation

- `node --test docs/ai/apps/asyra-design/plans/__tests__/group-context-menu-flow-inspector.contract.test.cjs` (13/13 passed)
- `yarn lint:ci` (0 errors, 52 existing warnings)
- `git diff --check HEAD^ HEAD`