### PR TITLE
build: upgrade supported runtime to Node 24

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Setup Yarn
         run: corepack enable && yarn set version 4.3.1
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies
@@ -67,10 +67,10 @@ jobs:
       - name: Setup Yarn
         run: corepack enable && yarn set version 4.3.1
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: 24
           cache: 'yarn'
 
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: 24
           cache: 'yarn'
 
       - name: Install dependencies
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: 24
           cache: 'yarn'
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Framework packages now publish explicit ESM entrypoints, declaration files,
-  package-local licenses, Node.js 20.x engines, and exact internal production
+  package-local licenses, Node.js 24.x engines, and exact internal production
   dependency ranges in packed artifacts.
 - The generated Asyra Design template now installs and builds independently
   from packed artifacts without workspace aliases or dependency hoisting.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ authorization, or UI behavior.
 ## Release support
 
 Framework `0.2.5` is the release-readiness candidate for the 19 public
-`@asyra/*` packages. The formal environment is Node.js 20.x and Yarn 4.3.1.
+`@asyra/*` packages. The formal environment is Node.js 24.x and Yarn 4.3.1.
 The release supports the official 2D preset and engine-neutral CUSTOM
 composition; production 3D, HYBRID, auto-layout, and unit-aware aggregation are
 not available in this release.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,7 +21,7 @@ The candidate supports:
 - explicitly composed AI action plans through registered app actions;
 - side-effect-free operation when Collaboration or AI is not enabled.
 
-The supported runtime is Node.js 20.x with Yarn 4.3.1. Declarations are
+The supported runtime is Node.js 24.x with Yarn 4.3.1. Declarations are
 validated with TypeScript 5.8.3, and the React surface targets React 19. The
 formal browser evidence uses the current Chromium supplied by Playwright 1.57.
 

--- a/apps/asyra-design/README.md
+++ b/apps/asyra-design/README.md
@@ -6,7 +6,7 @@ state, rendering, interaction, and collaboration APIs.
 
 ## Requirements
 
-- Node.js 20.x
+- Node.js 24.x
 - Yarn 4.3.1
 
 Install dependencies from the repository root:

--- a/apps/asyra-design/TEMPLATE.md
+++ b/apps/asyra-design/TEMPLATE.md
@@ -6,7 +6,7 @@ artifacts and imports only declared public entrypoints.
 
 ## Requirements
 
-- Node.js 20.x
+- Node.js 24.x
 - Yarn 4.3.1
 
 ## Install and verify

