### PR TITLE
perf: start dev watchers without prebuild

### DIFF
--- a/apps/asyra-design/README.md
+++ b/apps/asyra-design/README.md
@@ -15,6 +15,15 @@ Install dependencies from the repository root:
 yarn install
 ```
 
+On a fresh clone, build the workspace outputs once before starting development:
+
+```bash
+yarn react:build
+```
+
+After running `yarn clean`, run `yarn react:build` again before starting
+development. Ordinary development sessions can reuse the existing outputs.
+
 ## Local Service Configuration
 
 The checked-in `apps/asyra-design/.env` configures the frontend, socket
@@ -59,8 +68,9 @@ yarn dev:all
 ```
 
 `dev:all` starts all workspace package watchers plus the App dev server only.
-It assumes the workspace `dist` outputs already exist; use the explicit build
-commands after a clean checkout or `yarn clean`. The backend and socket server
+It does not create missing workspace `dist` outputs. On a fresh clone, run
+`yarn install` and `yarn react:build` before `yarn dev:all`; after `yarn clean`,
+run `yarn react:build` before `yarn dev:all`. The backend and socket server
 remain the explicit first two terminals above.
 
 Open one required non-empty `fileId`, for example:

--- a/apps/asyra-design/README.md
+++ b/apps/asyra-design/README.md
@@ -58,9 +58,10 @@ Start the frontend in a third terminal:
 yarn dev:all
 ```
 
-`dev:all` builds and starts the required workspace packages plus the
-App dev server only. The backend and socket server remain the explicit first
-two terminals above.
+`dev:all` starts all workspace package watchers plus the App dev server only.
+It assumes the workspace `dist` outputs already exist; use the explicit build
+commands after a clean checkout or `yarn clean`. The backend and socket server
+remain the explicit first two terminals above.
 
 Open one required non-empty `fileId`, for example:
 

--- a/apps/asyra-design/e2e/render-delta-performance.spec.ts
+++ b/apps/asyra-design/e2e/render-delta-performance.spec.ts
@@ -131,6 +131,7 @@ test.describe('Render delta performance budget', () => {
         const {
           core,
           elementApis,
+          getActiveCollaborationHandle,
           subscribeToBrowserDragPhases,
           subscribeToDiagnosticCounters
         } = await import('../src/testing/runtime-access')
@@ -231,6 +232,19 @@ test.describe('Render delta performance budget', () => {
           ],
           { undoable: false }
         )
+
+        const collaboration = getActiveCollaborationHandle()
+        if (!collaboration) {
+          throw new Error(
+            'Collaboration runtime is unavailable for isolated profiling'
+          )
+        }
+        await collaboration.whenIdle()
+        if (collaboration.getStatus() !== 'connected') {
+          throw new Error(
+            'Collaboration runtime did not settle before isolated profiling'
+          )
+        }
 
         await new Promise<void>((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(() => resolve()))

--- a/docs/ai/apps/asyra-design/modules/e2e.md
+++ b/docs/ai/apps/asyra-design/modules/e2e.md
@@ -102,6 +102,10 @@ test:e2e:balanced-ai-correctness` runs that heavy case explicitly with one
 - CI runs the dense-vector Render timing budget first with one isolated worker,
   then excludes that file while parallelizing the remaining functional suite;
   the formal timing thresholds are not relaxed to absorb runner contention
+- after creating the dense-vector fixture, the timing test waits for the active
+  Collaboration session and publication outbox to become idle before installing
+  phase timers; setup publication work is excluded without changing the normal
+  App composition or timing thresholds
 - pull-request CI resolves the balanced AI heavy gate from the exact
   base-to-head changed paths in
   `scripts/balanced-ai-correctness-scope.mjs`; unrelated changes and scheduled

--- a/docs/ai/framework/plans/completed/render-delta-update-plan.md
+++ b/docs/ai/framework/plans/completed/render-delta-update-plan.md
@@ -343,6 +343,12 @@ vector geometry cache. The existing element-id derived snapshot remains the
 semantic target of the delta projection; its dimension may not expand without new
 profiling.
 
+Before installing the phase timers, the formal fixture creates its vector and
+fill, then waits for the active Collaboration session and publication outbox to
+be idle and confirms that the session remains connected. This excludes fixture
+setup publication work from the measured Render phases without changing the
+ordinary App composition or any formal timing threshold.
+
 For this bounded 12-frame sample, p50 and p95 use the lower sample quantile at
 `floor((sampleCount - 1) * ratio)`. The maximum sample retains its own explicit
 oracle, so the p95 and max budgets remain independent. The first vector

--- a/docs/ai/workflows/package-release-validation.md
+++ b/docs/ai/workflows/package-release-validation.md
@@ -38,9 +38,23 @@ command that does.
 `dev:all` discovers `packages/*` from their manifests and starts every package
 `dev` command plus the Asyra Design dev server in parallel. It does not validate
 the Turbo graph or build workspace packages; existing `dist` outputs are a
-precondition. Use the explicit build commands after a clean checkout or
-`yarn clean`. `clean` remains a Turbo workspace command; every package that
-emits `dist` must provide `clean`.
+precondition. A fresh clone must use this sequence from the repository root:
+
+```bash
+yarn install
+yarn react:build
+yarn dev:all
+```
+
+After `yarn clean`, recreate the outputs before restarting the watchers:
+
+```bash
+yarn react:build
+yarn dev:all
+```
+
+`clean` remains a Turbo workspace command; every package that emits `dist` must
+provide `clean`.
 
 ## Script Tests
 

--- a/docs/ai/workflows/package-release-validation.md
+++ b/docs/ai/workflows/package-release-validation.md
@@ -35,9 +35,12 @@ Any root, app, CI, E2E, or deployment command that directly depends on a
 package-specific Turbo task must first pass `gen:turbo:check` or call a root
 command that does.
 
-`dev:all` discovers `packages/*` from their manifests, builds them in workspace
-dependency order, and starts each package's `dev` command. `clean` remains a
-Turbo workspace command; every package that emits `dist` must provide `clean`.
+`dev:all` discovers `packages/*` from their manifests and starts every package
+`dev` command plus the Asyra Design dev server in parallel. It does not validate
+the Turbo graph or build workspace packages; existing `dist` outputs are a
+precondition. Use the explicit build commands after a clean checkout or
+`yarn clean`. `clean` remains a Turbo workspace command; every package that
+emits `dist` must provide `clean`.
 
 ## Script Tests
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "reference-implementation"
   ],
   "scripts": {
-    "dev:all": "yarn gen:turbo:check && node scripts/dev-all.js",
+    "dev:all": "node scripts/dev-all.js",
     "watch:design-system": "turbo run watch:design-system",
     "rebuild:design-system": "yarn workspace @asyra/design-system rebuild:design-system",
     "react:build": "yarn gen:turbo:check && turbo run react:build",

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -105,16 +105,17 @@ test('root commands validate the committed Turbo graph without rewriting it', ()
 test('Asyra Design keeps frontend startup, live transport, and local persistence separate', () => {
   const rootManifest = readJSON('package.json')
   const appReadme = readText('apps/asyra-design/README.md')
+  const devAllRunner = readText('scripts/dev-all.js')
 
-  assert.equal(
-    rootManifest.scripts['dev:all'],
-    'yarn gen:turbo:check && node scripts/dev-all.js'
-  )
+  assert.equal(rootManifest.scripts['dev:all'], 'node scripts/dev-all.js')
+  assert.doesNotMatch(rootManifest.scripts['dev:all'], /gen:turbo/)
+  assert.doesNotMatch(devAllRunner, /initialBuilds/)
   assert.match(appReadme, /yarn dev:all/)
   assert.match(
     appReadme,
-    /`dev:all` builds and starts.*workspace packages.*App\s+dev server only/is
+    /`dev:all` starts.*workspace package watchers.*App\s+dev server only/is
   )
+  assert.doesNotMatch(appReadme, /`dev:all` builds/i)
   assert.doesNotMatch(
     appReadme,
     /workspace packages,\s+the memory-only WebSocket reference server,\s+and the App dev server/i
@@ -358,17 +359,20 @@ test('AI agent runtime is an optional zero-runtime-dependency workspace package'
   )
 })
 
-test('dev:all discovers collaboration and orders its Factory dependency first', async () => {
+test('dev:all discovers all package watchers without scheduling builds', async () => {
   const plan = await createWorkspaceDevAllPlan(repositoryRoot)
-  const initialDirectories = plan.initialBuilds.map(({ dir }) => dir)
   const devDirectories = plan.devProcesses.map(({ dir }) => dir)
+  const expectedDirectories = fs
+    .readdirSync(path.join(repositoryRoot, 'packages'), {
+      withFileTypes: true
+    })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join('packages', entry.name))
+    .sort()
 
-  assert.ok(initialDirectories.includes('packages/collaboration'))
-  assert.ok(devDirectories.includes('packages/collaboration'))
-  assert.ok(
-    initialDirectories.indexOf('packages/factory') <
-      initialDirectories.indexOf('packages/collaboration')
-  )
+  assert.deepEqual(devDirectories, expectedDirectories)
+  assert.ok(plan.devProcesses.every(({ cmd }) => cmd === 'yarn dev'))
+  assert.equal('initialBuilds' in plan, false)
   assert.equal('serviceBuilds' in plan, false)
   assert.equal('services' in plan, false)
   assert.deepEqual(plan.app, {

--- a/scripts/dev-all-plan.js
+++ b/scripts/dev-all-plan.js
@@ -5,19 +5,8 @@ import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const DEFAULT_REPO_ROOT = path.resolve(__dirname, '..')
-const WORKSPACE_SCOPE = '@asyra/'
-const DESIGN_SYSTEM_PACKAGE = 'design-system'
-
-export const createInitialBuildCommand = (packageName) =>
-  packageName === DESIGN_SYSTEM_PACKAGE
-    ? 'yarn build:design-system'
-    : 'yarn exec tsc --pretty false'
 
 export const createDevAllPlan = (packageNames) => ({
-  initialBuilds: packageNames.map((packageName) => ({
-    dir: path.join('packages', packageName),
-    cmd: createInitialBuildCommand(packageName)
-  })),
   devProcesses: packageNames.map((packageName) => ({
     dir: path.join('packages', packageName),
     cmd: 'yarn dev'
@@ -28,92 +17,28 @@ export const createDevAllPlan = (packageNames) => ({
   }
 })
 
-const getManifestWorkspaceDeps = (manifest, packageNames) => {
-  const workspacePackageNames = new Set(packageNames)
-  const deps = {
-    ...(manifest.dependencies ?? {}),
-    ...(manifest.peerDependencies ?? {})
-  }
-
-  return Object.keys(deps)
-    .filter((dependencyName) => dependencyName.startsWith(WORKSPACE_SCOPE))
-    .map((dependencyName) => dependencyName.slice(WORKSPACE_SCOPE.length))
-    .filter((dependencyName) => workspacePackageNames.has(dependencyName))
-}
-
-export const orderPackageNamesByWorkspaceDependencies = (
-  packageNames,
-  manifestsByPackageName
-) => {
-  const ordered = []
-  const visiting = new Set()
-  const visited = new Set()
-  const packageNameSet = new Set(packageNames)
-
-  const visit = (packageName) => {
-    if (visited.has(packageName)) {
-      return
-    }
-    if (visiting.has(packageName)) {
-      throw new Error(
-        `Workspace dependency cycle detected while planning dev:all: ${packageName}`
-      )
-    }
-    visiting.add(packageName)
-
-    const manifest = manifestsByPackageName.get(packageName)
-    if (manifest) {
-      for (const dependencyName of getManifestWorkspaceDeps(
-        manifest,
-        packageNames
-      )) {
-        if (packageNameSet.has(dependencyName)) {
-          visit(dependencyName)
-        }
-      }
-    }
-
-    visiting.delete(packageName)
-    visited.add(packageName)
-    ordered.push(packageName)
-  }
-
-  for (const packageName of packageNames) {
-    visit(packageName)
-  }
-
-  return ordered
-}
-
-export const readWorkspacePackageManifests = async (
+export const readWorkspacePackageNames = async (
   repoRoot = DEFAULT_REPO_ROOT
 ) => {
   const packagesDir = path.resolve(repoRoot, 'packages')
   const dirs = await fs.readdir(packagesDir, { withFileTypes: true })
-  const manifestsByPackageName = new Map()
+  const packageNames = dirs
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name)
+    .sort()
 
-  for (const dirent of dirs) {
-    if (!dirent.isDirectory()) {
-      continue
-    }
-    const packageName = dirent.name
-    const packageJsonPath = path.join(packagesDir, packageName, 'package.json')
-    const manifest = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'))
-    manifestsByPackageName.set(packageName, manifest)
-  }
-
-  return manifestsByPackageName
+  await Promise.all(
+    packageNames.map(async (packageName) => {
+      const manifestPath = path.join(packagesDir, packageName, 'package.json')
+      JSON.parse(await fs.readFile(manifestPath, 'utf8'))
+    })
+  )
+  return packageNames
 }
 
 export const createWorkspaceDevAllPlan = async (
   repoRoot = DEFAULT_REPO_ROOT
 ) => {
-  const manifestsByPackageName = await readWorkspacePackageManifests(repoRoot)
-  const packageNames = [...manifestsByPackageName.keys()].sort()
-  const orderedPackageNames = orderPackageNamesByWorkspaceDependencies(
-    packageNames,
-    manifestsByPackageName
-  )
-
-  return createDevAllPlan(orderedPackageNames)
+  const packageNames = await readWorkspacePackageNames(repoRoot)
+  return createDevAllPlan(packageNames)
 }

--- a/scripts/dev-all.js
+++ b/scripts/dev-all.js
@@ -45,10 +45,6 @@ async function runAll() {
   try {
     const plan = await createWorkspaceDevAllPlan(repoRoot)
 
-    for (const { dir, cmd } of plan.initialBuilds) {
-      await runCommand(cmd, path.resolve(repoRoot, dir))
-    }
-
     await Promise.all(
       [...plan.devProcesses, plan.app].map(({ dir, cmd }) => {
         return runCommand(cmd, path.resolve(repoRoot, dir))


### PR DESCRIPTION
## Summary

- keep the custom dev-all supervisor and start all package watchers plus the App dev server in parallel
- remove the serial workspace prebuild, dependency ordering, and unrelated Turbo graph check
- document existing dist outputs as a precondition and add regression coverage for the watcher-only contract

## Performance evidence

- before: watcher and App startup was blocked for about 27 seconds by 19 serial initial builds
- after: all 19 package watcher commands and the App command are dispatched within the first 1 second
- Vite reported ready in 1.539 seconds during the final smoke test
- all TypeScript watchers completed their initial compilation with 0 errors in about 6 seconds
- Ctrl-C cleanup left no watcher process or port 3000 listener

## Validation

- test-first regression failed against the old Turbo-check and dependency-ordered initial-build contract
- yarn test:scripts
- yarn gen:turbo:check
- yarn lint:ci
- yarn react:build
- yarn test:local
- focused ESLint and Prettier checks
- PID-tracked yarn dev:all smoke test