--- a/apps/asyra-design/package.json
+++ b/apps/asyra-design/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.5",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
   "dependencies": {
     "@asyra/ai-agent-runtime": "workspace:*",
     "@asyra/collaboration": "workspace:*",

--- a/create-app/asyra-design/template/README.md
+++ b/create-app/asyra-design/template/README.md
@@ -6,7 +6,7 @@ artifacts and imports only declared public entrypoints.
 
 ## Requirements
 
-- Node.js 20.x
+- Node.js 24.x
 - Yarn 4.3.1
 
 ## Install and verify

--- a/create-app/asyra-design/template/package.json
+++ b/create-app/asyra-design/template/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.5",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
   "dependencies": {
     "@asyra/ai-agent-runtime": "0.2.5",
     "@asyra/collaboration": "0.2.5",
@@ -99,9 +102,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "engines": {
-    "node": "20.x"
   },
   "packageManager": "yarn@4.3.1"
 }

--- a/docs/ai/decisions/releases/unreleased.md
+++ b/docs/ai/decisions/releases/unreleased.md
@@ -332,3 +332,38 @@ Append-only rule: do not edit/delete prior entries; add a superseding entry when
   - `docs/ai/framework/plans/asyra-framework-website-plan.md`
 - Related Commit(s):
   - pending
+
+## 2026-08-05 - Complete the Node.js 24 runtime prerequisite
+
+- Context:
+  - Framework package publication remained blocked until local, CI, generated
+    consumer, Asyra Design, and Vercel evidence agreed on one Node.js runtime.
+  - The existing Vercel project still selected Node.js 20.x even though
+    Vercel supported Node.js 24.x.
+- Decision:
+  - Make Node.js 24.x the only current supported runtime across repository and
+    package manifests, release automation, generated output, CI, and public
+    support records while preserving Yarn 4.3.1.
+  - Set the existing Asyra Design Vercel project to Node.js 24.x and accept the
+    reviewed feature-branch Preview only after its build log, static resources,
+    required-file route, and editable frontend smoke passed.
+  - Record the migration prerequisite as `READY` with no unresolved P0/P1/P2
+    finding.
+- Consequences:
+  - The next release-sequence plan may begin from one Node.js 24.x contract;
+    Node.js 20 is no longer a current support path.
+  - The deployed project currently owns static assets only, so no Vercel
+    Function or Middleware path exists to waive or test.
+  - Merge, package version changes, Changesets, registry or create-app
+    publication, tag, production deployment, and formal release remain
+    separately authorized operations.
+- Related Plan:
+  - `docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md`
+- Related Inspector:
+  - `docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs`
+- Related Pull Request:
+  - [#107](https://github.com/karote00/asyra/pull/107)
+- Related Preview:
+  - [Node.js 24 feature-branch Preview](https://asyra-git-codex-node-24-runtime-upgrade-karote00s-projects.vercel.app)
+- Related Commit:
+  - `e24c021b2f93ba200c728761d400d0ac0a87379d`

--- a/docs/ai/framework/PLANS.md
+++ b/docs/ai/framework/PLANS.md
@@ -31,15 +31,15 @@ release, deployment, and the formal release remain separately owned work.
 Complete these plans in order unless a plan explicitly allows read-only
 research to proceed without mutating the repository or an external system.
 
-1. Node.js 24 runtime upgrade and Vercel validation
+The Node.js 24 runtime prerequisite completed with local, CI, and Vercel
+Preview `READY` evidence on 2026-08-05. The retained records are:
 
-- Move the local, package, CI, release-validation, generated-app, and Vercel
-  runtime contract to Node.js 24.
-- Any local, CI, or Vercel failure blocks package publication.
-- Reference:
-  `docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md`
+- Completed plan:
+  `docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md`.
+- Retained Inspector:
+  `docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs`.
 
-2. Local exact-version package installation research
+1. Local exact-version package installation research
 
 - Determine the exact proof boundary of local tarballs and whether a local
   registry is justified for registry-style `name@version` resolution.
@@ -47,7 +47,7 @@ research to proceed without mutating the repository or an external system.
 - Reference:
   `docs/ai/framework/plans/local-versioned-package-install-research-plan.md`
 
-3. Framework package patch release
+2. Framework package patch release
 
 - First publish the seven never-published Framework packages once at `0.2.5`,
   then prove all 19 packages share the public `0.2.5` baseline.
@@ -57,7 +57,7 @@ research to proceed without mutating the repository or an external system.
 - Reference:
   `docs/ai/framework/plans/framework-package-patch-release-plan.md`
 
-4. Formal `create-asyra-design-app` release
+3. Formal `create-asyra-design-app` release
 
 - Begin only after the Framework patch set is publicly installable.
 - Apply user-specified Asyra/Asyra Design versions, regenerate through the
@@ -66,7 +66,7 @@ research to proceed without mutating the repository or an external system.
 - Reference:
   `docs/ai/framework/plans/create-asyra-design-app-release-plan.md`
 
-5. Asyra Framework marketing and documentation website
+4. Asyra Framework marketing and documentation website
 
 - Build the public Next.js/Tailwind documentation experience after public
   package and create-app contracts are stable.

--- a/docs/ai/framework/RELEASE_SUPPORT.md
+++ b/docs/ai/framework/RELEASE_SUPPORT.md
@@ -38,7 +38,7 @@ dependency hoisting are not part of the public contract.
 
 | Surface            | Release contract                                                        |
 | ------------------ | ----------------------------------------------------------------------- |
-| Node.js            | Node.js 20.x                                                            |
+| Node.js            | Node.js 24.x                                                            |
 | Package manager    | Yarn 4.3.1 for repository and generated-template gates                  |
 | TypeScript         | Declared `^5.7.2`; artifact declarations verified with TypeScript 5.8.3 |
 | React              | React 19 for `@asyra/design-system` and Asyra Design                    |
@@ -46,7 +46,7 @@ dependency hoisting are not part of the public contract.
 | Browser evidence   | Current Playwright Chromium from `@playwright/test` 1.57                |
 | Framework profiles | 2D and engine-neutral CUSTOM composition                                |
 
-The formal artifact and generated-template gates run on Node.js 20.x. A run on
+The formal artifact and generated-template gates run on Node.js 24.x. A run on
 another Node version is diagnostic evidence only and cannot produce the final
 `READY` decision.
 
@@ -102,7 +102,7 @@ generated declarations and this migration table.
 
 ## Reproducible readiness commands
 
-From a clean Node.js 20.x checkout:
+From a clean Node.js 24.x checkout:
 
 ```bash
 yarn install --immutable

--- a/docs/ai/framework/decisions/releases/unreleased.md
+++ b/docs/ai/framework/decisions/releases/unreleased.md
@@ -2206,3 +2206,38 @@ unregister -> app migration -> core.start()` as the public app route.
   - `docs/ai/framework/plans/framework-release-readiness-flow-inspector.data.cjs`
 - Related Pull Request:
   - [#106](https://github.com/karote00/asyra/pull/106)
+
+## 2026-08-05 - Complete the Node.js 24 runtime prerequisite
+
+- Context:
+  - Framework package publication remained blocked until local, CI, generated
+    consumer, Asyra Design, and Vercel evidence agreed on one Node.js runtime.
+  - The existing Vercel project still selected Node.js 20.x even though
+    Vercel supported Node.js 24.x.
+- Decision:
+  - Make Node.js 24.x the only current supported runtime across repository and
+    package manifests, release automation, generated output, CI, and public
+    support records while preserving Yarn 4.3.1.
+  - Set the existing Asyra Design Vercel project to Node.js 24.x and accept the
+    reviewed feature-branch Preview only after its build log, static resources,
+    required-file route, and editable frontend smoke passed.
+  - Record the migration prerequisite as `READY` with no unresolved P0/P1/P2
+    finding.
+- Consequences:
+  - The next release-sequence plan may begin from one Node.js 24.x contract;
+    Node.js 20 is no longer a current support path.
+  - The deployed project currently owns static assets only, so no Vercel
+    Function or Middleware path exists to waive or test.
+  - Merge, package version changes, Changesets, registry or create-app
+    publication, tag, production deployment, and formal release remain
+    separately authorized operations.
+- Related Plan:
+  - `docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md`
+- Related Inspector:
+  - `docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs`
+- Related Pull Request:
+  - [#107](https://github.com/karote00/asyra/pull/107)
+- Related Preview:
+  - [Node.js 24 feature-branch Preview](https://asyra-git-codex-node-24-runtime-upgrade-karote00s-projects.vercel.app)
+- Related Commit:
+  - `e24c021b2f93ba200c728761d400d0ac0a87379d`

--- a/docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs
@@ -1,0 +1,289 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global __dirname, require */
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const data = require('../node-24-runtime-upgrade-flow-inspector.data.cjs')
+const repoRoot = path.resolve(__dirname, '../../../../..')
+
+const step = (id) => {
+  const value = data.steps.find((item) => item.id === id)
+  assert.ok(value, `Missing Inspector step: ${id}`)
+  return value
+}
+
+const contractText = (owner) =>
+  [
+    owner.purpose,
+    ...owner.inputs,
+    ...owner.outputs,
+    ...owner.conditions,
+    ...owner.bypasses,
+    ...owner.allowedContributors,
+    ...owner.forbiddenContributors,
+    ...owner.implementationBoundary
+  ].join(' ')
+
+const anchorForHeading = (heading) =>
+  heading
+    .trim()
+    .toLowerCase()
+    .replace(/[`*_~]/g, '')
+    .replace(/[^\p{Letter}\p{Number}\s-]/gu, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+
+const anchorsIn = (markdown) =>
+  new Set(
+    markdown
+      .split('\n')
+      .filter((line) => /^#{1,6}\s+/.test(line))
+      .map((line) => anchorForHeading(line.replace(/^#{1,6}\s+/, '')))
+  )
+
+test('Node.js 24 Inspector authorities and entry resolve', () => {
+  assert.equal(data.target.id, 'node-24-runtime-upgrade')
+  assert.equal(data.target.title, 'Node.js 24 Runtime Upgrade Flow Inspector')
+  assert.equal(
+    data.authority.specPath,
+    'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md'
+  )
+  assert.equal(
+    data.authority.inspectorPath,
+    'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs'
+  )
+  assert.ok(fs.existsSync(path.resolve(repoRoot, data.authority.specPath)))
+  assert.ok(fs.existsSync(path.resolve(repoRoot, data.authority.inspectorPath)))
+  assert.ok(
+    fs.existsSync(
+      path.resolve(
+        __dirname,
+        '..',
+        'node-24-runtime-upgrade-flow-inspector.html'
+      )
+    )
+  )
+})
+
+test('Node.js 24 Inspector defines exactly nine complete owner steps', () => {
+  const requiredFields = [
+    'id',
+    'order',
+    'laneId',
+    'title',
+    'ownerPackage',
+    'purpose',
+    'inputs',
+    'outputs',
+    'conditions',
+    'bypasses',
+    'allowedContributors',
+    'forbiddenContributors',
+    'cacheDimensions',
+    'implementationBoundary',
+    'specRefs',
+    'failureOwnerStepId'
+  ]
+  const laneIds = new Set(data.lanes.map((item) => item.id))
+  const stepIds = new Set(data.steps.map((item) => item.id))
+
+  assert.equal(stepIds.size, data.steps.length)
+  assert.equal(data.steps.length, 9)
+
+  data.steps.forEach((item) => {
+    assert.deepEqual(Object.keys(item), requiredFields)
+    assert.ok(laneIds.has(item.laneId), `${item.id} lane`)
+    assert.ok(stepIds.has(item.failureOwnerStepId), `${item.id} failure owner`)
+    assert.deepEqual(item.cacheDimensions, [], `${item.id} unjustified cache`)
+    ;[
+      'inputs',
+      'outputs',
+      'conditions',
+      'bypasses',
+      'allowedContributors',
+      'forbiddenContributors',
+      'implementationBoundary',
+      'specRefs'
+    ].forEach((field) => {
+      assert.ok(item[field].length > 0, `${item.id} empty ${field}`)
+    })
+    assert.match(item.conditions.join(' '), /Cleanup owner:/)
+  })
+})
+
+test('Node.js 24 Inspector assigns every required owner once', () => {
+  assert.equal(
+    step('freeze-runtime-source').ownerPackage,
+    'Repository root runtime contract'
+  )
+  assert.equal(
+    step('validate-manifest-compatibility').ownerPackage,
+    'Workspace manifest runtime contract'
+  )
+  assert.equal(
+    step('validate-package-release-scripts').ownerPackage,
+    'Framework release runtime validation'
+  )
+  assert.equal(
+    step('validate-generated-template').ownerPackage,
+    'Official Asyra Design template generator'
+  )
+  assert.equal(
+    step('validate-ci-runtime').ownerPackage,
+    'GitHub Actions runtime configuration'
+  )
+  assert.equal(
+    step('validate-asyra-design-runtime').ownerPackage,
+    'Asyra Design local runtime validation'
+  )
+  assert.equal(
+    step('validate-vercel-runtime').ownerPackage,
+    'Linked Asyra Design Vercel project'
+  )
+  assert.equal(
+    step('synchronize-runtime-support').ownerPackage,
+    'Framework and Asyra Design support documentation'
+  )
+  assert.equal(
+    step('decide-node-24-readiness').ownerPackage,
+    'Node.js 24 migration readiness decision'
+  )
+})
+
+test('routes and artifacts retain one valid owner and declared consumers', () => {
+  const stepIds = new Set(data.steps.map((item) => item.id))
+  const artifactIds = new Set(data.artifacts.map((item) => item.id))
+
+  assert.equal(artifactIds.size, data.artifacts.length)
+  assert.equal(
+    new Set(data.routes.map((item) => item.id)).size,
+    data.routes.length
+  )
+
+  data.steps.forEach((item) => {
+    item.inputs
+      .filter((input) => input.startsWith('artifact:'))
+      .forEach((id) => assert.ok(artifactIds.has(id), `${item.id} input ${id}`))
+    item.outputs.forEach((id) =>
+      assert.ok(artifactIds.has(id), `${item.id} output ${id}`)
+    )
+  })
+
+  data.routes.forEach((route) => {
+    assert.ok(stepIds.has(route.from), `${route.id} from`)
+    if (route.to) assert.ok(stepIds.has(route.to), `${route.id} to`)
+    route.producedArtifacts.forEach((id) => {
+      const artifact = data.artifacts.find((item) => item.id === id)
+      assert.ok(artifact, `${route.id} artifact ${id}`)
+      assert.equal(artifact.ownerStepId, route.from, `${route.id} owner ${id}`)
+      if (route.to) {
+        assert.ok(
+          artifact.consumerStepIds.includes(route.to),
+          `${route.id} consumer ${id}`
+        )
+      }
+    })
+  })
+
+  data.artifacts.forEach((artifact) => {
+    assert.ok(stepIds.has(artifact.ownerStepId), artifact.id)
+    assert.ok(step(artifact.ownerStepId).outputs.includes(artifact.id))
+    artifact.consumerStepIds.forEach((consumerId) => {
+      assert.ok(stepIds.has(consumerId), `${artifact.id} ${consumerId}`)
+      assert.ok(step(consumerId).inputs.includes(artifact.id))
+    })
+    if (!artifact.terminal) {
+      assert.ok(artifact.consumerStepIds.length > 0, `${artifact.id} consumer`)
+    }
+  })
+})
+
+test('all Node.js 24 specification anchors resolve', () => {
+  const markdown = fs.readFileSync(
+    path.resolve(repoRoot, data.authority.specPath),
+    'utf8'
+  )
+  const anchors = anchorsIn(markdown)
+  ;[
+    ...data.steps.flatMap((item) => item.specRefs),
+    ...data.invariants.flatMap((item) => item.specRefs),
+    ...data.acceptanceContracts.flatMap((item) => item.specRefs)
+  ].forEach((reference) => {
+    assert.ok(reference.startsWith('#'), `external spec ref: ${reference}`)
+    assert.ok(anchors.has(reference.slice(1)), `missing anchor ${reference}`)
+  })
+})
+
+test('runtime surfaces remain distinct and Vercel owns build plus function proof', () => {
+  const local = contractText(step('validate-asyra-design-runtime'))
+  const vercel = contractText(step('validate-vercel-runtime'))
+  const decision = contractText(step('decide-node-24-readiness'))
+
+  assert.match(local, /Browser pass does not waive a local build, server/i)
+  assert.match(local, /browser-only pass never produces artifact:local-node/i)
+  assert.match(vercel, /preview build log reports the actual Node\.js 24/i)
+  assert.match(vercel, /Every project-owned Vercel function or middleware/i)
+  assert.match(vercel, /explicitly records not-applicable/i)
+  assert.match(vercel, /without exposing values/i)
+  assert.match(
+    decision,
+    /browser-only or frontend-only evidence for build\/server\/function runtime/i
+  )
+})
+
+test('implementation boundaries preserve generator, CI, Vercel, and closeout owners', () => {
+  assert.ok(
+    step('freeze-runtime-source').implementationBoundary.includes(
+      'scripts/__tests__/node-runtime-contract.test.mjs'
+    )
+  )
+  assert.ok(
+    step('validate-manifest-compatibility').implementationBoundary.includes(
+      'packages/*/package.json'
+    )
+  )
+  assert.ok(
+    step('validate-generated-template').implementationBoundary.includes(
+      'scripts/release-template.js'
+    )
+  )
+  assert.ok(
+    step('validate-ci-runtime').implementationBoundary.includes(
+      '.github/workflows/main.yml'
+    )
+  )
+  assert.ok(
+    step('validate-vercel-runtime').implementationBoundary.includes(
+      'existing linked Asyra Design Vercel Project Settings'
+    )
+  )
+  assert.ok(
+    step('decide-node-24-readiness').implementationBoundary.includes(
+      'docs/ai/framework/PLANS.md'
+    )
+  )
+})
+
+test('READY requires all owner evidence and preserves release boundaries', () => {
+  const decision = contractText(step('decide-node-24-readiness'))
+
+  assert.match(decision, /READY requires every non-finding evidence artifact/i)
+  assert.match(decision, /no unresolved P0\/P1\/P2 finding/i)
+  assert.match(decision, /BLOCKED with the first incorrect canonical owner/i)
+  assert.match(
+    decision,
+    /package version bump, Changeset, registry publication, tag, merge, production deployment, or formal release/i
+  )
+})
+
+test('acceptance contracts cover every Node.js 24 owner step', () => {
+  const acceptedStepIds = new Set(
+    data.acceptanceContracts.flatMap((contract) => contract.stepIds)
+  )
+  data.steps.forEach((item) =>
+    assert.ok(acceptedStepIds.has(item.id), `${item.id} lacks product case/DoD`)
+  )
+})

--- a/docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs
@@ -49,7 +49,7 @@ test('Node.js 24 Inspector authorities and entry resolve', () => {
   assert.equal(data.target.title, 'Node.js 24 Runtime Upgrade Flow Inspector')
   assert.equal(
     data.authority.specPath,
-    'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md'
+    'docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md'
   )
   assert.equal(
     data.authority.inspectorPath,

--- a/docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs
@@ -250,6 +250,12 @@ test('implementation boundaries preserve generator, CI, Vercel, and closeout own
       'scripts/release-template.js'
     )
   )
+  assert.equal(
+    step('validate-package-release-scripts').implementationBoundary.includes(
+      'scripts/release-records.js'
+    ),
+    false
+  )
   assert.ok(
     step('validate-ci-runtime').implementationBoundary.includes(
       '.github/workflows/main.yml'
@@ -263,6 +269,11 @@ test('implementation boundaries preserve generator, CI, Vercel, and closeout own
   assert.ok(
     step('decide-node-24-readiness').implementationBoundary.includes(
       'docs/ai/framework/PLANS.md'
+    )
+  )
+  assert.ok(
+    step('synchronize-runtime-support').implementationBoundary.includes(
+      'scripts/release-records.js'
     )
   )
 })

--- a/docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md
+++ b/docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md
@@ -2,12 +2,62 @@
 
 ## Status
 
-Queued as the first post-Gate-5 release prerequisite.
+Completed with a reproducible local, CI, and Vercel Preview `READY` decision
+on 2026-08-05.
 
-No Framework package version may be bumped or published until this plan reaches
-`READY`. If local, CI, or Vercel validation fails on Node.js 24, package
-publication remains blocked and the failure returns to the first incorrect
-runtime, dependency, build, test, or deployment owner.
+Node.js 24.x is now the single current runtime contract for the repository,
+Framework packages, Asyra Design, release automation, CI, generated template,
+public support records, and the existing Vercel project. Yarn remains 4.3.1.
+This result does not authorize merge, package version changes, Changesets,
+registry or create-app publication, tag, production deployment, or a formal
+release.
+
+## Completion Record
+
+- Baseline: local Node.js `v24.13.0`, Corepack `0.29.3`, Yarn `4.3.1`, and
+  Darwin arm64. No runtime manager, dependency, package manager, or
+  development tool was installed or upgraded.
+- Runtime contract: root, all 19 Framework packages, Asyra Design, the durable
+  clean-consumer fixture, release validators, CI, the official template
+  generator, generated output, and current public support records require
+  Node.js `24.x`. Package versions remain `0.2.5`.
+- Test-first evidence: the formal runtime contract failed against the previous
+  Node.js 20 declarations before canonical owners changed, then passed after
+  migration. The public-support oracle likewise failed before the support
+  records changed and passed after synchronization.
+- Local evidence: immutable install, Turbo graph, 21 dependency boundaries,
+  clean 20-target workspace build, full tests, lint, 69 Inspector/viewer
+  contracts, fresh 19-package artifacts, packed-only clean consumer, and the
+  12-package generated-template consumer passed on Node.js 24.
+- App evidence: the isolated render-performance gate passed 5 cases; ordinary
+  E2E passed 135 cases with 3 contract-scoped skips; collaboration E2E passed
+  10 cases with 2 explicit opt-in skips; the unavailable-service visual case
+  passed. Agent inspection of the live-app dense-vector, transformed-vector,
+  Group source/peer, reconnect, and status-toast screenshots found no visual
+  regression. All agent-started processes and ports were cleaned.
+- CI evidence: pull request
+  [`#107`](https://github.com/karote00/asyra/pull/107) at migration commit
+  `e24c021b2f93ba200c728761d400d0ac0a87379d` passed validation and release
+  readiness in run
+  [`30942427036`](https://github.com/karote00/asyra/actions/runs/30942427036)
+  and ordinary/collaboration E2E in run
+  [`30942427298`](https://github.com/karote00/asyra/actions/runs/30942427298).
+- Vercel evidence: existing project `prj_rMVZ3Pq4G3cb0dPDZmDpYfZNAElJ` now
+  selects Node.js `24.x` for builds and Serverless Functions. Preview
+  [`HUktFsbih`](https://vercel.com/karote00s-projects/asyra/HUktFsbihYsvXbZ5mqMwd5DYomD8)
+  built the reviewed branch and commit with Node.js `24.x`, completed all 20
+  workspace build targets, and is available at the stable
+  [feature-branch Preview](https://asyra-git-codex-node-24-runtime-upgrade-karote00s-projects.vercel.app).
+- Preview smoke: the deployed frontend loaded with the required `fileId`,
+  remained locally editable while its separately owned collaboration service
+  was unavailable, and created and rendered a selected rectangle with matching
+  Layers and Properties state. Deployment resources contain 18 static assets
+  and no Vercel Function or Middleware, so function-path smoke is explicitly
+  not applicable. The app declares no required Vercel environment variable;
+  the optional collaboration endpoint retains its documented same-origin
+  fallback, and the project has no custom environment variables to migrate.
+- Review result: no unresolved P0/P1/P2 finding remains. Final decision:
+  `READY` for the Node.js 24 runtime prerequisite only.
 
 ## Goal
 

--- a/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs
@@ -1,0 +1,1027 @@
+/* global module */
+
+;(function () {
+  'use strict'
+
+  const specPath =
+    'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md'
+  const inspectorPath =
+    'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs'
+
+  const lanes = [
+    { id: 'contract', title: 'Runtime Contract', order: 1 },
+    { id: 'repository', title: 'Repository Compatibility', order: 2 },
+    { id: 'automation', title: 'Automation and Generated Output', order: 3 },
+    { id: 'application', title: 'Application Runtime Evidence', order: 4 },
+    { id: 'deployment', title: 'Vercel Deployment Runtime', order: 5 },
+    { id: 'support', title: 'Support and Decision', order: 6 }
+  ]
+
+  const steps = [
+    {
+      id: 'freeze-runtime-source',
+      order: 1,
+      laneId: 'contract',
+      title: 'Freeze the Node.js 24 runtime source',
+      ownerPackage: 'Repository root runtime contract',
+      purpose:
+        'Select the available Node.js 24 LTS baseline, preserve Yarn 4.3.1, and make the root manifest plus formal runtime assertions the one repository-wide supported-runtime source.',
+      inputs: [
+        'Node.js 24 migration product contract',
+        'local Node, Corepack, Yarn, OS, and architecture evidence',
+        'official Node.js LTS support evidence',
+        'linked Asyra Design Vercel project identity and current runtime metadata'
+      ],
+      outputs: ['artifact:runtime-contract', 'artifact:runtime-source-finding'],
+      conditions: [
+        'The selected local runtime is one available Node.js 24.x LTS patch and the portable contract is the Node.js 24.x major line.',
+        'Corepack is recorded and the repository package-manager contract remains Yarn 4.3.1.',
+        'Formal assertions require Node.js 24 before any downstream canonical declaration is changed.',
+        'Cleanup owner: freeze-runtime-source owns no server, browser, port, deployment, or project-external installation.'
+      ],
+      bypasses: [
+        'A missing local Node.js 24 runtime, an installation that would write outside the project, a required Yarn/toolchain change, or contradictory support evidence produces artifact:runtime-source-finding.',
+        'A Node.js version outside major 24 cannot produce artifact:runtime-contract.'
+      ],
+      allowedContributors: [
+        'Node.js official LTS support records',
+        'repository root package.json',
+        'formal runtime contract tests',
+        'read-only local and linked-project metadata'
+      ],
+      forbiddenContributors: [
+        'new version manager, package, dependency, binary, or development tool',
+        'Yarn version other than 4.3.1',
+        'package version bump, Changeset, tag, publication, or release',
+        'browser-only evidence used as local Node evidence'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'package.json',
+        'scripts/__tests__/node-runtime-contract.test.mjs',
+        'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md',
+        'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs',
+        'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html',
+        'docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs'
+      ],
+      specRefs: [
+        '#goal',
+        '#bounded-task-contract',
+        '#required-inspector',
+        '#1-freeze-nodejs-24-baseline',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'freeze-runtime-source'
+    },
+    {
+      id: 'validate-manifest-compatibility',
+      order: 2,
+      laneId: 'repository',
+      title: 'Validate workspace and package manifests',
+      ownerPackage: 'Workspace manifest runtime contract',
+      purpose:
+        'Require the root-selected Node.js 24.x contract in all 19 Framework packages, Asyra Design, the packed-only consumer fixture, and every supported manifest consumer without changing package versions or dependencies.',
+      inputs: ['artifact:runtime-contract'],
+      outputs: [
+        'artifact:manifest-compatibility',
+        'artifact:manifest-compatibility-finding'
+      ],
+      conditions: [
+        'All 19 public Framework manifests declare exactly Node.js 24.x.',
+        'Asyra Design declares Node.js 24.x at the Vercel project root package and the durable clean-consumer fixture declares the same major.',
+        'Package names, versions, dependency ranges, packageManager fields, and Yarn 4.3.1 remain otherwise unchanged.',
+        'Cleanup owner: validate-manifest-compatibility owns no generated output, install directory, tarball, server, browser, or port.'
+      ],
+      bypasses: [
+        'A manifest outside the supported set is not rewritten merely because it contains similar syntax.',
+        'Any missing or contradictory supported manifest produces artifact:manifest-compatibility-finding and blocks artifact, app, CI, and deployment proof.'
+      ],
+      allowedContributors: [
+        'artifact:runtime-contract',
+        'root, Framework package, Asyra Design, and clean-consumer manifests',
+        'formal manifest compatibility assertions'
+      ],
+      forbiddenContributors: [
+        'package version changes',
+        'dependency or package-manager changes',
+        'manual edits to create-app generated output',
+        'unrelated workspace metadata cleanup'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'packages/*/package.json',
+        'apps/asyra-design/package.json',
+        'fixtures/framework-release-consumer/package.json',
+        'scripts/__tests__/node-runtime-contract.test.mjs'
+      ],
+      specRefs: [
+        '#bounded-task-contract',
+        '#2-strengthen-runtime-tests-first',
+        '#3-update-canonical-runtime-owners',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'validate-manifest-compatibility'
+    },
+    {
+      id: 'validate-package-release-scripts',
+      order: 3,
+      laneId: 'repository',
+      title: 'Validate package and release scripts',
+      ownerPackage: 'Framework release runtime validation',
+      purpose:
+        'Make package packing, packed metadata validation, clean-consumer execution, and release-record validation accept only Node.js 24.x while retaining the existing diagnostic and publication boundaries.',
+      inputs: ['artifact:runtime-contract', 'artifact:manifest-compatibility'],
+      outputs: [
+        'artifact:release-runtime-contract',
+        'artifact:release-runtime-finding'
+      ],
+      conditions: [
+        'Package artifact validation requires Node.js 24.x metadata for every one of the 19 tarballs.',
+        'Clean-consumer and generated-template readiness reject a non-24 execution runtime unless the existing diagnostic-only override is explicitly selected.',
+        'Release records and focused tests name Node.js 24.x without changing candidate package versions or granting publication.',
+        'Cleanup owner: validate-package-release-scripts retains the existing release harness ownership for project-local tarballs, isolated consumers, evidence, child processes, and cleanup.'
+      ],
+      bypasses: [
+        'The existing unsupported-runtime override remains diagnostic-only and cannot produce READY.',
+        'Any artifact, consumer, script, or release-record mismatch produces artifact:release-runtime-finding at this owner.'
+      ],
+      allowedContributors: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'release package, clean-consumer, template-readiness, and record scripts',
+        'focused release automation tests'
+      ],
+      forbiddenContributors: [
+        'workspace source fallback inside packed consumers',
+        'allowed-failure Node.js 24 route',
+        'package version bump, publication, tag, or formal release',
+        'product behavior change or dependency upgrade'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'scripts/release-package-artifacts.js',
+        'scripts/release-readiness.js',
+        'scripts/release-template-readiness.js',
+        'scripts/release-records.js',
+        'scripts/__tests__/release-automation.test.mjs',
+        'scripts/__tests__/release-package-artifacts.test.mjs',
+        'scripts/__tests__/release-clean-consumer.test.mjs',
+        'scripts/__tests__/release-template-readiness.test.mjs',
+        'scripts/__tests__/release-records.test.mjs',
+        'scripts/__tests__/node-runtime-contract.test.mjs'
+      ],
+      specRefs: [
+        '#2-strengthen-runtime-tests-first',
+        '#3-update-canonical-runtime-owners',
+        '#4-validate-locally-on-nodejs-24',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'validate-package-release-scripts'
+    },
+    {
+      id: 'validate-generated-template',
+      order: 4,
+      laneId: 'automation',
+      title: 'Validate the generated template contract',
+      ownerPackage: 'Official Asyra Design template generator',
+      purpose:
+        'Make the official generator produce the Node.js 24.x template contract, regenerate committed create-app output only through that generator, and prove the packed-only generated consumer under Node.js 24.',
+      inputs: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:release-runtime-contract'
+      ],
+      outputs: [
+        'artifact:generated-template-contract',
+        'artifact:generated-template-finding'
+      ],
+      conditions: [
+        'scripts/release-template.js is the sole owner that writes the generated package engine and synchronizes the template README from the app source.',
+        'Generated package.json and README require Node.js 24.x and Yarn 4.3.1 and contain no workspace-only path.',
+        'Template synchronization, packed-artifact install, build, tests, startup smoke, and cleanup use the formal generator/readiness commands.',
+        'Cleanup owner: validate-generated-template owns generator comparison output, isolated template consumers, child processes, smoke ports, and their removal.'
+      ],
+      bypasses: [
+        'Manual implementation edits under create-app/asyra-design/template are forbidden; mismatches return to the generator owner.',
+        'Any generator, parity, packed install, build, test, startup, or cleanup failure produces artifact:generated-template-finding.'
+      ],
+      allowedContributors: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:release-runtime-contract',
+        'apps/asyra-design source template inputs',
+        'official release-template generator and readiness harness'
+      ],
+      forbiddenContributors: [
+        'manual generated-output repair',
+        'workspace alias or node_modules fallback',
+        'dependency, Yarn, or package version change',
+        'generated output used as source authority'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'scripts/release-template.js',
+        'scripts/release-template-readiness.js',
+        'scripts/__tests__/release-automation.test.mjs',
+        'scripts/__tests__/release-template-readiness.test.mjs',
+        'apps/asyra-design/TEMPLATE.md',
+        'create-app/asyra-design/template/package.json',
+        'create-app/asyra-design/template/README.md',
+        'scripts/__tests__/node-runtime-contract.test.mjs'
+      ],
+      specRefs: [
+        '#2-strengthen-runtime-tests-first',
+        '#3-update-canonical-runtime-owners',
+        '#4-validate-locally-on-nodejs-24',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'validate-generated-template'
+    },
+    {
+      id: 'validate-ci-runtime',
+      order: 5,
+      laneId: 'automation',
+      title: 'Validate the CI Node.js runtime',
+      ownerPackage: 'GitHub Actions runtime configuration',
+      purpose:
+        'Run the complete validation, release-readiness, E2E, collaboration, performance, and deploy-preparation jobs on the selected Node.js 24 line without a Node.js 20 fallback or allowed failure.',
+      inputs: [
+        'artifact:runtime-contract',
+        'artifact:release-runtime-contract',
+        'artifact:generated-template-contract'
+      ],
+      outputs: ['artifact:ci-runtime-contract', 'artifact:ci-runtime-finding'],
+      conditions: [
+        'Every actions/setup-node owner in main and E2E workflows selects Node.js 24.',
+        'CI preserves Yarn 4.3.1 and the existing build, tests, lint, dependency, artifact, consumer, template, E2E, collaboration, and performance gates.',
+        'Required checks must pass from the pushed feature branch before READY.',
+        'Cleanup owner: GitHub Actions owns hosted runners and job cleanup; repository workflows introduce no persistent project resource.'
+      ],
+      bypasses: [
+        'Node.js 20 green plus Node.js 24 allowed failure is forbidden.',
+        'Any workflow mismatch or failed required check produces artifact:ci-runtime-finding and blocks deployment readiness.'
+      ],
+      allowedContributors: [
+        'artifact:runtime-contract',
+        'artifact:release-runtime-contract',
+        'artifact:generated-template-contract',
+        'GitHub Actions workflows and formal workflow assertions'
+      ],
+      forbiddenContributors: [
+        'continue-on-error for Node.js 24 compatibility',
+        'Node.js 20 fallback matrix',
+        'dependency or Yarn upgrade',
+        'merge, release, tag, or publication authority'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        '.github/workflows/main.yml',
+        '.github/workflows/e2e.yml',
+        'scripts/__tests__/workspace-automation.test.mjs',
+        'scripts/__tests__/node-runtime-contract.test.mjs'
+      ],
+      specRefs: [
+        '#3-update-canonical-runtime-owners',
+        '#5-validate-ci-on-nodejs-24',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'validate-ci-runtime'
+    },
+    {
+      id: 'validate-asyra-design-runtime',
+      order: 6,
+      laneId: 'application',
+      title: 'Validate Asyra Design locally',
+      ownerPackage: 'Asyra Design local runtime validation',
+      purpose:
+        'Prove the complete workspace and Asyra Design build, Node server paths, browser flows, collaboration, performance budgets, and visual gates on Node.js 24 without treating browser execution as Node execution.',
+      inputs: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:release-runtime-contract',
+        'artifact:generated-template-contract',
+        'artifact:ci-runtime-contract'
+      ],
+      outputs: [
+        'artifact:local-node-evidence',
+        'artifact:browser-runtime-evidence',
+        'artifact:asyra-design-runtime-finding'
+      ],
+      conditions: [
+        'Immutable install, Turbo graph, dependency boundaries, full workspace build/tests/lint, Inspector tests, tarballs, clean consumer, generated template, and Asyra Design production build execute under local Node.js 24.',
+        'Asyra Design ordinary E2E, collaboration E2E, performance gates, and current formal visual gates produce separate browser-runtime evidence.',
+        'Browser pass does not waive a local build, server, package, artifact, or template failure.',
+        'Cleanup owner: validate-asyra-design-runtime PID-tracks and removes every agent-started server, browser, child process, temporary project-local artifact, and extra port.'
+      ],
+      bypasses: [
+        'A product behavior regression, runtime failure, leaked process, or unresolved P0/P1/P2 finding produces artifact:asyra-design-runtime-finding.',
+        'A browser-only pass never produces artifact:local-node-evidence.'
+      ],
+      allowedContributors: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:release-runtime-contract',
+        'artifact:generated-template-contract',
+        'artifact:ci-runtime-contract',
+        'formal root, package, app, E2E, performance, visual, and Inspector gates'
+      ],
+      forbiddenContributors: [
+        'manual screenshot as a substitute for a formal gate',
+        'browser runtime used as Node build or server evidence',
+        'fixture-specific exception, fallback output, or skipped gate',
+        'product behavior or dependency change'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'package.json',
+        'turbo.json',
+        'apps/asyra-design/package.json',
+        'apps/asyra-design/e2e',
+        'apps/asyra-design/playwright*.config.ts',
+        'scripts/run-e2e.sh',
+        'scripts/release-package-artifacts.js',
+        'scripts/release-readiness.js',
+        'scripts/release-template-readiness.js',
+        'tools/flow-inspector/__tests__/viewer-entry.test.cjs'
+      ],
+      specRefs: ['#4-validate-locally-on-nodejs-24', '#definition-of-done'],
+      failureOwnerStepId: 'validate-asyra-design-runtime'
+    },
+    {
+      id: 'validate-vercel-runtime',
+      order: 7,
+      laneId: 'deployment',
+      title: 'Validate Vercel build and function runtime',
+      ownerPackage: 'Linked Asyra Design Vercel project',
+      purpose:
+        'Set the existing project build/runtime to Node.js 24.x, create a feature-branch preview, and separately prove the build runtime, deployed frontend, and every project-owned Vercel function or middleware route.',
+      inputs: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:ci-runtime-contract',
+        'artifact:local-node-evidence',
+        'artifact:browser-runtime-evidence'
+      ],
+      outputs: [
+        'artifact:vercel-build-evidence',
+        'artifact:vercel-function-evidence',
+        'artifact:vercel-frontend-evidence',
+        'artifact:vercel-runtime-finding'
+      ],
+      conditions: [
+        'The existing linked Asyra Design project setting is Node.js 24.x and apps/asyra-design/package.json independently selects the same major.',
+        'The preview build log reports the actual Node.js 24.x patch used by the Vercel build runtime.',
+        'The deployed frontend passes smoke verification independently from build success.',
+        'Every project-owned Vercel function or middleware route is exercised; when none exists, artifact:vercel-function-evidence explicitly records not-applicable rather than borrowing frontend evidence.',
+        'Required environment variable names remain configured for Preview without exposing values.',
+        'Cleanup owner: Vercel owns preview build/function processes; validate-vercel-runtime owns only preview inspection and does not create a production deployment.'
+      ],
+      bypasses: [
+        'Vercel rejection of Node.js 24.x, a Node 20 build, missing required environment configuration, or a failed frontend/function path produces artifact:vercel-runtime-finding.',
+        'Production deployment is forbidden and cannot replace preview evidence.'
+      ],
+      allowedContributors: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:ci-runtime-contract',
+        'artifact:local-node-evidence',
+        'artifact:browser-runtime-evidence',
+        'apps/asyra-design/package.json',
+        'vercel.json',
+        'linked Vercel Project Settings, preview build logs, deployment metadata, and smoke responses'
+      ],
+      forbiddenContributors: [
+        'production deployment',
+        'browser pass used as Vercel build or function runtime evidence',
+        'secret values in logs, source, artifacts, comments, or reports',
+        'new Vercel project or unrelated deployment configuration'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'apps/asyra-design/package.json',
+        'vercel.json',
+        '.vercel/project.json read-only linked-project metadata',
+        'existing linked Asyra Design Vercel Project Settings',
+        'existing linked Asyra Design Vercel preview deployments',
+        'scripts/__tests__/node-runtime-contract.test.mjs'
+      ],
+      specRefs: [
+        '#1-freeze-nodejs-24-baseline',
+        '#3-update-canonical-runtime-owners',
+        '#6-validate-vercel',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'validate-vercel-runtime'
+    },
+    {
+      id: 'synchronize-runtime-support',
+      order: 8,
+      laneId: 'support',
+      title: 'Synchronize runtime support documentation',
+      ownerPackage: 'Framework and Asyra Design support documentation',
+      purpose:
+        'Replace current Node.js 20 support claims with Node.js 24.x only after local, CI, package, generated-template, app, and Vercel evidence all agree, while leaving historical point-in-time evidence intact.',
+      inputs: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:release-runtime-contract',
+        'artifact:generated-template-contract',
+        'artifact:ci-runtime-contract',
+        'artifact:local-node-evidence',
+        'artifact:browser-runtime-evidence',
+        'artifact:vercel-build-evidence',
+        'artifact:vercel-function-evidence',
+        'artifact:vercel-frontend-evidence'
+      ],
+      outputs: [
+        'artifact:runtime-support-contract',
+        'artifact:runtime-support-finding'
+      ],
+      conditions: [
+        'Current public support records, root/app/template/package READMEs, release validation workflow, changelog, and release notes consistently name Node.js 24.x and Yarn 4.3.1.',
+        'Generated README changes originate in apps/asyra-design/TEMPLATE.md and the official generator.',
+        'Historical completed-plan evidence remains a point-in-time Node.js 20 record unless it asserts current support.',
+        'Cleanup owner: synchronize-runtime-support owns documentation changes only and creates no runtime process, artifact, deployment, or publication.'
+      ],
+      bypasses: [
+        'Documentation cannot relabel a failed runtime owner or missing Vercel evidence as supported.',
+        'Any contradiction in current support records produces artifact:runtime-support-finding.'
+      ],
+      allowedContributors: [
+        'all successful runtime evidence artifacts',
+        'current framework, package, app, template, release, and workflow support records',
+        'docs-contract synchronization checks'
+      ],
+      forbiddenContributors: [
+        'historical evidence rewritten as if it ran on Node.js 24',
+        'future support promise without executable evidence',
+        'generated README edited by hand',
+        'version bump, Changeset, publication, tag, or release record'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'README.md',
+        'CHANGELOG.md',
+        'RELEASE_NOTES.md',
+        'packages/*/README.md',
+        'apps/asyra-design/README.md',
+        'apps/asyra-design/TEMPLATE.md',
+        'create-app/asyra-design/template/README.md',
+        'docs/ai/framework/RELEASE_SUPPORT.md',
+        'docs/ai/workflows/package-release-validation.md',
+        'scripts/release-records.js',
+        'scripts/__tests__/release-records.test.mjs'
+      ],
+      specRefs: ['#7-synchronize-support-records', '#definition-of-done'],
+      failureOwnerStepId: 'synchronize-runtime-support'
+    },
+    {
+      id: 'decide-node-24-readiness',
+      order: 9,
+      laneId: 'support',
+      title: 'Decide READY or owner-specific BLOCKED',
+      ownerPackage: 'Node.js 24 migration readiness decision',
+      purpose:
+        'Emit READY only from same-branch local, CI, package, template, Asyra Design, and Vercel preview evidence with no unresolved P0/P1/P2 finding; otherwise preserve an exact owner-specific BLOCKED result.',
+      inputs: [
+        'artifact:runtime-contract',
+        'artifact:manifest-compatibility',
+        'artifact:release-runtime-contract',
+        'artifact:generated-template-contract',
+        'artifact:ci-runtime-contract',
+        'artifact:local-node-evidence',
+        'artifact:browser-runtime-evidence',
+        'artifact:vercel-build-evidence',
+        'artifact:vercel-function-evidence',
+        'artifact:vercel-frontend-evidence',
+        'artifact:runtime-support-contract',
+        'artifact:runtime-source-finding',
+        'artifact:manifest-compatibility-finding',
+        'artifact:release-runtime-finding',
+        'artifact:generated-template-finding',
+        'artifact:ci-runtime-finding',
+        'artifact:asyra-design-runtime-finding',
+        'artifact:vercel-runtime-finding',
+        'artifact:runtime-support-finding'
+      ],
+      outputs: ['artifact:node-24-ready', 'artifact:node-24-blocked'],
+      conditions: [
+        'READY requires every non-finding evidence artifact from the same reviewed feature branch and no unresolved P0/P1/P2 finding.',
+        'READY records the commit SHA, PR URL, Node/Corepack/Yarn versions, local and CI gates, Vercel preview URL, and Node.js 24 build evidence.',
+        'Successful closeout updates the Framework plans index, archives the completed plan, retains this Inspector as authority, and appends decision history.',
+        'Cleanup owner: decide-node-24-readiness owns only durable plan/index/decision records and no deployment, package, registry, tag, merge, or release resource.'
+      ],
+      bypasses: [
+        'Any required finding or missing evidence emits artifact:node-24-blocked with the first incorrect canonical owner and reproducible evidence.',
+        'BLOCKED forbids package version bump, publish, tag, production deployment, merge, and formal release.'
+      ],
+      allowedContributors: [
+        'all declared evidence and finding artifacts',
+        'feature-branch commit and ready-for-review pull-request metadata',
+        'required-check results and Vercel preview evidence',
+        'Framework plans index and decision history'
+      ],
+      forbiddenContributors: [
+        'partial green subset relabeled READY',
+        'browser-only or frontend-only evidence for build/server/function runtime',
+        'package version bump, Changeset, registry publication, tag, merge, production deployment, or formal release',
+        'unresolved P0/P1/P2 finding'
+      ],
+      cacheDimensions: [],
+      implementationBoundary: [
+        'docs/ai/framework/PLANS.md',
+        'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md',
+        'docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md',
+        'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs',
+        'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html',
+        'docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs',
+        'docs/ai/framework/decisions/releases/unreleased.md',
+        'docs/ai/decisions/releases/unreleased.md'
+      ],
+      specRefs: [
+        '#status',
+        '#bounded-task-contract',
+        '#7-synchronize-support-records',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'decide-node-24-readiness'
+    }
+  ]
+
+  const routes = [
+    {
+      id: 'runtime-contract-to-manifests',
+      from: 'freeze-runtime-source',
+      to: 'validate-manifest-compatibility',
+      kind: 'runtime contract',
+      predicate: 'Node.js 24.x and Yarn 4.3.1 baseline is resolved',
+      producedArtifacts: ['artifact:runtime-contract']
+    },
+    {
+      id: 'manifests-to-release',
+      from: 'validate-manifest-compatibility',
+      to: 'validate-package-release-scripts',
+      kind: 'manifest compatibility',
+      predicate: 'all supported manifests declare the runtime contract',
+      producedArtifacts: ['artifact:manifest-compatibility']
+    },
+    {
+      id: 'release-to-template',
+      from: 'validate-package-release-scripts',
+      to: 'validate-generated-template',
+      kind: 'release runtime contract',
+      predicate: 'package and consumer runtime enforcement is exact',
+      producedArtifacts: ['artifact:release-runtime-contract']
+    },
+    {
+      id: 'template-to-ci',
+      from: 'validate-generated-template',
+      to: 'validate-ci-runtime',
+      kind: 'generated consumer contract',
+      predicate: 'official generator and output require Node.js 24.x',
+      producedArtifacts: ['artifact:generated-template-contract']
+    },
+    {
+      id: 'ci-to-local',
+      from: 'validate-ci-runtime',
+      to: 'validate-asyra-design-runtime',
+      kind: 'CI runtime contract',
+      predicate: 'workflows select Node.js 24 without fallback',
+      producedArtifacts: ['artifact:ci-runtime-contract']
+    },
+    {
+      id: 'local-node-to-vercel',
+      from: 'validate-asyra-design-runtime',
+      to: 'validate-vercel-runtime',
+      kind: 'local Node evidence',
+      predicate:
+        'local build, server, package, artifact, and template gates pass',
+      producedArtifacts: ['artifact:local-node-evidence']
+    },
+    {
+      id: 'browser-to-vercel',
+      from: 'validate-asyra-design-runtime',
+      to: 'validate-vercel-runtime',
+      kind: 'browser evidence',
+      predicate:
+        'Asyra Design browser, collaboration, performance, and visual gates pass',
+      producedArtifacts: ['artifact:browser-runtime-evidence']
+    },
+    {
+      id: 'vercel-build-to-support',
+      from: 'validate-vercel-runtime',
+      to: 'synchronize-runtime-support',
+      kind: 'Vercel build evidence',
+      predicate: 'preview build log identifies Node.js 24.x',
+      producedArtifacts: ['artifact:vercel-build-evidence']
+    },
+    {
+      id: 'vercel-function-to-support',
+      from: 'validate-vercel-runtime',
+      to: 'synchronize-runtime-support',
+      kind: 'Vercel function evidence',
+      predicate:
+        'all project-owned functions or middleware pass, or absence is explicit',
+      producedArtifacts: ['artifact:vercel-function-evidence']
+    },
+    {
+      id: 'vercel-frontend-to-support',
+      from: 'validate-vercel-runtime',
+      to: 'synchronize-runtime-support',
+      kind: 'Vercel frontend evidence',
+      predicate: 'deployed preview frontend smoke passes',
+      producedArtifacts: ['artifact:vercel-frontend-evidence']
+    },
+    {
+      id: 'support-to-decision',
+      from: 'synchronize-runtime-support',
+      to: 'decide-node-24-readiness',
+      kind: 'support contract',
+      predicate:
+        'current support records match all successful runtime evidence',
+      producedArtifacts: ['artifact:runtime-support-contract']
+    }
+  ]
+
+  const evidenceArtifacts = [
+    [
+      'artifact:runtime-contract',
+      'freeze-runtime-source',
+      [
+        'validate-manifest-compatibility',
+        'validate-package-release-scripts',
+        'validate-generated-template',
+        'validate-ci-runtime',
+        'validate-asyra-design-runtime',
+        'validate-vercel-runtime',
+        'synchronize-runtime-support',
+        'decide-node-24-readiness'
+      ]
+    ],
+    [
+      'artifact:manifest-compatibility',
+      'validate-manifest-compatibility',
+      [
+        'validate-package-release-scripts',
+        'validate-generated-template',
+        'validate-asyra-design-runtime',
+        'validate-vercel-runtime',
+        'synchronize-runtime-support',
+        'decide-node-24-readiness'
+      ]
+    ],
+    [
+      'artifact:release-runtime-contract',
+      'validate-package-release-scripts',
+      [
+        'validate-generated-template',
+        'validate-ci-runtime',
+        'validate-asyra-design-runtime',
+        'synchronize-runtime-support',
+        'decide-node-24-readiness'
+      ]
+    ],
+    [
+      'artifact:generated-template-contract',
+      'validate-generated-template',
+      [
+        'validate-ci-runtime',
+        'validate-asyra-design-runtime',
+        'synchronize-runtime-support',
+        'decide-node-24-readiness'
+      ]
+    ],
+    [
+      'artifact:ci-runtime-contract',
+      'validate-ci-runtime',
+      [
+        'validate-asyra-design-runtime',
+        'validate-vercel-runtime',
+        'synchronize-runtime-support',
+        'decide-node-24-readiness'
+      ]
+    ],
+    [
+      'artifact:local-node-evidence',
+      'validate-asyra-design-runtime',
+      [
+        'validate-vercel-runtime',
+        'synchronize-runtime-support',
+        'decide-node-24-readiness'
+      ]
+    ],
+    [
+      'artifact:browser-runtime-evidence',
+      'validate-asyra-design-runtime',
+      [
+        'validate-vercel-runtime',
+        'synchronize-runtime-support',
+        'decide-node-24-readiness'
+      ]
+    ],
+    [
+      'artifact:vercel-build-evidence',
+      'validate-vercel-runtime',
+      ['synchronize-runtime-support', 'decide-node-24-readiness']
+    ],
+    [
+      'artifact:vercel-function-evidence',
+      'validate-vercel-runtime',
+      ['synchronize-runtime-support', 'decide-node-24-readiness']
+    ],
+    [
+      'artifact:vercel-frontend-evidence',
+      'validate-vercel-runtime',
+      ['synchronize-runtime-support', 'decide-node-24-readiness']
+    ],
+    [
+      'artifact:runtime-support-contract',
+      'synchronize-runtime-support',
+      ['decide-node-24-readiness']
+    ]
+  ]
+
+  const findingArtifacts = [
+    ['artifact:runtime-source-finding', 'freeze-runtime-source'],
+    [
+      'artifact:manifest-compatibility-finding',
+      'validate-manifest-compatibility'
+    ],
+    ['artifact:release-runtime-finding', 'validate-package-release-scripts'],
+    ['artifact:generated-template-finding', 'validate-generated-template'],
+    ['artifact:ci-runtime-finding', 'validate-ci-runtime'],
+    ['artifact:asyra-design-runtime-finding', 'validate-asyra-design-runtime'],
+    ['artifact:vercel-runtime-finding', 'validate-vercel-runtime'],
+    ['artifact:runtime-support-finding', 'synchronize-runtime-support']
+  ]
+
+  evidenceArtifacts.forEach(([id, ownerStepId, consumerStepIds]) => {
+    consumerStepIds.forEach((consumerStepId) => {
+      const routeExists = routes.some(
+        (route) =>
+          route.from === ownerStepId &&
+          route.to === consumerStepId &&
+          route.producedArtifacts.includes(id)
+      )
+      if (routeExists) return
+      routes.push({
+        id: `${ownerStepId}-to-${consumerStepId}-${id.slice('artifact:'.length)}`,
+        from: ownerStepId,
+        to: consumerStepId,
+        kind: 'validated evidence handoff',
+        predicate:
+          'consumer reads the completed owner artifact without rederiving it',
+        producedArtifacts: [id]
+      })
+    })
+  })
+
+  findingArtifacts.forEach(([id, ownerStepId]) => {
+    routes.push({
+      id: `${ownerStepId}-finding-to-decision`,
+      from: ownerStepId,
+      to: 'decide-node-24-readiness',
+      kind: 'owner finding',
+      predicate: 'owner cannot produce its required Node.js 24 evidence',
+      producedArtifacts: [id]
+    })
+  })
+
+  const artifacts = [
+    ...evidenceArtifacts.map(([id, ownerStepId, consumerStepIds]) => ({
+      id,
+      ownerStepId,
+      channel: 'validated runtime evidence',
+      consumerStepIds,
+      terminal: false
+    })),
+    ...findingArtifacts.map(([id, ownerStepId]) => ({
+      id,
+      ownerStepId,
+      channel: 'owner-specific blocking finding',
+      consumerStepIds: ['decide-node-24-readiness'],
+      terminal: false
+    })),
+    {
+      id: 'artifact:node-24-ready',
+      ownerStepId: 'decide-node-24-readiness',
+      channel: 'terminal runtime readiness decision',
+      consumerStepIds: [],
+      terminal: true
+    },
+    {
+      id: 'artifact:node-24-blocked',
+      ownerStepId: 'decide-node-24-readiness',
+      channel: 'terminal runtime readiness decision',
+      consumerStepIds: [],
+      terminal: true
+    }
+  ]
+
+  routes.push(
+    {
+      id: 'ready-decision',
+      from: 'decide-node-24-readiness',
+      kind: 'terminal',
+      predicate: 'all required evidence exists and no P0/P1/P2 finding remains',
+      producedArtifacts: ['artifact:node-24-ready']
+    },
+    {
+      id: 'blocked-decision',
+      from: 'decide-node-24-readiness',
+      kind: 'terminal',
+      predicate: 'required evidence is missing or an owner finding remains',
+      producedArtifacts: ['artifact:node-24-blocked']
+    }
+  )
+
+  const invariants = [
+    {
+      id: 'single-runtime-major',
+      title: 'Node.js 24.x is the sole supported major',
+      statement:
+        'Root, package, app, consumer, generator, CI, Vercel, validation, and current support owners must converge on Node.js 24.x while Yarn remains 4.3.1.',
+      stepIds: steps.map((step) => step.id),
+      artifactIds: evidenceArtifacts.map(([id]) => id),
+      specRefs: ['#goal', '#definition-of-done']
+    },
+    {
+      id: 'runtime-surface-separation',
+      title: 'Runtime surfaces are not interchangeable',
+      statement:
+        'Local Node execution, browser runtime, Vercel build runtime, and Vercel function runtime have separate evidence; a browser or frontend pass cannot waive build, server, or function failure.',
+      stepIds: [
+        'validate-asyra-design-runtime',
+        'validate-vercel-runtime',
+        'decide-node-24-readiness'
+      ],
+      artifactIds: [
+        'artifact:local-node-evidence',
+        'artifact:browser-runtime-evidence',
+        'artifact:vercel-build-evidence',
+        'artifact:vercel-function-evidence',
+        'artifact:vercel-frontend-evidence'
+      ],
+      specRefs: ['#required-inspector', '#6-validate-vercel']
+    },
+    {
+      id: 'generated-source-authority',
+      title: 'Generated output has one source owner',
+      statement:
+        'The official release-template generator and app template source own generated runtime output; create-app files are never manually repaired.',
+      stepIds: ['validate-generated-template'],
+      artifactIds: ['artifact:generated-template-contract'],
+      specRefs: ['#3-update-canonical-runtime-owners']
+    },
+    {
+      id: 'release-boundary',
+      title: 'Runtime READY is not release authority',
+      statement:
+        'READY may produce scoped commits, a feature-branch PR, and a preview deployment, but never authorizes package version bump, publication, tag, merge, production deployment, or formal release.',
+      stepIds: ['decide-node-24-readiness'],
+      artifactIds: ['artifact:node-24-ready', 'artifact:node-24-blocked'],
+      specRefs: ['#bounded-task-contract', '#definition-of-done']
+    }
+  ]
+
+  const acceptanceContracts = [
+    {
+      id: 'runtime-source-case',
+      title: 'Node.js 24 source and test-first contract',
+      assertions: [
+        'The available local Node.js 24 LTS patch, Corepack, Yarn 4.3.1, OS, architecture, project identity, and existing Vercel runtime are recorded.',
+        'Formal assertions require Node.js 24 before canonical declarations change.'
+      ],
+      stepIds: ['freeze-runtime-source'],
+      specRefs: [
+        '#1-freeze-nodejs-24-baseline',
+        '#2-strengthen-runtime-tests-first'
+      ]
+    },
+    {
+      id: 'manifest-and-release-case',
+      title: 'Workspace, package, artifact, and consumer contract',
+      assertions: [
+        'Root, 19 Framework packages, Asyra Design, and the durable consumer fixture require Node.js 24.x without version or dependency changes.',
+        'Package artifacts, packed-only clean consumers, and release records enforce the same runtime.'
+      ],
+      stepIds: [
+        'validate-manifest-compatibility',
+        'validate-package-release-scripts'
+      ],
+      specRefs: [
+        '#3-update-canonical-runtime-owners',
+        '#4-validate-locally-on-nodejs-24'
+      ]
+    },
+    {
+      id: 'template-case',
+      title: 'Official generated consumer',
+      assertions: [
+        'The official generator writes Node.js 24.x and Yarn 4.3.1.',
+        'Regenerated output passes parity, packed-only install, build, tests, startup smoke, and cleanup.'
+      ],
+      stepIds: ['validate-generated-template'],
+      specRefs: [
+        '#3-update-canonical-runtime-owners',
+        '#4-validate-locally-on-nodejs-24'
+      ]
+    },
+    {
+      id: 'ci-case',
+      title: 'Node.js 24 CI without fallback',
+      assertions: [
+        'Validation, release-readiness, E2E, collaboration, and deploy-preparation jobs select Node.js 24.',
+        'Required checks retain the complete formal gates and do not allow Node.js 24 failure.'
+      ],
+      stepIds: ['validate-ci-runtime'],
+      specRefs: ['#5-validate-ci-on-nodejs-24']
+    },
+    {
+      id: 'local-and-browser-case',
+      title: 'Complete local and browser validation',
+      assertions: [
+        'Immutable install, graph, dependencies, full build/tests/lint, Inspectors, artifacts, consumers, template, and app production build pass on local Node.js 24.',
+        'Ordinary/collaboration E2E, performance, and visual gates pass as separate browser evidence with all processes and ports cleaned.'
+      ],
+      stepIds: ['validate-asyra-design-runtime'],
+      specRefs: ['#4-validate-locally-on-nodejs-24']
+    },
+    {
+      id: 'vercel-case',
+      title: 'Real Node.js 24 Vercel preview',
+      assertions: [
+        'The existing project setting and project-root package select Node.js 24.x and a real preview build log identifies Node.js 24.',
+        'Frontend smoke and every function/middleware route pass independently; absence of functions is explicit and required environment values remain secret.'
+      ],
+      stepIds: ['validate-vercel-runtime'],
+      specRefs: ['#6-validate-vercel']
+    },
+    {
+      id: 'support-and-decision-case',
+      title: 'Consistent support and reproducible decision',
+      assertions: [
+        'Current support records name Node.js 24.x only after all required evidence passes.',
+        'READY records reproducible local, CI, PR, and Vercel evidence; otherwise BLOCKED names the first incorrect owner and forbids release work.'
+      ],
+      stepIds: ['synchronize-runtime-support', 'decide-node-24-readiness'],
+      specRefs: ['#7-synchronize-support-records', '#definition-of-done']
+    }
+  ]
+
+  const data = {
+    schema: { id: 'asyra.flow-inspector', version: 2 },
+    target: {
+      id: 'node-24-runtime-upgrade',
+      kind: 'system',
+      title: 'Node.js 24 Runtime Upgrade Flow Inspector',
+      subtitle:
+        'One Node.js 24.x contract across repository manifests, release automation, generated consumers, CI, local and browser gates, Vercel build/functions, support records, and the final READY or owner-specific BLOCKED decision.'
+    },
+    authority: {
+      specPath,
+      inspectorPath,
+      semanticOwner: 'Node.js 24 runtime upgrade product contract',
+      inspectorOwner: 'Node.js 24 Runtime Upgrade Flow Inspector data'
+    },
+    links: [
+      {
+        id: 'product-contract',
+        label: 'Product Contract',
+        href: './node-24-runtime-upgrade-and-vercel-validation-plan.md',
+        kind: 'authority'
+      },
+      {
+        id: 'release-support',
+        label: 'Release Support',
+        href: '../RELEASE_SUPPORT.md',
+        kind: 'framework'
+      },
+      {
+        id: 'flow-inspector-contract',
+        label: 'Flow Inspector Contract',
+        href: '../FLOW_INSPECTOR.md',
+        kind: 'framework'
+      }
+    ],
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  }
+
+  const freeze = (value) => {
+    if (!value || typeof value !== 'object' || Object.isFrozen(value)) {
+      return value
+    }
+    Object.freeze(value)
+    Object.values(value).forEach(freeze)
+    return value
+  }
+
+  freeze(data)
+  if (typeof globalThis !== 'undefined') globalThis.FLOW_INSPECTOR_DATA = data
+  if (typeof module !== 'undefined' && module.exports) module.exports = data
+})()

--- a/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs
@@ -129,7 +129,7 @@
       title: 'Validate package and release scripts',
       ownerPackage: 'Framework release runtime validation',
       purpose:
-        'Make package packing, packed metadata validation, clean-consumer execution, and release-record validation accept only Node.js 24.x while retaining the existing diagnostic and publication boundaries.',
+        'Make package packing, packed metadata validation, clean-consumer execution, and generated-template readiness accept only Node.js 24.x while retaining the existing diagnostic and publication boundaries.',
       inputs: ['artifact:runtime-contract', 'artifact:manifest-compatibility'],
       outputs: [
         'artifact:release-runtime-contract',
@@ -138,7 +138,7 @@
       conditions: [
         'Package artifact validation requires Node.js 24.x metadata for every one of the 19 tarballs.',
         'Clean-consumer and generated-template readiness reject a non-24 execution runtime unless the existing diagnostic-only override is explicitly selected.',
-        'Release records and focused tests name Node.js 24.x without changing candidate package versions or granting publication.',
+        'Focused release runtime tests name Node.js 24.x without changing candidate package versions or granting publication; public release-record support assertions remain owned by synchronize-runtime-support.',
         'Cleanup owner: validate-package-release-scripts retains the existing release harness ownership for project-local tarballs, isolated consumers, evidence, child processes, and cleanup.'
       ],
       bypasses: [
@@ -148,7 +148,7 @@
       allowedContributors: [
         'artifact:runtime-contract',
         'artifact:manifest-compatibility',
-        'release package, clean-consumer, template-readiness, and record scripts',
+        'release package, clean-consumer, and template-readiness scripts',
         'focused release automation tests'
       ],
       forbiddenContributors: [
@@ -162,12 +162,10 @@
         'scripts/release-package-artifacts.js',
         'scripts/release-readiness.js',
         'scripts/release-template-readiness.js',
-        'scripts/release-records.js',
         'scripts/__tests__/release-automation.test.mjs',
         'scripts/__tests__/release-package-artifacts.test.mjs',
         'scripts/__tests__/release-clean-consumer.test.mjs',
         'scripts/__tests__/release-template-readiness.test.mjs',
-        'scripts/__tests__/release-records.test.mjs',
         'scripts/__tests__/node-runtime-contract.test.mjs'
       ],
       specRefs: [
@@ -470,7 +468,8 @@
         'docs/ai/framework/RELEASE_SUPPORT.md',
         'docs/ai/workflows/package-release-validation.md',
         'scripts/release-records.js',
-        'scripts/__tests__/release-records.test.mjs'
+        'scripts/__tests__/release-records.test.mjs',
+        'scripts/__tests__/node-runtime-contract.test.mjs'
       ],
       specRefs: ['#7-synchronize-support-records', '#definition-of-done'],
       failureOwnerStepId: 'synchronize-runtime-support'
@@ -903,7 +902,7 @@
       title: 'Workspace, package, artifact, and consumer contract',
       assertions: [
         'Root, 19 Framework packages, Asyra Design, and the durable consumer fixture require Node.js 24.x without version or dependency changes.',
-        'Package artifacts, packed-only clean consumers, and release records enforce the same runtime.'
+        'Package artifacts and packed-only clean consumers enforce the same runtime.'
       ],
       stepIds: [
         'validate-manifest-compatibility',

--- a/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs
@@ -4,7 +4,7 @@
   'use strict'
 
   const specPath =
-    'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md'
+    'docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md'
   const inspectorPath =
     'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs'
 
@@ -59,7 +59,7 @@
       implementationBoundary: [
         'package.json',
         'scripts/__tests__/node-runtime-contract.test.mjs',
-        'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md',
+        'docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md',
         'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs',
         'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html',
         'docs/ai/framework/plans/__tests__/node-24-runtime-upgrade-flow-inspector.contract.test.cjs'
@@ -529,7 +529,6 @@
       cacheDimensions: [],
       implementationBoundary: [
         'docs/ai/framework/PLANS.md',
-        'docs/ai/framework/plans/node-24-runtime-upgrade-and-vercel-validation-plan.md',
         'docs/ai/framework/plans/completed/node-24-runtime-upgrade-and-vercel-validation-plan.md',
         'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.data.cjs',
         'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html',
@@ -987,7 +986,7 @@
       {
         id: 'product-contract',
         label: 'Product Contract',
-        href: './node-24-runtime-upgrade-and-vercel-validation-plan.md',
+        href: './completed/node-24-runtime-upgrade-and-vercel-validation-plan.md',
         kind: 'authority'
       },
       {

--- a/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html
+++ b/docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html
@@ -1,0 +1,688 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Node.js 24 Runtime Upgrade Flow Inspector</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #101418;
+        --panel: #151b22;
+        --panel-2: #1d2530;
+        --line: #334155;
+        --text: #e5edf5;
+        --muted: #9caab8;
+        --accent: #59b7ff;
+        --accent-2: #f97373;
+        --warn: #f6c85f;
+        --ok: #7bd88f;
+        --card-w: 270px;
+        --card-h: 118px;
+        --gap-x: 220px;
+        --gap-y: 100px;
+      }
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; color: var(--text); background: var(--bg); font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; }
+      .app { display: grid; grid-template-columns: minmax(980px, 1fr) 430px; height: 100vh; overflow: hidden; }
+      .main { min-width: 0; overflow: auto; padding: 24px; }
+      .header { display: flex; justify-content: space-between; margin-bottom: 18px; }
+      h1 { margin: 0 0 6px; font-size: 24px; }
+      .subtitle, .detail-summary { color: var(--muted); }
+      .header-links, .filters { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0 18px; }
+      .header-link, .filter-button { border: 1px solid var(--line); border-radius: 999px; padding: 6px 10px; color: var(--accent); background: var(--panel); }
+      .filter-button.active { border-color: var(--accent); }
+      .guide-panel { margin-bottom: 18px; border: 1px solid var(--line); border-radius: 14px; padding: 12px 16px; background: var(--panel); }
+      .guide-grid { display: grid; grid-template-columns: repeat(2, minmax(240px, 1fr)); gap: 12px; }
+      .guide-card { border: 1px solid var(--line); border-radius: 12px; padding: 12px; background: var(--panel-2); }
+      .flow { position: relative; min-width: 100%; min-height: 620px; }
+      .flow-svg { position: absolute; inset: 0; pointer-events: none; }
+      .step-card { position: absolute; width: var(--card-w); min-height: var(--card-h); border: 1px solid var(--line); border-radius: 14px; padding: 14px; color: var(--text); background: var(--panel); text-align: left; }
+      .step-card.selected { border-color: var(--accent); }
+      .step-card h2 { margin: 0 0 6px; font-size: 15px; }
+      .detail { height: 100vh; overflow: auto; border-left: 1px solid var(--line); padding: 24px; background: #0f1720; }
+      .detail-section { margin-bottom: 16px; border: 1px solid var(--line); border-radius: 12px; padding: 14px; background: var(--panel); }
+      .detail-section h3 { margin: 0 0 8px; font-size: 12px; text-transform: uppercase; }
+      code { color: #dbeafe; }
+      a { color: var(--accent); }
+      .hidden { display: none; }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <main class="main">
+        <div class="header">
+          <div>
+            <h1 id="inspector-title">Flow Inspector</h1>
+            <p id="inspector-subtitle" class="subtitle">Loading target contract.</p>
+            <div id="inspector-links" class="header-links"></div>
+          </div>
+        </div>
+        <div id="filters" class="filters"></div>
+        <details class="guide-panel">
+          <summary>Viewer controls and contract</summary>
+          <section class="guide-grid">
+            <article class="guide-card">
+              <h2>Viewer controls</h2>
+              <p>Filter by owner lane and select a card to inspect its exact inputs, outputs, boundaries, and failure owner.</p>
+            </article>
+            <article class="guide-card">
+              <h2>Target contract</h2>
+              <p id="target-contract-summary">Loading target contract.</p>
+            </article>
+          </section>
+        </details>
+        <section id="flow" class="flow" aria-label="Node.js 24 runtime upgrade flow"></section>
+      </main>
+      <aside id="detail" class="detail" aria-label="step detail"></aside>
+    </div>
+    <script src="./node-24-runtime-upgrade-flow-inspector.data.cjs"></script>
+    <script data-flow-inspector-renderer>
+/* global console, document, window */
+
+;(function () {
+  'use strict'
+
+  const data = globalThis.FLOW_INSPECTOR_DATA
+  if (!data) {
+    throw new Error(
+      'Missing FLOW_INSPECTOR_DATA. Load the target data file before the shared viewer.'
+    )
+  }
+
+  const {
+    schema,
+    target,
+    authority,
+    links = [],
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  } = data
+
+  const requiredCollections = {
+    links,
+    lanes,
+    steps,
+    routes,
+    artifacts,
+    invariants,
+    acceptanceContracts
+  }
+  const invalidCollections = Object.entries(requiredCollections)
+    .filter(([, value]) => !Array.isArray(value))
+    .map(([name]) => name)
+  if (invalidCollections.length) {
+    throw new Error(
+      `Flow Inspector target has invalid collections: ${invalidCollections.join(', ')}`
+    )
+  }
+  if (schema?.id !== 'asyra.flow-inspector' || schema.version !== 2) {
+    throw new Error('Flow Inspector requires schema asyra.flow-inspector/v2.')
+  }
+
+  const flow = document.getElementById('flow')
+  const detail = document.getElementById('detail')
+  const filters = document.getElementById('filters')
+  const title = document.getElementById('inspector-title')
+  const subtitle = document.getElementById('inspector-subtitle')
+  const headerLinks = document.getElementById('inspector-links')
+  const targetSummary = document.getElementById('target-contract-summary')
+
+  const requiredElements = {
+    flow,
+    detail,
+    filters,
+    title,
+    subtitle,
+    headerLinks,
+    targetSummary
+  }
+  const missingElements = Object.entries(requiredElements)
+    .filter(([, element]) => !element)
+    .map(([name]) => name)
+  if (missingElements.length) {
+    throw new Error(
+      `Flow Inspector shell is missing: ${missingElements.join(', ')}`
+    )
+  }
+
+  const escapeHtml = (value) =>
+    String(value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;')
+
+  const specLink = links.find((link) => link.kind === 'authority')
+
+  const formatItem = (value) => {
+    if (value && typeof value === 'object' && value.href && value.label) {
+      return `<a href="${escapeHtml(value.href)}">${escapeHtml(value.label)}</a>`
+    }
+    const text = String(value)
+    if (text.startsWith('#') && specLink) {
+      return `<a href="${escapeHtml(`${specLink.href}${text}`)}"><code>${escapeHtml(text)}</code></a>`
+    }
+    return escapeHtml(text).replace(/`([^`]+)`/g, '<code>$1</code>')
+  }
+
+  const section = (heading, items, className = '') => {
+    const values = items && items.length ? items : ['None']
+    return `
+      <section class="detail-section ${className}">
+        <h3>${escapeHtml(heading)}</h3>
+        <ul>${values.map((item) => `<li>${formatItem(item)}</li>`).join('')}</ul>
+      </section>`
+  }
+
+  const laneById = new Map(lanes.map((lane) => [lane.id, lane]))
+  const stepById = new Map(steps.map((step) => [step.id, step]))
+  const artifactById = new Map(
+    artifacts.map((artifact) => [artifact.id, artifact])
+  )
+  const stepsByLane = new Map(
+    lanes.map((lane) => [
+      lane.id,
+      steps
+        .filter((step) => step.laneId === lane.id)
+        .sort((left, right) => left.order - right.order)
+    ])
+  )
+
+  const layout = {
+    left: 28,
+    top: 68,
+    cardW: 270,
+    cardH: 118,
+    gapX: 220,
+    gapY: 100
+  }
+
+  let selectedId = steps[0]?.id ?? null
+  let selectedLaneId = 'All'
+
+  const isVisible = (step) =>
+    selectedLaneId === 'All' || step.laneId === selectedLaneId
+
+  const getStepLane = (step) =>
+    lanes.findIndex((lane) => lane.id === step.laneId)
+
+  const getStepRow = (step) =>
+    stepsByLane.get(step.laneId)?.findIndex((item) => item.id === step.id) ?? 0
+
+  const stepPosition = (step) => ({
+    x: layout.left + getStepLane(step) * (layout.cardW + layout.gapX),
+    y: layout.top + getStepRow(step) * (layout.cardH + layout.gapY)
+  })
+
+  const getFlowBounds = () => {
+    const visibleSteps = steps.filter(isVisible)
+    const laneIndexes = visibleSteps.map(getStepLane)
+    const rowIndexes = visibleSteps.map(getStepRow)
+    const maxLane = laneIndexes.length ? Math.max(...laneIndexes) : 0
+    const maxRow = rowIndexes.length ? Math.max(...rowIndexes) : 0
+    return {
+      width:
+        layout.left * 2 + (maxLane + 1) * layout.cardW + maxLane * layout.gapX,
+      height:
+        layout.top * 2 + (maxRow + 1) * layout.cardH + maxRow * layout.gapY
+    }
+  }
+
+  const toSvgPoint = (svg, x, y) => {
+    const point = svg.createSVGPoint()
+    point.x = x
+    point.y = y
+    const matrix = svg.getScreenCTM()
+    return matrix ? point.matrixTransform(matrix.inverse()) : { x, y }
+  }
+
+  const getEdgePath = (svg, fromCard, toCard, fromStep, toStep) => {
+    const fromBox = fromCard.getBoundingClientRect()
+    const toBox = toCard.getBoundingClientRect()
+    if (fromStep.laneId === toStep.laneId) {
+      const start = toSvgPoint(
+        svg,
+        fromBox.left + fromBox.width / 2,
+        fromBox.bottom
+      )
+      const end = toSvgPoint(svg, toBox.left + toBox.width / 2, toBox.top)
+      const midpointY = fromBox.bottom + (toBox.top - fromBox.bottom) * 0.5
+      const controlStart = toSvgPoint(
+        svg,
+        fromBox.left + fromBox.width / 2,
+        midpointY
+      )
+      const controlEnd = toSvgPoint(
+        svg,
+        toBox.left + toBox.width / 2,
+        midpointY
+      )
+      return `M ${start.x} ${start.y} C ${controlStart.x} ${controlStart.y}, ${controlEnd.x} ${controlEnd.y}, ${end.x} ${end.y}`
+    }
+
+    const direction = toBox.left >= fromBox.left ? 1 : -1
+    const startX = direction > 0 ? fromBox.right : fromBox.left
+    const startY = fromBox.top + fromBox.height / 2
+    const endX = direction > 0 ? toBox.left : toBox.right
+    const endY = toBox.top + toBox.height / 2
+    const distanceX = Math.abs(endX - startX)
+    const curve = Math.max(120, Math.min(distanceX * 0.46, layout.gapX * 0.92))
+    const start = toSvgPoint(svg, startX, startY)
+    const end = toSvgPoint(svg, endX, endY)
+    const controlStart = toSvgPoint(svg, startX + direction * curve, startY)
+    const controlEnd = toSvgPoint(svg, endX - direction * curve, endY)
+    return `M ${start.x} ${start.y} C ${controlStart.x} ${controlStart.y}, ${controlEnd.x} ${controlEnd.y}, ${end.x} ${end.y}`
+  }
+
+  const routeClass = (kind) => {
+    if (kind === 'bypass') return 'route-bypass'
+    if (kind === 'coexecute' || kind === 'fanout') return 'route-parallel'
+    return `route-${kind}`
+  }
+
+  const renderEdges = (svg) => {
+    svg.querySelectorAll('.edge-path').forEach((node) => node.remove())
+    routes.forEach((route) => {
+      if (!route.to) return
+      const from = stepById.get(route.from)
+      const to = stepById.get(route.to)
+      if (!from || !to || !isVisible(from) || !isVisible(to)) return
+      const fromCard = flow.querySelector(`[data-step-id="${route.from}"]`)
+      const toCard = flow.querySelector(`[data-step-id="${route.to}"]`)
+      if (!fromCard || !toCard) return
+
+      const path = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path'
+      )
+      path.setAttribute('d', getEdgePath(svg, fromCard, toCard, from, to))
+      path.setAttribute(
+        'class',
+        `edge-path ${routeClass(route.kind)}${route.from === selectedId || route.to === selectedId ? ' is-active' : ''}`
+      )
+      path.setAttribute('data-route-id', route.id)
+      path.setAttribute('marker-end', 'url(#arrow)')
+      const tooltip = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'title'
+      )
+      tooltip.textContent = `${route.id}: ${route.kind}; ${route.predicate}`
+      path.appendChild(tooltip)
+      svg.appendChild(path)
+    })
+  }
+
+  const routesForStep = (stepId, direction) =>
+    routes
+      .filter((route) => route[direction] === stepId)
+      .map(
+        (route) =>
+          `${route.id} [${route.kind}]: ${route.predicate}; ${route.from} -> ${route.to ?? 'terminal'}; artifacts ${route.producedArtifacts.join(', ')}`
+      )
+
+  const artifactsOwnedBy = (stepId) =>
+    artifacts
+      .filter((artifact) => artifact.ownerStepId === stepId)
+      .map(
+        (artifact) =>
+          `${artifact.id}: ${artifact.channel}; consumers ${artifact.consumerStepIds.join(', ') || 'terminal'}`
+      )
+
+  const artifactsConsumedBy = (stepId) =>
+    artifacts
+      .filter((artifact) => artifact.consumerStepIds.includes(stepId))
+      .map(
+        (artifact) =>
+          `${artifact.id}: owner ${artifact.ownerStepId}; ${artifact.channel}`
+      )
+
+  const invariantsForStep = (stepId) =>
+    invariants
+      .filter((invariant) => invariant.stepIds.includes(stepId))
+      .map(
+        (invariant) =>
+          `${invariant.id}: ${invariant.statement}; refs ${invariant.specRefs.join(', ')}`
+      )
+
+  const acceptanceForStep = (stepId) =>
+    acceptanceContracts
+      .filter((contract) => contract.stepIds.includes(stepId))
+      .map(
+        (contract) =>
+          `${contract.id}: ${contract.assertions.join('; ')}; refs ${contract.specRefs.join(', ')}`
+      )
+
+  const renderHeader = () => {
+    document.title = target.title
+    title.textContent = target.title
+    subtitle.textContent = target.subtitle
+    headerLinks.innerHTML = links
+      .map(
+        (link) =>
+          `<a class="header-link" href="${escapeHtml(link.href)}" data-link-kind="${escapeHtml(link.kind)}">${escapeHtml(link.label)}</a>`
+      )
+      .join('')
+    targetSummary.innerHTML = [
+      `Target: <code>${escapeHtml(target.kind)}:${escapeHtml(target.id)}</code>`,
+      `Schema: <code>${escapeHtml(schema.id)}/v${escapeHtml(schema.version)}</code>`,
+      `Semantic authority: <code>${escapeHtml(authority.specPath)}</code>`,
+      `Inspector data: <code>${escapeHtml(authority.inspectorPath)}</code>`
+    ].join('<br />')
+  }
+
+  const renderFilters = () => {
+    filters.innerHTML = ''
+    ;[{ id: 'All', title: 'All' }, ...lanes].forEach((lane) => {
+      const button = document.createElement('button')
+      button.className = `filter-button${lane.id === selectedLaneId ? ' is-active' : ''}`
+      button.type = 'button'
+      button.textContent = lane.title
+      button.addEventListener('click', () => {
+        selectedLaneId = lane.id
+        const selectedStep = stepById.get(selectedId)
+        if (selectedStep && !isVisible(selectedStep)) {
+          selectedId = steps.find(isVisible)?.id ?? steps[0]?.id ?? null
+        }
+        render()
+      })
+      filters.appendChild(button)
+    })
+  }
+
+  const renderDetail = () => {
+    const selected = stepById.get(selectedId) ?? steps[0]
+    if (!selected) {
+      detail.innerHTML = '<p>No steps are declared.</p>'
+      return
+    }
+    const lane = laneById.get(selected.laneId)
+    detail.innerHTML = `
+      <div class="detail-group">${escapeHtml(lane?.title ?? selected.laneId)}</div>
+      <div class="detail-heading">
+        <span class="step-number">Step ${escapeHtml(selected.order)}</span>
+        <h2>${escapeHtml(selected.title)}</h2>
+      </div>
+      <p class="detail-summary">${escapeHtml(selected.purpose)}</p>
+      ${section('Target links', links, 'rule-box')}
+      ${section('Owner package', [selected.ownerPackage], 'alignment-box')}
+      ${section('Inputs', selected.inputs)}
+      ${section('Outputs', selected.outputs)}
+      ${section('Conditions', selected.conditions, 'trace-box')}
+      ${section('Bypasses', selected.bypasses, 'trace-box')}
+      ${section('Allowed contributors', selected.allowedContributors, 'evidence-box')}
+      ${section('Forbidden contributors', selected.forbiddenContributors, 'risk-box')}
+      ${section('Cache dimensions', selected.cacheDimensions, 'trace-box')}
+      ${section('Implementation boundary', selected.implementationBoundary)}
+      ${section('Spec references', selected.specRefs, 'rule-box')}
+      ${section('Failure owner step', [selected.failureOwnerStepId], 'risk-box')}
+      ${section('Incoming routes', routesForStep(selected.id, 'to'), 'trace-box')}
+      ${section('Outgoing routes', routesForStep(selected.id, 'from'), 'trace-box')}
+      ${section('Owned artifacts', artifactsOwnedBy(selected.id), 'trace-box')}
+      ${section('Consumed artifacts', artifactsConsumedBy(selected.id), 'trace-box')}
+      ${section('Invariants', invariantsForStep(selected.id), 'evidence-box')}
+      ${section('Acceptance contracts', acceptanceForStep(selected.id), 'test-box')}`
+  }
+
+  const renderFlow = () => {
+    flow.innerHTML = ''
+    const bounds = getFlowBounds()
+    flow.style.minWidth = `${bounds.width}px`
+    flow.style.minHeight = `${bounds.height}px`
+
+    lanes.forEach((lane, laneIndex) => {
+      const label = document.createElement('div')
+      label.className = 'lane-label'
+      label.style.left = `${layout.left + laneIndex * (layout.cardW + layout.gapX)}px`
+      label.textContent = lane.title
+      flow.appendChild(label)
+    })
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('class', 'flow-svg')
+    svg.setAttribute('viewBox', `0 0 ${bounds.width} ${bounds.height}`)
+    svg.style.width = `${bounds.width}px`
+    svg.style.height = `${bounds.height}px`
+    svg.innerHTML = `
+      <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(148, 163, 184, 0.62)"></path>
+        </marker>
+      </defs>`
+    flow.appendChild(svg)
+
+    steps.filter(isVisible).forEach((step) => {
+      const position = stepPosition(step)
+      const lane = laneById.get(step.laneId)
+      const tags = step.tags ?? []
+      const card = document.createElement('button')
+      card.type = 'button'
+      card.className = [
+        'step-card',
+        step.id === selectedId ? 'is-selected' : '',
+        tags.includes('risk') ? 'is-risk' : '',
+        tags.includes('critical') ? 'is-critical' : '',
+        tags.includes('blocker') ? 'is-blocker' : ''
+      ]
+        .filter(Boolean)
+        .join(' ')
+      card.style.left = `${position.x}px`
+      card.style.top = `${position.y}px`
+      card.dataset.stepId = step.id
+      card.innerHTML = `
+        <div class="step-kicker">
+          <span class="step-number">Step ${escapeHtml(step.order)}</span>
+          <span>${escapeHtml(lane?.title ?? step.laneId)}</span>
+        </div>
+        <div class="step-title">${escapeHtml(step.title)}</div>
+        <div class="step-summary">${escapeHtml(step.purpose)}</div>
+        <div class="badge-row">
+          <span class="badge truth">${escapeHtml(step.ownerPackage)}</span>
+          ${tags
+            .slice(0, 2)
+            .map((tag) => `<span class="badge">${escapeHtml(tag)}</span>`)
+            .join('')}
+        </div>`
+      card.addEventListener('click', () => {
+        selectedId = step.id
+        render()
+      })
+      flow.appendChild(card)
+    })
+
+    renderEdges(svg)
+  }
+
+  const runStaticChecks = () => {
+    const errors = []
+    const uniqueIds = (label, items) => {
+      const seen = new Set()
+      items.forEach((item) => {
+        if (seen.has(item.id)) errors.push(`${label}:duplicate:${item.id}`)
+        seen.add(item.id)
+      })
+    }
+    uniqueIds('lane', lanes)
+    uniqueIds('step', steps)
+    uniqueIds('route', routes)
+    uniqueIds('artifact', artifacts)
+    uniqueIds('invariant', invariants)
+    uniqueIds('acceptance', acceptanceContracts)
+
+    if (!target?.id || !target?.kind || !target?.title) {
+      errors.push('target:incomplete')
+    }
+
+    const requiredStepFields = [
+      'id',
+      'order',
+      'laneId',
+      'title',
+      'ownerPackage',
+      'purpose',
+      'inputs',
+      'outputs',
+      'conditions',
+      'bypasses',
+      'allowedContributors',
+      'forbiddenContributors',
+      'cacheDimensions',
+      'implementationBoundary',
+      'specRefs',
+      'failureOwnerStepId'
+    ]
+    steps.forEach((step) => {
+      requiredStepFields.forEach((field) => {
+        if (step[field] === undefined)
+          errors.push(`${step.id}:missing:${field}`)
+      })
+      if (!laneById.has(step.laneId)) errors.push(`${step.id}:lane`)
+      if (!stepById.has(step.failureOwnerStepId)) {
+        errors.push(`${step.id}:failureOwnerStepId`)
+      }
+      step.inputs
+        .filter((input) => input.startsWith('artifact:'))
+        .forEach((artifactId) => {
+          if (!artifactById.has(artifactId)) {
+            errors.push(`${step.id}:input:${artifactId}`)
+          }
+        })
+      step.outputs.forEach((artifactId) => {
+        if (!artifactById.has(artifactId)) {
+          errors.push(`${step.id}:output:${artifactId}`)
+        }
+      })
+    })
+
+    routes.forEach((route) => {
+      if (!stepById.has(route.from)) errors.push(`${route.id}:from`)
+      if (route.to && !stepById.has(route.to)) errors.push(`${route.id}:to`)
+      route.producedArtifacts.forEach((artifactId) => {
+        const artifact = artifactById.get(artifactId)
+        if (!artifact) {
+          errors.push(`${route.id}:artifact:${artifactId}`)
+          return
+        }
+        if (artifact.ownerStepId !== route.from) {
+          errors.push(`${route.id}:artifact-owner:${artifactId}`)
+        }
+        if (route.to && !artifact.consumerStepIds.includes(route.to)) {
+          errors.push(`${route.id}:artifact-consumer:${artifactId}`)
+        }
+      })
+    })
+
+    artifacts.forEach((artifact) => {
+      const owner = stepById.get(artifact.ownerStepId)
+      if (!owner) {
+        errors.push(`${artifact.id}:owner`)
+      } else if (!owner.outputs.includes(artifact.id)) {
+        errors.push(`${artifact.id}:owner-output`)
+      }
+      artifact.consumerStepIds.forEach((stepId) => {
+        const consumer = stepById.get(stepId)
+        if (!consumer) {
+          errors.push(`${artifact.id}:consumer:${stepId}`)
+        } else if (!consumer.inputs.includes(artifact.id)) {
+          errors.push(`${artifact.id}:consumer-input:${stepId}`)
+        }
+      })
+      if (!artifact.terminal && !artifact.consumerStepIds.length) {
+        errors.push(`${artifact.id}:missing-consumer`)
+      }
+    })
+
+    invariants.forEach((invariant) => {
+      invariant.stepIds.forEach((stepId) => {
+        if (!stepById.has(stepId)) {
+          errors.push(`${invariant.id}:step:${stepId}`)
+        }
+      })
+      invariant.artifactIds.forEach((artifactId) => {
+        if (!artifactById.has(artifactId)) {
+          errors.push(`${invariant.id}:artifact:${artifactId}`)
+        }
+      })
+    })
+
+    acceptanceContracts.forEach((contract) => {
+      contract.stepIds.forEach((stepId) => {
+        if (!stepById.has(stepId)) {
+          errors.push(`${contract.id}:step:${stepId}`)
+        }
+      })
+    })
+
+    if (errors.length) {
+      console.error('Flow Inspector static check failed', {
+        target: target.id,
+        errors
+      })
+    } else {
+      console.info('Flow Inspector static check passed', {
+        target: target.id,
+        lanes: lanes.length,
+        steps: steps.length,
+        routes: routes.length,
+        artifacts: artifacts.length,
+        invariants: invariants.length,
+        acceptanceContracts: acceptanceContracts.length
+      })
+    }
+  }
+
+  const runLayoutChecks = () => {
+    const cards = [...flow.querySelectorAll('.step-card')].map((card) => {
+      const rect = card.getBoundingClientRect()
+      return {
+        id: card.dataset.stepId,
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom
+      }
+    })
+    const overlaps = []
+    cards.forEach((card, index) => {
+      cards.slice(index + 1).forEach((other) => {
+        const overlapX =
+          Math.min(card.right, other.right) - Math.max(card.left, other.left)
+        const overlapY =
+          Math.min(card.bottom, other.bottom) - Math.max(card.top, other.top)
+        if (overlapX > 8 && overlapY > 8) {
+          overlaps.push(`${card.id}:${other.id}`)
+        }
+      })
+    })
+    if (overlaps.length) {
+      console.error('Flow Inspector layout check failed', { overlaps })
+    } else {
+      console.info('Flow Inspector layout check passed', {
+        cards: cards.length
+      })
+    }
+  }
+
+  const render = () => {
+    renderHeader()
+    renderFilters()
+    renderFlow()
+    renderDetail()
+    runLayoutChecks()
+  }
+
+  runStaticChecks()
+  render()
+  window.addEventListener('resize', () => {
+    const svg = flow.querySelector('.flow-svg')
+    if (svg) renderEdges(svg)
+  })
+})()
+    </script>
+  </body>
+</html>

--- a/docs/ai/workflows/package-release-validation.md
+++ b/docs/ai/workflows/package-release-validation.md
@@ -93,7 +93,7 @@ dependencies. `release:records` freezes the candidate versions, public support
 documents, package READMEs, Changesets configuration, and the distinction
 between readiness and publication.
 
-The formal commands require Node.js 20.x to report `READY`. The explicit
+The formal commands require Node.js 24.x to report `READY`. The explicit
 `--allow-unsupported-node` option is local diagnostic evidence only and cannot
 authorize the release decision.
 

--- a/fixtures/framework-release-consumer/package.json
+++ b/fixtures/framework-release-consumer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "create-app/*"
   ],
   "engines": {
-    "node": "20.x",
+    "node": "24.x",
     "yarn": ">=4.3.1"
   },
   "resolutions": {

--- a/packages/ai-agent-runtime/README.md
+++ b/packages/ai-agent-runtime/README.md
@@ -13,5 +13,5 @@ network traffic, timer, listener, or canonical mutation.
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/ai-agent-runtime/package.json
+++ b/packages/ai-agent-runtime/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "main": "dist/index.js",

--- a/packages/collaboration/README.md
+++ b/packages/collaboration/README.md
@@ -48,7 +48,7 @@ for complete composition, lifecycle, provider, and app-ownership details.
 
 ## Release support
 
-The `@asyra/collaboration` `0.2.5` ESM artifact supports Node.js 20.x. Use only
+The `@asyra/collaboration` `0.2.5` ESM artifact supports Node.js 24.x. Use only
 package-root exports. The package is opt-in and creates no provider or network
 side effect until an app explicitly composes and connects it. See the
 [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "main": "dist/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,6 +48,6 @@ window and is planned for removal in the next major release.
 
 ## Release support
 
-The `@asyra/core` `0.2.5` ESM artifact supports Node.js 20.x. Use only
+The `@asyra/core` `0.2.5` ESM artifact supports Node.js 24.x. Use only
 package-root or explicitly exported subpath APIs. See the
 [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -9,6 +9,6 @@ import '@asyra/design-system/index.css'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x and declares React 19 peer
+The `0.2.5` ESM artifact supports Node.js 24.x and declares React 19 peer
 dependencies. Use only the package-root and documented style exports. See the
 [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "main": "./dist/index.es.js",

--- a/packages/factory/README.md
+++ b/packages/factory/README.md
@@ -9,5 +9,5 @@ import factory from '@asyra/factory'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/factory/package.json
+++ b/packages/factory/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/feature-system/README.md
+++ b/packages/feature-system/README.md
@@ -9,5 +9,5 @@ import { defineFeature, getFeature } from '@asyra/feature-system'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/feature-system/package.json
+++ b/packages/feature-system/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/input-system/README.md
+++ b/packages/input-system/README.md
@@ -73,7 +73,7 @@ This project is licensed under the MIT License.
 
 ## Release support
 
-The `@asyra/input-system` `0.2.5` ESM artifact supports Node.js 20.x. Use only
+The `@asyra/input-system` `0.2.5` ESM artifact supports Node.js 24.x. Use only
 package-root exports. See the
 [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).
 

--- a/packages/input-system/package.json
+++ b/packages/input-system/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "main": "dist/index.js",

--- a/packages/persistence/README.md
+++ b/packages/persistence/README.md
@@ -9,5 +9,5 @@ import type { DocumentLoadSource } from '@asyra/persistence'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/preset/README.md
+++ b/packages/preset/README.md
@@ -9,6 +9,6 @@ import { applyPreset } from '@asyra/preset'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 Production 3D and HYBRID profiles are not available in this release. See the
 [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/preset/package.json
+++ b/packages/preset/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/props-manager/README.md
+++ b/packages/props-manager/README.md
@@ -9,5 +9,5 @@ import propsManager from '@asyra/props-manager'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/props-manager/package.json
+++ b/packages/props-manager/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/reactive-events/README.md
+++ b/packages/reactive-events/README.md
@@ -9,5 +9,5 @@ import { eventRegistry } from '@asyra/reactive-events'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/reactive-events/package.json
+++ b/packages/reactive-events/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/render-engine-pixi/README.md
+++ b/packages/render-engine-pixi/README.md
@@ -9,5 +9,5 @@ import { createPixiRenderEngine } from '@asyra/render-engine-pixi'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/render-engine-pixi/package.json
+++ b/packages/render-engine-pixi/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/render-engine/README.md
+++ b/packages/render-engine/README.md
@@ -9,5 +9,5 @@ import type { RenderEngineProvider } from '@asyra/render-engine'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/render-engine/package.json
+++ b/packages/render-engine/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -13,5 +13,5 @@ compatibility surfaces for `RenderAdapter`, `RenderGraphics`, and
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/scene-tree/README.md
+++ b/packages/scene-tree/README.md
@@ -9,5 +9,5 @@ import sceneTree from '@asyra/scene-tree'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/scene-tree/package.json
+++ b/packages/scene-tree/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/selection/README.md
+++ b/packages/selection/README.md
@@ -8,5 +8,5 @@ import selection from '@asyra/selection'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/selection/package.json
+++ b/packages/selection/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/system-context/README.md
+++ b/packages/system-context/README.md
@@ -9,5 +9,5 @@ import systemContext from '@asyra/system-context'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/system-context/package.json
+++ b/packages/system-context/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "main": "dist/index.js",

--- a/packages/ui-context/README.md
+++ b/packages/ui-context/README.md
@@ -9,5 +9,5 @@ import uiContext from '@asyra/ui-context'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/ui-context/package.json
+++ b/packages/ui-context/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -9,5 +9,5 @@ import { isRecord } from '@asyra/utils'
 
 ## Release support
 
-The `0.2.5` ESM artifact supports Node.js 20.x. Use only package-root exports.
+The `0.2.5` ESM artifact supports Node.js 24.x. Use only package-root exports.
 See the [Framework release support contract](../../docs/ai/framework/RELEASE_SUPPORT.md).

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   },
   "packageManager": "yarn@4.3.1",
   "keywords": [],

--- a/scripts/__tests__/node-runtime-contract.test.mjs
+++ b/scripts/__tests__/node-runtime-contract.test.mjs
@@ -140,3 +140,27 @@ test('the Vercel project-root manifest selects Node.js 24 without a conflicting 
   assert.equal(vercelConfig.functions, undefined)
   assert.doesNotMatch(JSON.stringify(vercelConfig), /nodejs20|20\.x/i)
 })
+
+test('current public support records require Node.js 24 without a legacy-major fallback', () => {
+  const supportPaths = [
+    'README.md',
+    'CHANGELOG.md',
+    'RELEASE_NOTES.md',
+    ...FRAMEWORK_RELEASE_PACKAGE_NAMES.map(
+      (name) => `packages/${name.slice('@asyra/'.length)}/README.md`
+    ),
+    'apps/asyra-design/README.md',
+    'apps/asyra-design/TEMPLATE.md',
+    'create-app/asyra-design/template/README.md',
+    'docs/ai/framework/RELEASE_SUPPORT.md',
+    'docs/ai/workflows/package-release-validation.md',
+    'scripts/release-records.js'
+  ]
+
+  for (const supportPath of supportPaths) {
+    const contents = readText(supportPath)
+
+    assert.match(contents, /Node\.js 24\.x/, supportPath)
+    assert.doesNotMatch(contents, /Node(?:\.js)? 20(?:\.x)?/, supportPath)
+  }
+})

--- a/scripts/__tests__/node-runtime-contract.test.mjs
+++ b/scripts/__tests__/node-runtime-contract.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { FRAMEWORK_RELEASE_PACKAGE_NAMES } from '../framework-release-packages.js'
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+)
+const supportedNodeRange = '24.x'
+const supportedYarnVersion = '4.3.1'
+
+const readJson = (relativePath) =>
+  JSON.parse(fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8'))
+
+const readText = (relativePath) =>
+  fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8')
+
+test('the executing validation runtime is Node.js 24 with Yarn 4.3.1', () => {
+  assert.equal(Number.parseInt(process.versions.node.split('.')[0], 10), 24)
+  assert.equal(
+    execFileSync('yarn', ['--version'], {
+      cwd: repositoryRoot,
+      encoding: 'utf8'
+    }).trim(),
+    supportedYarnVersion
+  )
+})
+
+test('the repository root manifest requires Node.js 24 and Yarn 4.3.1', () => {
+  const rootManifest = readJson('package.json')
+
+  assert.deepEqual(rootManifest.engines, {
+    node: supportedNodeRange,
+    yarn: '>=4.3.1'
+  })
+  assert.equal(rootManifest.packageManager, 'yarn@4.3.1')
+})
+
+test('Framework packages, Asyra Design, and clean consumer require Node.js 24', () => {
+  const manifestPaths = [
+    ...FRAMEWORK_RELEASE_PACKAGE_NAMES.map(
+      (name) => `packages/${name.slice('@asyra/'.length)}/package.json`
+    ),
+    'apps/asyra-design/package.json',
+    'fixtures/framework-release-consumer/package.json'
+  ]
+  const runtimeContracts = manifestPaths.map((manifestPath) => ({
+    manifestPath,
+    node: readJson(manifestPath).engines?.node ?? null
+  }))
+
+  assert.deepEqual(
+    runtimeContracts,
+    manifestPaths.map((manifestPath) => ({
+      manifestPath,
+      node: supportedNodeRange
+    }))
+  )
+})
+
+test('release artifacts and consumers enforce Node.js 24', () => {
+  const contracts = [
+    {
+      path: 'scripts/release-package-artifacts.js',
+      patterns: [/manifest\.engines\?\.node !== '24\.x'/]
+    },
+    {
+      path: 'scripts/release-readiness.js',
+      patterns: [/major !== 24/, /requires Node 24\.x/]
+    },
+    {
+      path: 'scripts/release-template-readiness.js',
+      patterns: [
+        /manifest\.engines\?\.node !== '24\.x'/,
+        /requires Node 24\.x/,
+        /major !== 24/
+      ]
+    }
+  ]
+
+  for (const contract of contracts) {
+    const source = readText(contract.path)
+    for (const pattern of contract.patterns) {
+      assert.match(source, pattern, `${contract.path} ${pattern}`)
+    }
+    assert.doesNotMatch(source, /Node(?:\.js)? 20\.x|'20\.x'/)
+  }
+})
+
+test('the official generator writes the Node.js 24 contract', () => {
+  const source = readText('scripts/release-template.js')
+
+  assert.match(source, /node: '24\.x'/)
+  assert.doesNotMatch(source, /Node(?:\.js)? 20\.x|'20\.x'/)
+})
+
+test('the generated template contract requires Node.js 24 and Yarn 4.3.1', () => {
+  const manifest = readJson('create-app/asyra-design/template/package.json')
+  const sourceReadme = readText('apps/asyra-design/TEMPLATE.md')
+  const generatedReadme = readText('create-app/asyra-design/template/README.md')
+
+  assert.deepEqual(manifest.engines, { node: supportedNodeRange })
+  assert.equal(manifest.packageManager, 'yarn@4.3.1')
+  assert.equal(generatedReadme, sourceReadme)
+  assert.match(generatedReadme, /Node\.js 24\.x/)
+  assert.doesNotMatch(generatedReadme, /Node\.js 20\.x/)
+})
+
+test('all GitHub Actions Node setup owners select the Node.js 24 line', () => {
+  for (const workflowPath of [
+    '.github/workflows/main.yml',
+    '.github/workflows/e2e.yml'
+  ]) {
+    const workflow = readText(workflowPath)
+    const versions = [
+      ...workflow.matchAll(/node-version:\s*['"]?([^'"\s]+)['"]?/g)
+    ].map((match) => match[1])
+
+    assert.ok(versions.length > 0, `${workflowPath} Node setup`)
+    assert.equal(
+      versions.every((version) => /^24(?:\.|$)/.test(version)),
+      true,
+      `${workflowPath} versions: ${versions.join(', ')}`
+    )
+    assert.doesNotMatch(workflow, /Setup Node\.js 20|node-version:\s*['"]?20/)
+  }
+})
+
+test('the Vercel project-root manifest selects Node.js 24 without a conflicting custom runtime', () => {
+  const appManifest = readJson('apps/asyra-design/package.json')
+  const vercelConfig = readJson('vercel.json')
+
+  assert.deepEqual(appManifest.engines, { node: supportedNodeRange })
+  assert.equal(vercelConfig.version, 2)
+  assert.equal(vercelConfig.functions, undefined)
+  assert.doesNotMatch(JSON.stringify(vercelConfig), /nodejs20|20\.x/i)
+})

--- a/scripts/__tests__/release-automation.test.mjs
+++ b/scripts/__tests__/release-automation.test.mjs
@@ -93,7 +93,7 @@ test('generated template manifest is standalone on the supported release runtime
   )
   const serializedScripts = JSON.stringify(manifest.scripts ?? {})
 
-  assert.deepEqual(manifest.engines, { node: '20.x' })
+  assert.deepEqual(manifest.engines, { node: '24.x' })
   assert.equal(manifest.packageManager, 'yarn@4.3.1')
   assert.doesNotMatch(serializedScripts, /(?:\.\.\/){2}|--cwd\s+\.\.\/\.\./)
   assert.doesNotMatch(JSON.stringify(manifest), /workspace:|(?:link|portal):/)
@@ -120,7 +120,7 @@ test('generated template documents its verified standalone commands and opt-ins'
   )
 
   assert.equal(generated, source)
-  assert.match(generated, /Node\.js 20\.x/)
+  assert.match(generated, /Node\.js 24\.x/)
   for (const command of [
     'yarn install',
     'yarn react:build',

--- a/scripts/__tests__/release-package-artifacts.test.mjs
+++ b/scripts/__tests__/release-package-artifacts.test.mjs
@@ -174,7 +174,7 @@ test('every release package manifest declares the publishable artifact contract'
 
     assert.equal(manifest.license, 'MIT', `${record.packageName} license`)
     assert.equal(manifest.type, 'module', `${record.packageName} type`)
-    assert.deepEqual(manifest.engines, { node: '20.x' })
+    assert.deepEqual(manifest.engines, { node: '24.x' })
     assert.deepEqual(manifest.files, [
       'dist',
       '!dist/**/__tests__',

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -160,11 +160,12 @@ test('CI, E2E, and release validation own their bounded integration gates', () =
   assert.match(releaseValidation, /yarn release:app:check --prod=\$\{appName\}/)
 })
 
-test('CI reproduces Framework Release Gate 5 from packed artifacts on Node 20', () => {
+test('CI reproduces Framework Release Gate 5 from packed artifacts on Node 24', () => {
   const ci = readText('.github/workflows/main.yml')
   const releaseJob = ci.slice(ci.indexOf('framework-release-readiness:'))
 
-  assert.match(releaseJob, /node-version: 20\.17\.0/)
+  assert.match(releaseJob, /node-version: 24/)
+  assert.doesNotMatch(releaseJob, /node-version: 20/)
   assert.match(releaseJob, /yarn install --immutable/)
   assert.match(releaseJob, /yarn react:build/)
   assert.match(releaseJob, /yarn release:packages --prebuilt/)

--- a/scripts/release-package-artifacts.js
+++ b/scripts/release-package-artifacts.js
@@ -274,7 +274,7 @@ export const validateFrameworkReleasePackageArtifacts = ({
     if (
       manifest.license !== 'MIT' ||
       manifest.type !== 'module' ||
-      manifest.engines?.node !== '20.x'
+      manifest.engines?.node !== '24.x'
     ) {
       throw new Error(`${record.packageName} packed metadata is incomplete`)
     }

--- a/scripts/release-readiness.js
+++ b/scripts/release-readiness.js
@@ -176,9 +176,9 @@ const runCommandDefault = (command, args, options) => {
 
 const assertSupportedRuntime = ({ allowUnsupportedNode }) => {
   const major = Number.parseInt(process.versions.node.split('.')[0], 10)
-  if (major !== 20 && !allowUnsupportedNode) {
+  if (major !== 24 && !allowUnsupportedNode) {
     throw new Error(
-      `Framework release verification requires Node 20.x; current runtime is ${process.version}`
+      `Framework release verification requires Node 24.x; current runtime is ${process.version}`
     )
   }
 }

--- a/scripts/release-records.js
+++ b/scripts/release-records.js
@@ -11,7 +11,7 @@ const REQUIRED_DOCUMENT_TOKENS = Object.freeze({
   'RELEASE_NOTES.md': ['0.2.5', 'release readiness', 'does not authorize'],
   'SECURITY.md': ['private security advisory', 'Framework Security Boundaries'],
   'docs/ai/framework/RELEASE_SUPPORT.md': [
-    'Node.js 20.x',
+    'Node.js 24.x',
     'Yarn 4.3.1',
     'TypeScript 5.8.3',
     'React 19',
@@ -35,7 +35,7 @@ const REQUIRED_DOCUMENT_TOKENS = Object.freeze({
     'release:template',
     'release:records'
   ],
-  'apps/asyra-design/README.md': ['Node.js 20.x', 'Yarn 4.3.1']
+  'apps/asyra-design/README.md': ['Node.js 24.x', 'Yarn 4.3.1']
 })
 
 const COMPLETED_READINESS_PLAN =
@@ -106,7 +106,7 @@ export const validateFrameworkReleaseRecords = ({ repositoryRoot }) => {
     assertFileContains(
       resolvedRoot,
       path.join('packages', directory, 'README.md'),
-      [name, 'Node.js 20.x', 'RELEASE_SUPPORT.md']
+      [name, 'Node.js 24.x', 'RELEASE_SUPPORT.md']
     )
     return {
       name,

--- a/scripts/release-template-readiness.js
+++ b/scripts/release-template-readiness.js
@@ -145,8 +145,8 @@ export const validateGeneratedTemplateContract = ({
   }
   const serializedManifest = JSON.stringify(manifest)
 
-  if (manifest.engines?.node !== '20.x') {
-    throw new Error('Generated template must require Node 20.x')
+  if (manifest.engines?.node !== '24.x') {
+    throw new Error('Generated template must require Node 24.x')
   }
   if (manifest.packageManager !== 'yarn@4.3.1') {
     throw new Error('Generated template must use Yarn 4.3.1')
@@ -302,9 +302,9 @@ const runCommandDefault = (command, args, options) => {
 
 const assertSupportedRuntime = ({ allowUnsupportedNode }) => {
   const major = Number.parseInt(process.versions.node.split('.')[0], 10)
-  if (major !== 20 && !allowUnsupportedNode) {
+  if (major !== 24 && !allowUnsupportedNode) {
     throw new Error(
-      `Framework release verification requires Node 20.x; current runtime is ${process.version}`
+      `Framework release verification requires Node 24.x; current runtime is ${process.version}`
     )
   }
 }

--- a/scripts/release-template.js
+++ b/scripts/release-template.js
@@ -191,7 +191,7 @@ if (!fs.existsSync(pkgPath)) {
   updateDeps(pkg.peerDependencies)
 
   pkg.engines = {
-    node: '20.x'
+    node: '24.x'
   }
   pkg.packageManager = 'yarn@4.3.1'
 

--- a/tools/flow-inspector/__tests__/viewer-entry.test.cjs
+++ b/tools/flow-inspector/__tests__/viewer-entry.test.cjs
@@ -232,6 +232,15 @@ const targets = [
     ),
     dataScript: './framework-release-readiness-flow-inspector.data.cjs',
     filterLaneTitle: 'Package Artifacts'
+  },
+  {
+    id: 'node-24-runtime-upgrade',
+    entryPath: path.join(
+      projectRoot,
+      'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html'
+    ),
+    dataScript: './node-24-runtime-upgrade-flow-inspector.data.cjs',
+    filterLaneTitle: 'Runtime Contract'
   }
 ]
 

--- a/tools/flow-inspector/embed-viewer.cjs
+++ b/tools/flow-inspector/embed-viewer.cjs
@@ -65,6 +65,10 @@ const targetEntries = [
   path.join(
     projectRoot,
     'docs/ai/framework/plans/framework-release-readiness-flow-inspector.html'
+  ),
+  path.join(
+    projectRoot,
+    'docs/ai/framework/plans/node-24-runtime-upgrade-flow-inspector.html'
   )
 ]
 


### PR DESCRIPTION
## Summary

- migrate root, all 19 Framework packages, Asyra Design, release consumers, and generated templates to Node.js 24.x
- run every GitHub Actions Node owner on Node.js 24 while preserving Yarn 4.3.1
- add a formal Node runtime contract and a nine-owner migration Inspector
- update the existing Vercel project from Node.js 20.x to 24.x and close the migration plan as READY

## Validation

- immutable install, Turbo graph, dependency validation, clean full workspace build, full test:ci, and lint:ci
- fresh 19-package artifact and clean-consumer verification
- generated Asyra Design template consumer verification
- ordinary E2E: 135 passed, 3 scoped skips; isolated performance: 5 passed
- collaboration E2E: 10 passed, 2 explicit opt-in skips
- status-toast visual spec passed; live-app screenshots inspected
- GitHub validate, release-readiness, ordinary E2E, collaboration E2E, and Vercel checks passed on the final commit
- Vercel Preview built on Node.js 24.x and passed required-file frontend/editability smoke

## Vercel

- Project Settings Node.js version: 24.x
- final Preview: https://asyra-git-codex-node-24-runtime-upgrade-karote00s-projects.vercel.app
- deployment contains 18 static assets and no Function or Middleware resources; function-path smoke is N/A
- no required custom Vercel environment variables exist for this app

## Boundaries

- no package version, dependency, Yarn, or product-behavior changes
- no publication, production deployment, tag, merge, or release
