### PR TITLE
Launch the Asyra Framework website

### DIFF
--- a/apps/asyra-design/__tests__/playwright-config.test.mjs
+++ b/apps/asyra-design/__tests__/playwright-config.test.mjs
@@ -65,8 +65,8 @@ test('ordinary and collaboration Playwright suites have separate discovery', () 
   assert.match(statusToast, /status-toast-visual\.spec\.ts/)
 })
 
-test('functional Playwright suites use the installed Google Chrome channel', async () => {
-  const configSources = await Promise.all(
+test('functional Playwright suites use Google Chrome while the isolated timing gate can pin managed Chromium', async () => {
+  const [ordinarySource, ...functionalSources] = await Promise.all(
     [
       '../playwright.config.ts',
       '../playwright.collaboration.config.ts',
@@ -76,7 +76,12 @@ test('functional Playwright suites use the installed Google Chrome channel', asy
     )
   )
 
-  configSources.forEach((configSource) => {
+  assert.match(ordinarySource, /E2E_RENDER_PERFORMANCE_BROWSER/)
+  assert.match(
+    ordinarySource,
+    /usesManagedChromium[\s\S]{0,160}channel:\s*'chrome'/
+  )
+  functionalSources.forEach((configSource) => {
     assert.match(
       configSource,
       /use:\s*\{\s*\.\.\.devices\['Desktop Chrome'\],\s*channel:\s*'chrome'\s*\}/

--- a/apps/asyra-design/e2e/render-delta-performance.spec.ts
+++ b/apps/asyra-design/e2e/render-delta-performance.spec.ts
@@ -124,10 +124,6 @@ test.describe('Render delta performance budget', () => {
   }, testInfo) => {
     test.setTimeout(120_000)
 
-    await page.exposeFunction('__requestPerformanceTestGarbageCollection', () =>
-      page.requestGC()
-    )
-
     const rawProfile = await page.evaluate(
       async ({ pointCount, sampleFrames, intersectionStep }) => {
         // E2E-only access to the currently composed framework runtime.
@@ -249,27 +245,6 @@ test.describe('Render delta performance budget', () => {
             'Collaboration runtime did not settle before isolated profiling'
           )
         }
-
-        const requestTestGarbageCollection = (
-          globalThis as typeof globalThis & {
-            __requestPerformanceTestGarbageCollection?: () => Promise<void>
-          }
-        ).__requestPerformanceTestGarbageCollection
-        if (typeof requestTestGarbageCollection !== 'function') {
-          throw new Error(
-            'Performance test garbage-collection control is unavailable'
-          )
-        }
-        await requestTestGarbageCollection()
-
-        const renderForStabilization = core.deps?.render
-        if (!renderForStabilization) {
-          throw new Error(
-            'Render runtime is unavailable for performance stabilization'
-          )
-        }
-        renderForStabilization.requestRender()
-        renderForStabilization.flushFrame()
 
         await new Promise<void>((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(() => resolve()))

--- a/apps/asyra-design/e2e/render-delta-performance.spec.ts
+++ b/apps/asyra-design/e2e/render-delta-performance.spec.ts
@@ -263,6 +263,15 @@ test.describe('Render delta performance budget', () => {
         }
         await requestTestGarbageCollection()
 
+        const renderForStabilization = core.deps?.render
+        if (!renderForStabilization) {
+          throw new Error(
+            'Render runtime is unavailable for performance stabilization'
+          )
+        }
+        renderForStabilization.requestRender()
+        renderForStabilization.flushFrame()
+
         await new Promise<void>((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
         )

--- a/apps/asyra-design/e2e/render-delta-performance.spec.ts
+++ b/apps/asyra-design/e2e/render-delta-performance.spec.ts
@@ -124,6 +124,11 @@ test.describe('Render delta performance budget', () => {
   }, testInfo) => {
     test.setTimeout(120_000)
 
+    await page.exposeFunction(
+      '__asyraRequestPerformanceTestGarbageCollection',
+      () => page.requestGC()
+    )
+
     const rawProfile = await page.evaluate(
       async ({ pointCount, sampleFrames, intersectionStep }) => {
         // E2E-only access to the currently composed framework runtime.
@@ -245,6 +250,18 @@ test.describe('Render delta performance budget', () => {
             'Collaboration runtime did not settle before isolated profiling'
           )
         }
+
+        const requestTestGarbageCollection = (
+          globalThis as typeof globalThis & {
+            __asyraRequestPerformanceTestGarbageCollection?: () => Promise<void>
+          }
+        ).__asyraRequestPerformanceTestGarbageCollection
+        if (typeof requestTestGarbageCollection !== 'function') {
+          throw new Error(
+            'Performance test garbage-collection control is unavailable'
+          )
+        }
+        await requestTestGarbageCollection()
 
         await new Promise<void>((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(() => resolve()))

--- a/apps/asyra-design/e2e/render-delta-performance.spec.ts
+++ b/apps/asyra-design/e2e/render-delta-performance.spec.ts
@@ -124,9 +124,8 @@ test.describe('Render delta performance budget', () => {
   }, testInfo) => {
     test.setTimeout(120_000)
 
-    await page.exposeFunction(
-      '__asyraRequestPerformanceTestGarbageCollection',
-      () => page.requestGC()
+    await page.exposeFunction('__requestPerformanceTestGarbageCollection', () =>
+      page.requestGC()
     )
 
     const rawProfile = await page.evaluate(
@@ -253,9 +252,9 @@ test.describe('Render delta performance budget', () => {
 
         const requestTestGarbageCollection = (
           globalThis as typeof globalThis & {
-            __asyraRequestPerformanceTestGarbageCollection?: () => Promise<void>
+            __requestPerformanceTestGarbageCollection?: () => Promise<void>
           }
-        ).__asyraRequestPerformanceTestGarbageCollection
+        ).__requestPerformanceTestGarbageCollection
         if (typeof requestTestGarbageCollection !== 'function') {
           throw new Error(
             'Performance test garbage-collection control is unavailable'

--- a/apps/asyra-design/playwright.config.ts
+++ b/apps/asyra-design/playwright.config.ts
@@ -5,6 +5,14 @@ import { resolveOrdinaryPlaywrightRuntimePolicy } from './playwright-runtime-pol
 const appEnvironment = resolveEnvironment(loadEnvironment())
 const runtimePolicy = resolveOrdinaryPlaywrightRuntimePolicy(process.env)
 const runsCrdt7076 = process.env.E2E_CRDT_7076 === 'true'
+const renderPerformanceBrowser =
+  process.env.E2E_RENDER_PERFORMANCE_BROWSER?.trim()
+if (renderPerformanceBrowser && renderPerformanceBrowser !== 'chromium') {
+  throw new Error(
+    'E2E_RENDER_PERFORMANCE_BROWSER supports only managed Chromium'
+  )
+}
+const usesManagedChromium = renderPerformanceBrowser === 'chromium'
 const documentBackendURL =
   process.env.E2E_DOCUMENT_BACKEND_URL?.trim() || 'http://127.0.0.1:4201'
 const documentBackendPort = new URL(documentBackendURL).port || '80'
@@ -80,7 +88,7 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chrome'
+        ...(usesManagedChromium ? {} : { channel: 'chrome' })
       }
     }
 

--- a/apps/asyra-framework-site/__tests__/e2e/launch-production.spec.ts
+++ b/apps/asyra-framework-site/__tests__/e2e/launch-production.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test'
+
+const productionUrl = process.env.SITE_URL
+const productionOrigin = productionUrl ? new URL(productionUrl).origin : ''
+
+test.skip(!productionUrl, 'SITE_URL is required for production verification')
+
+test('production is anonymous, canonical, searchable, and secure', async ({
+  page,
+  request
+}) => {
+  const response = await request.get('/')
+  expect(response.status()).toBe(200)
+  ;[
+    'content-security-policy',
+    'permissions-policy',
+    'referrer-policy',
+    'strict-transport-security',
+    'x-content-type-options',
+    'x-frame-options'
+  ].forEach((header) => expect(response.headers()[header]).toBeTruthy())
+
+  await page.goto('/docs')
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    `${productionOrigin}/docs`
+  )
+  await page.keyboard.press('Control+k')
+  const search = page.getByRole('dialog', { name: 'Search documentation' })
+  await expect(search).toBeVisible()
+  await search.getByRole('searchbox').fill('transaction')
+  await expect(search.locator('.search-results a').first()).toBeVisible()
+})
+
+test('production explains Asyra globally and reaches its verified reference product', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/')
+  await expect(
+    page.getByRole('heading', { name: 'Build what your world needs.' })
+  ).toBeVisible()
+  await expect(
+    page.getByText('Framework owns reusable infrastructure.')
+  ).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: 'Open Asyra Design' })
+  ).toHaveAttribute('href', 'https://asra.vercel.app')
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth
+  }))
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth)
+})
+
+test('production Runtime Atlas executes canonical evidence', async ({
+  page
+}) => {
+  await page.goto('/atlas')
+  const status = page.locator('[data-atlas-status]')
+  await page.locator('[data-atlas-action="run"]').click()
+  await expect(status).toHaveAttribute('data-atlas-status', 'accepted', {
+    timeout: 4_000
+  })
+})

--- a/apps/asyra-framework-site/__tests__/e2e/platform-visual.spec.ts
+++ b/apps/asyra-framework-site/__tests__/e2e/platform-visual.spec.ts
@@ -130,6 +130,15 @@ test('supporting routes expose exact status boundaries', async ({ page }) => {
   await expect(
     page.getByText('Reference product, not Framework owner')
   ).toBeVisible()
+  await expect(
+    page.getByRole('link', { name: 'Open Asyra Design' })
+  ).toHaveAttribute('href', 'https://asra.vercel.app')
+  const actions = page.locator('.case-study-actions a')
+  await expect(actions).toHaveCount(2)
+  const actionWidths = await actions.evaluateAll((elements) =>
+    elements.map((element) => element.getBoundingClientRect().width)
+  )
+  expect(new Set(actionWidths.map(Math.round)).size).toBe(1)
   await page.goto('/roadmap')
   await expect(
     page.getByText(

--- a/apps/asyra-framework-site/__tests__/foundations.test.mjs
+++ b/apps/asyra-framework-site/__tests__/foundations.test.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 import { loadContentBundle } from '../lib/content.mjs'
+import { isIndexingAuthorized, resolveSiteOrigin } from '../lib/site-origin.ts'
 
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const read = (filePath) => fs.readFileSync(path.join(appRoot, filePath), 'utf8')
@@ -36,18 +37,38 @@ test('unsupported-browser state is global, explicit, and content-safe', () => {
 
 test('robots stay closed until production indexing is explicitly authorized', () => {
   const source = read('app/robots.ts')
-  assert.match(source, /VERCEL_ENV === 'production'/)
-  assert.match(source, /NEXT_PUBLIC_SITE_INDEXING === 'true'/)
+  assert.equal(
+    isIndexingAuthorized({
+      VERCEL_ENV: 'preview',
+      NEXT_PUBLIC_SITE_INDEXING: 'true'
+    }),
+    false
+  )
+  assert.equal(
+    isIndexingAuthorized({
+      VERCEL_ENV: 'production',
+      NEXT_PUBLIC_SITE_INDEXING: 'true'
+    }),
+    true
+  )
+  assert.match(source, /isIndexingAuthorized\(\)/)
   assert.match(source, /disallow: '\/'/)
 })
 
-test('sitemap derives all content routes and uses only observed deployment hosts', () => {
+test('sitemap derives all content routes and uses the stable production origin', () => {
   const bundle = loadContentBundle()
   const source = read('app/sitemap.ts')
   assert.equal(bundle.pages.length, 41)
   assert.match(source, /\.\.\.bundle\.pages\.map/)
-  assert.match(source, /process\.env\.VERCEL_URL/)
-  assert.match(source, /http:\/\/localhost:3020/)
+  assert.equal(
+    resolveSiteOrigin({
+      VERCEL_PROJECT_PRODUCTION_URL: 'asyra-framework.vercel.app',
+      VERCEL_URL: 'asyra-framework-git-preview.vercel.app'
+    }),
+    'https://asyra-framework.vercel.app'
+  )
+  assert.match(source, /resolveSiteOrigin\(\)/)
+  assert.doesNotMatch(source, /process\.env\.VERCEL_URL/)
   assert.doesNotMatch(source, new RegExp(`https://${bundle.repositoryName}\\.`))
 })
 

--- a/apps/asyra-framework-site/__tests__/foundations.test.mjs
+++ b/apps/asyra-framework-site/__tests__/foundations.test.mjs
@@ -62,10 +62,10 @@ test('sitemap derives all content routes and uses the stable production origin',
   assert.match(source, /\.\.\.bundle\.pages\.map/)
   assert.equal(
     resolveSiteOrigin({
-      VERCEL_PROJECT_PRODUCTION_URL: 'asyra-framework.vercel.app',
-      VERCEL_URL: 'asyra-framework-git-preview.vercel.app'
+      VERCEL_PROJECT_PRODUCTION_URL: 'framework-site.example.test',
+      VERCEL_URL: 'preview-site.example.test'
     }),
-    'https://asyra-framework.vercel.app'
+    'https://framework-site.example.test'
   )
   assert.match(source, /resolveSiteOrigin\(\)/)
   assert.doesNotMatch(source, /process\.env\.VERCEL_URL/)

--- a/apps/asyra-framework-site/__tests__/launch.test.mjs
+++ b/apps/asyra-framework-site/__tests__/launch.test.mjs
@@ -98,7 +98,10 @@ test('every indexable route owns its exact canonical path', () => {
 test('Framework site Vercel configuration builds only the site workspace from the monorepo', () => {
   const config = JSON.parse(read('vercel.json'))
   assert.equal(config.framework, 'nextjs')
-  assert.equal(config.installCommand, 'cd ../.. && yarn install --immutable')
+  assert.equal(
+    config.installCommand,
+    'cd ../.. && corepack enable && corepack prepare yarn@4.3.1 --activate && yarn install --immutable'
+  )
   assert.equal(config.buildCommand, 'yarn react:build')
   assert.equal(config.outputDirectory, undefined)
   assert.equal(config.git?.deploymentEnabled?.['*'], false)

--- a/apps/asyra-framework-site/__tests__/launch.test.mjs
+++ b/apps/asyra-framework-site/__tests__/launch.test.mjs
@@ -102,7 +102,7 @@ test('Framework site Vercel configuration builds only the site workspace from th
     config.installCommand,
     'cd ../.. && corepack yarn install --immutable'
   )
-  assert.equal(config.buildCommand, 'corepack yarn react:build')
+  assert.equal(config.buildCommand, 'cd ../.. && corepack yarn react:build')
   assert.equal(config.outputDirectory, undefined)
   assert.equal(config.git?.deploymentEnabled?.['*'], false)
 })

--- a/apps/asyra-framework-site/__tests__/launch.test.mjs
+++ b/apps/asyra-framework-site/__tests__/launch.test.mjs
@@ -12,17 +12,17 @@ test('stable site origin is explicit, production-safe, and never guessed from a 
   assert.equal(resolveSiteOrigin({}), 'http://127.0.0.1:3020')
   assert.equal(
     resolveSiteOrigin({
-      VERCEL_PROJECT_PRODUCTION_URL: 'asyra-framework.vercel.app',
-      VERCEL_URL: 'asyra-framework-git-branch.vercel.app'
+      VERCEL_PROJECT_PRODUCTION_URL: 'framework-site.example.test',
+      VERCEL_URL: 'preview-site.example.test'
     }),
-    'https://asyra-framework.vercel.app'
+    'https://framework-site.example.test'
   )
   assert.equal(
     resolveSiteOrigin({
-      NEXT_PUBLIC_SITE_URL: 'https://framework.asyra.dev/',
-      VERCEL_PROJECT_PRODUCTION_URL: 'asyra-framework.vercel.app'
+      NEXT_PUBLIC_SITE_URL: 'https://docs.example.test/',
+      VERCEL_PROJECT_PRODUCTION_URL: 'framework-site.example.test'
     }),
-    'https://framework.asyra.dev'
+    'https://docs.example.test'
   )
   assert.throws(
     () => resolveSiteOrigin({ NEXT_PUBLIC_SITE_URL: 'javascript:alert(1)' }),
@@ -31,7 +31,7 @@ test('stable site origin is explicit, production-safe, and never guessed from a 
   assert.throws(
     () =>
       resolveSiteOrigin({
-        NEXT_PUBLIC_SITE_URL: 'https://framework.asyra.dev/docs'
+        NEXT_PUBLIC_SITE_URL: 'https://docs.example.test/guide'
       }),
     /valid HTTPS origin/i
   )

--- a/apps/asyra-framework-site/__tests__/launch.test.mjs
+++ b/apps/asyra-framework-site/__tests__/launch.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { isIndexingAuthorized, resolveSiteOrigin } from '../lib/site-origin.ts'
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const read = (filePath) => fs.readFileSync(path.join(appRoot, filePath), 'utf8')
+
+test('stable site origin is explicit, production-safe, and never guessed from a branch URL first', () => {
+  assert.equal(resolveSiteOrigin({}), 'http://127.0.0.1:3020')
+  assert.equal(
+    resolveSiteOrigin({
+      VERCEL_PROJECT_PRODUCTION_URL: 'asyra-framework.vercel.app',
+      VERCEL_URL: 'asyra-framework-git-branch.vercel.app'
+    }),
+    'https://asyra-framework.vercel.app'
+  )
+  assert.equal(
+    resolveSiteOrigin({
+      NEXT_PUBLIC_SITE_URL: 'https://framework.asyra.dev/',
+      VERCEL_PROJECT_PRODUCTION_URL: 'asyra-framework.vercel.app'
+    }),
+    'https://framework.asyra.dev'
+  )
+  assert.throws(
+    () => resolveSiteOrigin({ NEXT_PUBLIC_SITE_URL: 'javascript:alert(1)' }),
+    /valid HTTPS origin/i
+  )
+  assert.throws(
+    () =>
+      resolveSiteOrigin({
+        NEXT_PUBLIC_SITE_URL: 'https://framework.asyra.dev/docs'
+      }),
+    /valid HTTPS origin/i
+  )
+})
+
+test('indexing opens only for an explicitly authorized production deployment', () => {
+  assert.equal(isIndexingAuthorized({}), false)
+  assert.equal(
+    isIndexingAuthorized({
+      VERCEL_ENV: 'preview',
+      NEXT_PUBLIC_SITE_INDEXING: 'true'
+    }),
+    false
+  )
+  assert.equal(
+    isIndexingAuthorized({
+      VERCEL_ENV: 'production',
+      NEXT_PUBLIC_SITE_INDEXING: 'false'
+    }),
+    false
+  )
+  assert.equal(
+    isIndexingAuthorized({
+      VERCEL_ENV: 'production',
+      NEXT_PUBLIC_SITE_INDEXING: 'true'
+    }),
+    true
+  )
+})
+
+test('metadata, robots, and sitemap share the stable origin and indexing owner', () => {
+  const layout = read('app/layout.tsx')
+  const robots = read('app/robots.ts')
+  const sitemap = read('app/sitemap.ts')
+  assert.match(layout, /metadataBase: new URL\(resolveSiteOrigin\(\)\)/)
+  assert.match(layout, /alternates:[\s\S]*canonical: '\/'/)
+  assert.match(layout, /robots: isIndexingAuthorized\(\)/)
+  assert.match(robots, /isIndexingAuthorized\(\)/)
+  assert.match(robots, /sitemap: new URL\('\/sitemap\.xml', origin\)/)
+  assert.match(sitemap, /const origin = resolveSiteOrigin\(\)/)
+  assert.doesNotMatch(sitemap, /VERCEL_URL/)
+})
+
+test('every indexable route owns its exact canonical path', () => {
+  ;[
+    ['app/asyra-design/page.tsx', '/asyra-design'],
+    ['app/atlas/page.tsx', '/atlas'],
+    ['app/examples/page.tsx', '/examples'],
+    ['app/releases/page.tsx', '/releases'],
+    ['app/roadmap/page.tsx', '/roadmap']
+  ].forEach(([filePath, route]) => {
+    assert.match(
+      read(filePath),
+      new RegExp(`alternates: \\{ canonical: '${route}' \\}`),
+      filePath
+    )
+  })
+  assert.match(
+    read('app/docs/[[...slug]]/page.tsx'),
+    /alternates: \{ canonical: page\.route \}/
+  )
+})
+
+test('Framework site Vercel configuration builds only the site workspace from the monorepo', () => {
+  const config = JSON.parse(read('vercel.json'))
+  assert.equal(config.framework, 'nextjs')
+  assert.equal(config.installCommand, 'cd ../.. && yarn install --immutable')
+  assert.equal(config.buildCommand, 'yarn react:build')
+  assert.equal(config.outputDirectory, undefined)
+  assert.equal(config.git?.deploymentEnabled?.['*'], false)
+})
+
+test('all document responses receive the reviewed launch security headers', () => {
+  const config = read('next.config.ts')
+  ;[
+    'Content-Security-Policy',
+    'Permissions-Policy',
+    'Referrer-Policy',
+    'Strict-Transport-Security',
+    'X-Content-Type-Options',
+    'X-Frame-Options'
+  ].forEach((header) => assert.match(config, new RegExp(header)))
+  assert.match(config, /source: '\/\(\.\*\)'/)
+})
+
+test('Asyra Design case study uses the same verified public fact as Landing', () => {
+  const page = read('app/asyra-design/page.tsx')
+  assert.match(page, /verifiedLandingFacts\.designApp\.href/)
+  assert.match(page, /Open \{verifiedLandingFacts\.designApp\.title\}/)
+  assert.match(page, /Verified \{verifiedLandingFacts\.designApp\.verifiedAt\}/)
+  assert.doesNotMatch(page, /No public Asyra Design deployment URL/i)
+})
+
+test('production smoke and browser gates are URL-driven and tracked before Preview acceptance', () => {
+  const smoke = read('scripts/production-smoke.mjs')
+  const browser = read('__tests__/e2e/launch-production.spec.ts')
+  assert.match(smoke, /process\.env\.SITE_URL/)
+  assert.match(smoke, /NEXT_PUBLIC_SITE_INDEXING=true production deployment/i)
+  assert.match(smoke, /content-security-policy/i)
+  assert.match(smoke, /verifiedLandingFacts\.designApp\.href/)
+  assert.match(browser, /process\.env\.SITE_URL/)
+  assert.match(browser, /Search documentation/)
+  assert.match(browser, /data-atlas-status/)
+  assert.match(browser, /scrollWidth/)
+})

--- a/apps/asyra-framework-site/__tests__/launch.test.mjs
+++ b/apps/asyra-framework-site/__tests__/launch.test.mjs
@@ -102,8 +102,11 @@ test('Framework site Vercel configuration builds only the site workspace from th
     config.installCommand,
     'cd ../.. && corepack yarn install --immutable'
   )
-  assert.equal(config.buildCommand, 'cd ../.. && corepack yarn react:build')
-  assert.equal(config.outputDirectory, undefined)
+  assert.equal(
+    config.buildCommand,
+    'cd ../.. && corepack yarn turbo run build:asyra-framework-site --filter @asyra/asyra-framework-site'
+  )
+  assert.equal(config.outputDirectory, 'dist')
   assert.equal(config.git?.deploymentEnabled?.['*'], false)
 })
 

--- a/apps/asyra-framework-site/__tests__/launch.test.mjs
+++ b/apps/asyra-framework-site/__tests__/launch.test.mjs
@@ -100,9 +100,9 @@ test('Framework site Vercel configuration builds only the site workspace from th
   assert.equal(config.framework, 'nextjs')
   assert.equal(
     config.installCommand,
-    'cd ../.. && corepack enable && corepack prepare yarn@4.3.1 --activate && yarn install --immutable'
+    'cd ../.. && corepack yarn install --immutable'
   )
-  assert.equal(config.buildCommand, 'yarn react:build')
+  assert.equal(config.buildCommand, 'corepack yarn react:build')
   assert.equal(config.outputDirectory, undefined)
   assert.equal(config.git?.deploymentEnabled?.['*'], false)
 })

--- a/apps/asyra-framework-site/__tests__/routes.test.mjs
+++ b/apps/asyra-framework-site/__tests__/routes.test.mjs
@@ -23,7 +23,12 @@ test('Asyra Design route preserves reference-product and URL boundaries', () => 
   const source = read('app/asyra-design/page.tsx')
   assert.match(source, /Reference product, not Framework owner/i)
   assert.match(source, /pageById\.get\('cases\/asyra-design'\)/)
-  assert.match(source, /No public Asyra Design deployment URL/i)
+  assert.match(source, /verifiedLandingFacts\.designApp\.href/)
+  assert.match(
+    source,
+    /Verified \{verifiedLandingFacts\.designApp\.verifiedAt\}/
+  )
+  assert.doesNotMatch(source, /No public Asyra Design deployment URL/i)
   assert.doesNotMatch(
     source,
     new RegExp(`https?://(?:www\\.)?${bundle.repositoryName}`, 'i')

--- a/apps/asyra-framework-site/app/asyra-design/page.tsx
+++ b/apps/asyra-framework-site/app/asyra-design/page.tsx
@@ -5,11 +5,13 @@ import { EvidenceHero } from '@/components/evidence-hero'
 import { MarkdownContent } from '@/components/markdown-content'
 import { StatusLegend } from '@/components/status-legend'
 import { loadContentBundle } from '@/lib/content'
+import { verifiedLandingFacts } from '@/lib/landing-facts'
 
 export const metadata: Metadata = {
   title: 'Asyra Design reference product',
   description:
-    'See how the Asyra Design reference product composes Framework infrastructure with App-owned product knowledge.'
+    'See how the Asyra Design reference product composes Framework infrastructure with App-owned product knowledge.',
+  alternates: { canonical: '/asyra-design' }
 }
 
 export default function ReferenceProductPage() {
@@ -34,13 +36,27 @@ export default function ReferenceProductPage() {
             Generate an immediately usable App, then extend one bounded behavior
             through the public Framework route.
           </p>
-          <Link className="primary-action" href="/docs/start/create-design-app">
-            Start with Asyra Design
-            <ArrowRight aria-hidden="true" size={17} />
-          </Link>
+          <div className="case-study-actions">
+            <Link
+              className="primary-action"
+              href="/docs/start/create-design-app"
+            >
+              Start with Asyra Design
+              <ArrowRight aria-hidden="true" size={17} />
+            </Link>
+            <a
+              className="primary-action case-study-action--secondary"
+              href={verifiedLandingFacts.designApp.href}
+              rel="noreferrer"
+              target="_blank"
+            >
+              Open {verifiedLandingFacts.designApp.title}
+              <ArrowRight aria-hidden="true" size={17} />
+            </a>
+          </div>
           <p className="case-study-note">
-            No public Asyra Design deployment URL is shown until its canonical
-            URL is separately verified.
+            Verified {verifiedLandingFacts.designApp.verifiedAt} · public stable
+            alias
           </p>
         </aside>
         <article className="case-study-article">

--- a/apps/asyra-framework-site/app/atlas/page.tsx
+++ b/apps/asyra-framework-site/app/atlas/page.tsx
@@ -4,7 +4,8 @@ import { RuntimeAtlas } from '@/components/runtime-atlas'
 export const metadata: Metadata = {
   title: 'Runtime Atlas',
   description:
-    'Operate six real Asyra browser cases and inspect intent, ownership, transactions, canonical state, optional composition, projections, and failure evidence.'
+    'Operate six real Asyra browser cases and inspect intent, ownership, transactions, canonical state, optional composition, projections, and failure evidence.',
+  alternates: { canonical: '/atlas' }
 }
 
 export default function RuntimeAtlasPage() {

--- a/apps/asyra-framework-site/app/docs/[[...slug]]/page.tsx
+++ b/apps/asyra-framework-site/app/docs/[[...slug]]/page.tsx
@@ -21,7 +21,8 @@ export async function generateMetadata({
   if (!page) return { title: 'Documentation not found' }
   return {
     title: page.title,
-    description: page.description
+    description: page.description,
+    alternates: { canonical: page.route }
   }
 }
 

--- a/apps/asyra-framework-site/app/examples/page.tsx
+++ b/apps/asyra-framework-site/app/examples/page.tsx
@@ -6,7 +6,8 @@ import { loadContentBundle, sourceHref } from '@/lib/content'
 export const metadata: Metadata = {
   title: 'Executable examples',
   description:
-    'Run maintained Asyra examples that prove current public Framework behavior.'
+    'Run maintained Asyra examples that prove current public Framework behavior.',
+  alternates: { canonical: '/examples' }
 }
 
 export default function ExamplesPage() {

--- a/apps/asyra-framework-site/app/globals.css
+++ b/apps/asyra-framework-site/app/globals.css
@@ -2088,6 +2088,22 @@ a:focus-visible {
   max-width: 36ch;
 }
 
+.case-study-actions {
+  display: grid;
+  max-width: 420px;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.case-study-actions .primary-action {
+  width: 100%;
+}
+
+.case-study-action--secondary {
+  border-color: var(--rule-strong);
+  color: var(--ink);
+}
+
 .case-study-note {
   margin-top: 48px;
   padding-top: 18px;

--- a/apps/asyra-framework-site/app/layout.tsx
+++ b/apps/asyra-framework-site/app/layout.tsx
@@ -3,9 +3,11 @@ import type { ReactNode } from 'react'
 import { FoundationBrowserSupport } from '@/components/foundation-browser-support'
 import { SiteFooter } from '@/components/site-footer'
 import { SiteHeader } from '@/components/site-header'
+import { isIndexingAuthorized, resolveSiteOrigin } from '@/lib/site-origin'
 import './globals.css'
 
 export const metadata: Metadata = {
+  metadataBase: new URL(resolveSiteOrigin()),
   title: {
     default: 'Asyra Framework',
     template: '%s · Asyra Framework'
@@ -13,9 +15,23 @@ export const metadata: Metadata = {
   description:
     'Build domain-owned information products on deterministic, composable infrastructure.',
   applicationName: 'Asyra Framework',
-  robots: {
-    index: false,
-    follow: false
+  alternates: { canonical: '/' },
+  openGraph: {
+    description:
+      'Build domain-owned information products on deterministic, composable infrastructure.',
+    siteName: 'Asyra Framework',
+    title: 'Asyra Framework',
+    type: 'website',
+    url: '/'
+  },
+  robots: isIndexingAuthorized()
+    ? { follow: true, index: true }
+    : { follow: false, index: false },
+  twitter: {
+    card: 'summary',
+    description:
+      'Build domain-owned information products on deterministic, composable infrastructure.',
+    title: 'Asyra Framework'
   }
 }
 

--- a/apps/asyra-framework-site/app/releases/page.tsx
+++ b/apps/asyra-framework-site/app/releases/page.tsx
@@ -9,7 +9,8 @@ import { loadContentBundle } from '@/lib/content'
 export const metadata: Metadata = {
   title: 'Release candidate inventory',
   description:
-    'Inspect manifest-derived Asyra package versions, public entrypoints, support, migration, deprecation, and security boundaries.'
+    'Inspect manifest-derived Asyra package versions, public entrypoints, support, migration, deprecation, and security boundaries.',
+  alternates: { canonical: '/releases' }
 }
 
 export default function ReleasesPage() {

--- a/apps/asyra-framework-site/app/roadmap/page.tsx
+++ b/apps/asyra-framework-site/app/roadmap/page.tsx
@@ -7,7 +7,8 @@ import { loadContentBundle } from '@/lib/content'
 export const metadata: Metadata = {
   title: 'Current and future runtime boundaries',
   description:
-    'Separate current Asyra Framework support, App-owned product possibilities, and verified future runtime direction.'
+    'Separate current Asyra Framework support, App-owned product possibilities, and verified future runtime direction.',
+  alternates: { canonical: '/roadmap' }
 }
 
 export default function RoadmapPage() {

--- a/apps/asyra-framework-site/app/robots.ts
+++ b/apps/asyra-framework-site/app/robots.ts
@@ -1,13 +1,14 @@
 import type { MetadataRoute } from 'next'
+import { isIndexingAuthorized, resolveSiteOrigin } from '@/lib/site-origin'
 
 export default function robots(): MetadataRoute.Robots {
-  const indexingAuthorized =
-    process.env.VERCEL_ENV === 'production' &&
-    process.env.NEXT_PUBLIC_SITE_INDEXING === 'true'
+  const indexingAuthorized = isIndexingAuthorized()
+  const origin = resolveSiteOrigin()
 
   return {
     rules: indexingAuthorized
       ? { userAgent: '*', allow: '/' }
-      : { userAgent: '*', disallow: '/' }
+      : { userAgent: '*', disallow: '/' },
+    sitemap: new URL('/sitemap.xml', origin).toString()
   }
 }

--- a/apps/asyra-framework-site/app/sitemap.ts
+++ b/apps/asyra-framework-site/app/sitemap.ts
@@ -1,13 +1,10 @@
 import type { MetadataRoute } from 'next'
 import { loadContentBundle } from '@/lib/content'
-
-const siteOrigin = () => {
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`
-  return 'http://localhost:3020'
-}
+import { resolveSiteOrigin } from '@/lib/site-origin'
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const bundle = loadContentBundle()
+  const origin = resolveSiteOrigin()
   const routes = [
     '/',
     '/examples',
@@ -18,7 +15,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...bundle.pages.map(({ route }) => route)
   ]
   return routes.map((route) => ({
-    url: new URL(route, siteOrigin()).toString(),
+    url: new URL(route, origin).toString(),
     changeFrequency: route.startsWith('/docs') ? 'weekly' : 'monthly',
     priority: route === '/' ? 1 : 0.7
   }))

--- a/apps/asyra-framework-site/lib/site-origin.ts
+++ b/apps/asyra-framework-site/lib/site-origin.ts
@@ -1,0 +1,51 @@
+type SiteEnvironment = Readonly<Record<string, string | undefined>>
+
+const normalizeOrigin = (value: string, allowLocalHttp = false) => {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('Site URL must be a valid HTTPS origin')
+  }
+
+  const localHttp =
+    allowLocalHttp &&
+    url.protocol === 'http:' &&
+    (url.hostname === '127.0.0.1' || url.hostname === 'localhost')
+  if (
+    (!localHttp && url.protocol !== 'https:') ||
+    url.username ||
+    url.password ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error('Site URL must be a valid HTTPS origin')
+  }
+
+  return url.origin
+}
+
+const vercelOrigin = (hostname: string) =>
+  normalizeOrigin(`https://${hostname}`)
+
+export const resolveSiteOrigin = (
+  environment: SiteEnvironment = process.env
+) => {
+  if (environment.NEXT_PUBLIC_SITE_URL) {
+    return normalizeOrigin(environment.NEXT_PUBLIC_SITE_URL)
+  }
+  if (environment.VERCEL_PROJECT_PRODUCTION_URL) {
+    return vercelOrigin(environment.VERCEL_PROJECT_PRODUCTION_URL)
+  }
+  if (environment.VERCEL_URL) {
+    return vercelOrigin(environment.VERCEL_URL)
+  }
+  return normalizeOrigin('http://127.0.0.1:3020', true)
+}
+
+export const isIndexingAuthorized = (
+  environment: SiteEnvironment = process.env
+) =>
+  environment.VERCEL_ENV === 'production' &&
+  environment.NEXT_PUBLIC_SITE_INDEXING === 'true'

--- a/apps/asyra-framework-site/next.config.ts
+++ b/apps/asyra-framework-site/next.config.ts
@@ -4,11 +4,50 @@ import type { NextConfig } from 'next'
 
 const appRoot = path.dirname(fileURLToPath(import.meta.url))
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "connect-src 'self'",
+  "font-src 'self' data:",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data:",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "worker-src 'self' blob:"
+].join('; ')
+
 const nextConfig: NextConfig = {
   distDir: 'dist',
   poweredByHeader: false,
   reactStrictMode: true,
   typedRoutes: true,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'Content-Security-Policy', value: contentSecurityPolicy },
+          {
+            key: 'Permissions-Policy',
+            value:
+              'camera=(), geolocation=(), microphone=(), payment=(), usb=()'
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin'
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains'
+          },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' }
+        ]
+      }
+    ]
+  },
   turbopack: {
     root: path.resolve(appRoot, '../..')
   }

--- a/apps/asyra-framework-site/package.json
+++ b/apps/asyra-framework-site/package.json
@@ -13,9 +13,10 @@
     "react:build": "yarn build:asyra-framework-site",
     "typecheck": "tsc --noEmit",
     "test": "yarn test:local",
-    "test:contracts": "node --test ../../docs/ai/framework/plans/__tests__/*website-platform-flow-inspector.contract.test.cjs ../../docs/ai/framework/plans/__tests__/*website-landing-flow-inspector.contract.test.cjs ../../docs/ai/framework/plans/__tests__/*runtime-atlas-flow-inspector.contract.test.cjs",
+    "test:contracts": "node --test ../../docs/ai/framework/plans/__tests__/*website-platform-flow-inspector.contract.test.cjs ../../docs/ai/framework/plans/__tests__/*website-landing-flow-inspector.contract.test.cjs ../../docs/ai/framework/plans/__tests__/*runtime-atlas-flow-inspector.contract.test.cjs ../../docs/ai/framework/plans/__tests__/*website-launch-and-operations-flow-inspector.contract.test.cjs",
     "test:routes": "node scripts/route-smoke.mjs",
     "test:e2e": "playwright test --config playwright.config.ts",
+    "test:production": "node scripts/production-smoke.mjs && playwright test --config playwright.config.ts launch-production.spec.ts",
     "test:local": "yarn test:contracts && node --test __tests__/*.test.mjs",
     "test:ci": "yarn test:local",
     "lint": "yarn --cwd ../.. eslint apps/asyra-framework-site"

--- a/apps/asyra-framework-site/scripts/production-smoke.mjs
+++ b/apps/asyra-framework-site/scripts/production-smoke.mjs
@@ -1,0 +1,97 @@
+/* global URL, fetch */
+
+import assert from 'node:assert/strict'
+import process from 'node:process'
+import { loadContentBundle } from '../lib/content.mjs'
+import { verifiedLandingFacts } from '../lib/landing-facts.mjs'
+
+const suppliedUrl = process.env.SITE_URL
+assert.ok(
+  suppliedUrl,
+  'SITE_URL is required for the NEXT_PUBLIC_SITE_INDEXING=true production deployment'
+)
+const baseUrl = new URL(suppliedUrl)
+assert.equal(baseUrl.protocol, 'https:', 'Production SITE_URL must use HTTPS')
+assert.equal(baseUrl.pathname, '/', 'Production SITE_URL must be an origin')
+const origin = baseUrl.origin
+
+const bundle = loadContentBundle()
+const publicRoutes = [
+  '/',
+  '/atlas',
+  '/examples',
+  '/asyra-design',
+  '/releases',
+  '/roadmap',
+  ...bundle.pages.map(({ route }) => route)
+]
+
+const responses = new Map()
+for (const route of publicRoutes) {
+  const response = await fetch(new URL(route, origin), { redirect: 'follow' })
+  assert.equal(response.status, 200, route)
+  assert.equal(new URL(response.url).origin, origin, `${route} changed origin`)
+  const body = await response.text()
+  assert.ok(body.length > 80, `${route} returned an empty public surface`)
+  const canonical = new URL(route, origin).toString()
+  const escapedCanonical = canonical.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  assert.match(
+    body,
+    new RegExp(`rel="canonical"[^>]+href="${escapedCanonical}"`),
+    `${route} canonical`
+  )
+  responses.set(route, { body, headers: response.headers })
+}
+
+const home = responses.get('/')
+assert.ok(home)
+for (const header of [
+  'content-security-policy',
+  'permissions-policy',
+  'referrer-policy',
+  'strict-transport-security',
+  'x-content-type-options',
+  'x-frame-options'
+]) {
+  assert.ok(home.headers.get(header), `Missing ${header}`)
+}
+assert.ok(home.headers.get('cache-control'), 'Missing cache-control')
+assert.match(
+  home.body,
+  new RegExp(verifiedLandingFacts.designApp.href.replaceAll('.', '\\.'))
+)
+
+const robotsResponse = await fetch(new URL('/robots.txt', origin))
+assert.equal(robotsResponse.status, 200)
+const robots = await robotsResponse.text()
+assert.match(robots, /^Allow: \/$/m)
+assert.doesNotMatch(robots, /^Disallow: \/$/m)
+assert.match(
+  robots,
+  new RegExp(`^Sitemap: ${origin.replaceAll('.', '\\.')}\\/sitemap\\.xml$`, 'm')
+)
+
+const sitemapResponse = await fetch(new URL('/sitemap.xml', origin))
+assert.equal(sitemapResponse.status, 200)
+const sitemap = await sitemapResponse.text()
+for (const route of publicRoutes) {
+  assert.match(
+    sitemap,
+    new RegExp(
+      new URL(route, origin).toString().replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    ),
+    route
+  )
+}
+
+const missingResponse = await fetch(new URL('/launch-missing-route', origin))
+assert.equal(missingResponse.status, 404)
+assert.match(await missingResponse.text(), /This public route does not exist/)
+
+const designResponse = await fetch(verifiedLandingFacts.designApp.href)
+assert.equal(designResponse.status, 200, 'Asyra Design public reference')
+assert.match(await designResponse.text(), /<title[^>]*>Asyra Design<\/title>/i)
+
+process.stdout.write(
+  `Production smoke passed: ${publicRoutes.length + 2} anonymous public routes at ${origin}\n`
+)

--- a/apps/asyra-framework-site/scripts/production-smoke.mjs
+++ b/apps/asyra-framework-site/scripts/production-smoke.mjs
@@ -33,13 +33,18 @@ for (const route of publicRoutes) {
   assert.equal(new URL(response.url).origin, origin, `${route} changed origin`)
   const body = await response.text()
   assert.ok(body.length > 80, `${route} returned an empty public surface`)
-  const canonical = new URL(route, origin).toString()
-  const escapedCanonical = canonical.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  assert.match(
-    body,
-    new RegExp(`rel="canonical"[^>]+href="${escapedCanonical}"`),
-    `${route} canonical`
+  const canonicalMatch = body.match(/rel="canonical"[^>]+href="([^"]+)"/)
+  assert.ok(canonicalMatch, `${route} canonical`)
+  const canonical = new URL(canonicalMatch[1])
+  const expectedCanonical = new URL(route, origin)
+  assert.equal(canonical.origin, expectedCanonical.origin, `${route} origin`)
+  assert.equal(
+    canonical.pathname,
+    expectedCanonical.pathname,
+    `${route} canonical path`
   )
+  assert.equal(canonical.search, '', `${route} canonical query`)
+  assert.equal(canonical.hash, '', `${route} canonical hash`)
   responses.set(route, { body, headers: response.headers })
 }
 

--- a/apps/asyra-framework-site/vercel.json
+++ b/apps/asyra-framework-site/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "cd ../.. && yarn install --immutable",
+  "buildCommand": "yarn react:build",
+  "git": {
+    "deploymentEnabled": {
+      "*": false
+    }
+  }
+}

--- a/apps/asyra-framework-site/vercel.json
+++ b/apps/asyra-framework-site/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd ../.. && corepack yarn install --immutable",
-  "buildCommand": "cd ../.. && corepack yarn react:build",
+  "buildCommand": "cd ../.. && corepack yarn turbo run build:asyra-framework-site --filter @asyra/asyra-framework-site",
+  "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {
       "*": false

--- a/apps/asyra-framework-site/vercel.json
+++ b/apps/asyra-framework-site/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd ../.. && corepack yarn install --immutable",
-  "buildCommand": "corepack yarn react:build",
+  "buildCommand": "cd ../.. && corepack yarn react:build",
   "git": {
     "deploymentEnabled": {
       "*": false

--- a/apps/asyra-framework-site/vercel.json
+++ b/apps/asyra-framework-site/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "installCommand": "cd ../.. && yarn install --immutable",
+  "installCommand": "cd ../.. && corepack enable && corepack prepare yarn@4.3.1 --activate && yarn install --immutable",
   "buildCommand": "yarn react:build",
   "git": {
     "deploymentEnabled": {

--- a/apps/asyra-framework-site/vercel.json
+++ b/apps/asyra-framework-site/vercel.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "installCommand": "cd ../.. && corepack enable && corepack prepare yarn@4.3.1 --activate && yarn install --immutable",
-  "buildCommand": "yarn react:build",
+  "installCommand": "cd ../.. && corepack yarn install --immutable",
+  "buildCommand": "corepack yarn react:build",
   "git": {
     "deploymentEnabled": {
       "*": false

--- a/docs/ai/apps/asyra-design/modules/e2e.md
+++ b/docs/ai/apps/asyra-design/modules/e2e.md
@@ -103,17 +103,14 @@ test:e2e:balanced-ai-correctness` runs that heavy case explicitly with one
   then excludes that file while running the remaining functional suite with
   one worker; the formal timing thresholds are not relaxed to absorb runner
   contention, and the ordinary suite must return a deterministic teardown
+- the isolated timing gate sets `E2E_RENDER_PERFORMANCE_BROWSER=chromium` so
+  the ordinary config uses Playwright's installed Chromium binary; the
+  remaining functional suite continues to use the configured Google Chrome
+  channel
 - after creating the dense-vector fixture, the timing test waits for the active
   Collaboration session and publication outbox to become idle before installing
   phase timers; setup publication work is excluded without changing the normal
   App composition or timing thresholds
-- after the setup becomes idle and before installing phase timers, Playwright
-  requests one browser garbage collection so setup-owned allocations cannot be
-  charged to a later Render owner sample; the 12 measured product frames and
-  every count, total, p95, cold/steady max, and combined budget stay unchanged
-- before timers are installed, the test completes one unmeasured normal Render
-  frame and then waits two animation frames, isolating the first canvas/GPU
-  flush after test-only collection from the measured product frames
 - pull-request CI resolves the balanced AI heavy gate from the exact
   base-to-head changed paths in
   `scripts/balanced-ai-correctness-scope.mjs`; unrelated changes and scheduled
@@ -124,7 +121,8 @@ test:e2e:balanced-ai-correctness` runs that heavy case explicitly with one
   retains a separate max assertion, preventing p95 from degenerating into the
   same single-sample oracle while preserving every formal threshold
 - superseded runs for the same pull request or ref are cancelled, and both E2E
-  jobs install only the configured Chromium browser
+  jobs install only Chromium; the timing gate consumes that exact managed
+  binary while the functional suites keep their configured Chrome channel
 - the 7,076-element two-actor Agent recording remains the explicit
   `RUN_AI_CRDT_VIDEO=1` resource gate and is not materialized by
   default ordinary or collaboration CI

--- a/docs/ai/apps/asyra-design/modules/e2e.md
+++ b/docs/ai/apps/asyra-design/modules/e2e.md
@@ -111,6 +111,9 @@ test:e2e:balanced-ai-correctness` runs that heavy case explicitly with one
   requests one browser garbage collection so setup-owned allocations cannot be
   charged to a later Render owner sample; the 12 measured product frames and
   every count, total, p95, cold/steady max, and combined budget stay unchanged
+- before timers are installed, the test completes one unmeasured normal Render
+  frame and then waits two animation frames, isolating the first canvas/GPU
+  flush after test-only collection from the measured product frames
 - pull-request CI resolves the balanced AI heavy gate from the exact
   base-to-head changed paths in
   `scripts/balanced-ai-correctness-scope.mjs`; unrelated changes and scheduled

--- a/docs/ai/apps/asyra-design/modules/e2e.md
+++ b/docs/ai/apps/asyra-design/modules/e2e.md
@@ -107,6 +107,10 @@ test:e2e:balanced-ai-correctness` runs that heavy case explicitly with one
   Collaboration session and publication outbox to become idle before installing
   phase timers; setup publication work is excluded without changing the normal
   App composition or timing thresholds
+- after the setup becomes idle and before installing phase timers, Playwright
+  requests one browser garbage collection so setup-owned allocations cannot be
+  charged to a later Render owner sample; the 12 measured product frames and
+  every count, total, p95, cold/steady max, and combined budget stay unchanged
 - pull-request CI resolves the balanced AI heavy gate from the exact
   base-to-head changed paths in
   `scripts/balanced-ai-correctness-scope.mjs`; unrelated changes and scheduled

--- a/docs/ai/framework/plans/__tests__/asyra-website-launch-and-operations-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/__tests__/asyra-website-launch-and-operations-flow-inspector.contract.test.cjs
@@ -1,0 +1,161 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const data = require('../asyra-website-launch-and-operations-flow-inspector.data.cjs')
+
+const repoRoot = path.resolve(__dirname, '../../../../..')
+const step = (id) => {
+  const value = data.steps.find((item) => item.id === id)
+  assert.ok(value, `Missing Launch Inspector step: ${id}`)
+  return value
+}
+
+test('Launch authority paths resolve without treating ignored provider state as authority', () => {
+  Object.values(data.authority).forEach((filePath) => {
+    assert.ok(fs.existsSync(path.join(repoRoot, filePath)), filePath)
+  })
+})
+
+test('Launch owns six exact and unique public release cases', () => {
+  assert.deepEqual(data.caseIds, [
+    'distinct-project-preservation',
+    'integrated-preview-acceptance',
+    'immutable-production-candidate',
+    'production-indexing-metadata',
+    'anonymous-production-surface',
+    'rollback-readiness'
+  ])
+  assert.equal(new Set(data.caseIds).size, data.caseIds.length)
+})
+
+test('contract freezes a dedicated target, immutable source, exclusions, and failure behavior', () => {
+  const source = JSON.stringify(step('freeze-launch-contract'))
+  assert.match(source, /dedicated Vercel project/i)
+  assert.match(source, /never mutates the existing Asyra Design project/i)
+  assert.match(source, /One exact source commit/i)
+  assert.match(
+    source,
+    /Custom DNS, analytics, monitoring vendors, new secrets, and package publication remain excluded/i
+  )
+  assert.match(source, /secret value in repository or logs/i)
+})
+
+test('accepted Preview owns every tracked launch input before its commit is frozen', () => {
+  const preview = step('accept-integrated-preview')
+  const source = JSON.stringify(preview)
+  assert.match(source, /clean, pushed, immutable/i)
+  assert.match(
+    source,
+    /Build, typecheck, lint, tests, routes, accessibility, performance, visual review, Atlas, clean-consumer, and release-readiness gates pass/i
+  )
+  ;[
+    'apps/asyra-framework-site/vercel.json',
+    'apps/asyra-framework-site/next.config.ts',
+    'apps/asyra-framework-site/app/layout.tsx',
+    'apps/asyra-framework-site/app/robots.ts',
+    'apps/asyra-framework-site/app/sitemap.ts',
+    'apps/asyra-framework-site/__tests__/launch.test.mjs',
+    'apps/asyra-framework-site/__tests__/e2e/launch-production.spec.ts',
+    'apps/asyra-framework-site/scripts/production-smoke.mjs'
+  ].forEach((filePath) => {
+    assert.ok(preview.implementationBoundary.includes(filePath), filePath)
+  })
+})
+
+test('dedicated target configuration changes provider state without changing accepted source', () => {
+  const target = step('configure-vercel-target')
+  const source = JSON.stringify(target)
+  assert.match(source, /org and project ids differ/i)
+  assert.match(source, /NEXT_PUBLIC_SITE_INDEXING=true.*only.*production/i)
+  assert.match(source, /No token, secret, or provider credential/i)
+  assert.match(source, /root \.vercel link mutation/i)
+  assert.match(source, /tracked website source or configuration change/i)
+  assert.deepEqual(target.implementationBoundary, [
+    'authenticated Vercel project and environment operations',
+    'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md',
+    '.vercel/project.json read-only; never mutate'
+  ])
+})
+
+test('deployment uses the accepted source, stable alias, and a real rollback path', () => {
+  const source = JSON.stringify(step('deploy-accepted-candidate'))
+  assert.match(
+    source,
+    /deployed source commit equals the accepted Preview commit/i
+  )
+  assert.match(source, /stable production alias/i)
+  assert.match(source, /prior healthy deployment remains resolvable/i)
+  assert.match(source, /first project deployment.*unpromote\/delete-current/i)
+  assert.match(source, /dirty or different source commit/i)
+})
+
+test('production verification is anonymous, indexed, complete, and fail closed', () => {
+  const source = JSON.stringify(step('verify-production'))
+  assert.match(source, /stable alias and immutable deployment use TLS/i)
+  assert.match(source, /Robots permits production indexing/i)
+  assert.match(
+    source,
+    /Every public route, search path, example, release fact, Roadmap, Asyra Design link, and Runtime Atlas case works anonymously/i
+  )
+  assert.match(
+    source,
+    /Security, cache, accessibility, responsive, reduced-motion, performance, and failure behavior gates pass/i
+  )
+  assert.match(
+    source,
+    /Provider authentication.*never substitutes anonymous checks/i
+  )
+  assert.match(source, /failed candidate left promoted/i)
+})
+
+test('operations record remains exact without inventing excluded monitoring', () => {
+  const source = JSON.stringify(step('record-launch-operations'))
+  assert.match(source, /public URL and source commit are exact/i)
+  assert.match(source, /Rollback uses recorded provider deployment identity/i)
+  assert.match(source, /No analytics or monitoring ownership is implied/i)
+  assert.match(source, /credential or secret value/i)
+})
+
+test('Launch routes, artifacts, failures, and cache boundaries resolve', () => {
+  const stepIds = new Set(data.steps.map(({ id }) => id))
+  const artifactOwners = new Map(
+    data.artifacts.map(({ id, ownerStepId }) => [id, ownerStepId])
+  )
+
+  assert.equal(stepIds.size, data.steps.length)
+  assert.equal(artifactOwners.size, data.artifacts.length)
+  data.steps.forEach((item) => {
+    assert.deepEqual(item.cacheDimensions, [], item.id)
+    assert.equal(item.failureOwnerStepId, item.id)
+    assert.ok(item.implementationBoundary.length > 0, item.id)
+    assert.ok(item.specRefs.length > 0, item.id)
+  })
+  data.routes.forEach((route) => {
+    assert.ok(stepIds.has(route.from), route.id)
+    assert.ok(stepIds.has(route.to), route.id)
+    route.producedArtifacts.forEach((artifactId) => {
+      assert.equal(artifactOwners.get(artifactId), route.from, route.id)
+    })
+  })
+})
+
+test('Launch invariants preserve project separation, indexing, secrets, rollback, and exclusions', () => {
+  const source = JSON.stringify(data.invariants)
+  assert.match(
+    source,
+    /Framework site project and Asyra Design project remain distinct/i
+  )
+  assert.match(source, /one exact source commit/i)
+  assert.match(source, /Only production permits indexing/i)
+  assert.match(
+    source,
+    /No credential, secret, private endpoint, or internal-only document/i
+  )
+  assert.match(source, /restores or unpromotes/i)
+  assert.match(
+    source,
+    /Custom DNS, analytics, monitoring vendors, new secrets, and package publication remain excluded/i
+  )
+})

--- a/docs/ai/framework/plans/asyra-website-launch-and-operations-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/asyra-website-launch-and-operations-flow-inspector.data.cjs
@@ -1,0 +1,366 @@
+const caseIds = Object.freeze([
+  'distinct-project-preservation',
+  'integrated-preview-acceptance',
+  'immutable-production-candidate',
+  'production-indexing-metadata',
+  'anonymous-production-surface',
+  'rollback-readiness'
+])
+
+const step = (definition) =>
+  Object.freeze({ cacheDimensions: [], ...definition })
+
+module.exports = Object.freeze({
+  authority: Object.freeze({
+    specPath:
+      'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md',
+    inspectorPath:
+      'docs/ai/framework/plans/asyra-website-launch-and-operations-flow-inspector.data.cjs',
+    programPath: 'docs/ai/framework/plans/asyra-framework-website-plan.md',
+    siteWorkspacePath: 'apps/asyra-framework-site',
+    contentIndexPath: 'docs/public/generated/content-index.json',
+    exampleInventoryPath: 'docs/examples/inventory.json',
+    rootHostingConfigPath: 'vercel.json',
+    atlasPlanPath: 'docs/ai/framework/plans/asyra-runtime-atlas-plan.md'
+  }),
+  caseIds,
+  steps: Object.freeze([
+    step({
+      id: 'freeze-launch-contract',
+      order: 1,
+      ownerPackage: 'Launch product and authorization contract',
+      purpose:
+        'Freeze target separation, accepted-candidate, indexing, anonymous verification, rollback, external-write, and stop contracts before provider mutation.',
+      inputs: [
+        'accepted website program contract',
+        'eight accepted upstream child artifacts',
+        'explicit user production authority',
+        'read-only existing Asyra Design hosting identity'
+      ],
+      outputs: ['artifact:launch-contract'],
+      conditions: [
+        'The Framework site uses a dedicated Vercel project and never mutates the existing Asyra Design project id or stable alias.',
+        'One exact source commit and reviewed configuration own Preview and production acceptance.',
+        'Production indexing is project-scoped and enabled only for the accepted production environment.',
+        'Custom DNS, analytics, monitoring vendors, new secrets, and package publication remain excluded.'
+      ],
+      bypasses: [
+        'A provider-owned vercel.app production alias is sufficient; custom DNS is not required for first launch.'
+      ],
+      allowedContributors: [
+        'Launch plan and Inspector',
+        'accepted child plans and generated inventories',
+        'explicit user authorization',
+        'read-only provider and repository facts'
+      ],
+      forbiddenContributors: [
+        'unverified public URL',
+        'secret value in repository or logs',
+        'Asyra Design project mutation',
+        'upstream product semantic rewrite'
+      ],
+      implementationBoundary: [
+        'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md',
+        'docs/ai/framework/plans/asyra-website-launch-and-operations-flow-inspector.data.cjs',
+        'docs/ai/framework/plans/__tests__/asyra-website-launch-and-operations-flow-inspector.contract.test.cjs'
+      ],
+      specRefs: [
+        '#authorization-boundary',
+        '#bounded-task-contract',
+        '#executable-launch-cases',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'freeze-launch-contract'
+    }),
+    step({
+      id: 'accept-integrated-preview',
+      order: 2,
+      ownerPackage: 'Integrated Release Candidate Preview',
+      purpose:
+        'Accept one exact integration commit only after every upstream, content, runtime, visual, clean-consumer, release, and site gate passes.',
+      inputs: ['artifact:launch-contract', 'eight accepted upstream artifacts'],
+      outputs: ['artifact:accepted-preview'],
+      conditions: [
+        'The accepted commit is clean, pushed, immutable, and recorded before deployment.',
+        'Generated release, content, example, support, and external-link facts match their current owners.',
+        'Build, typecheck, lint, tests, routes, accessibility, performance, visual review, Atlas, clean-consumer, and release-readiness gates pass.'
+      ],
+      bypasses: [
+        'Registry publication remains outside this website child; provisional facts must remain labeled by their accepted generated owner.'
+      ],
+      allowedContributors: [
+        'accepted integration commit',
+        'deterministic project-owned gates',
+        'CI and synchronized visual evidence'
+      ],
+      forbiddenContributors: [
+        'dirty working tree',
+        'manual inspection as sole evidence',
+        'missing-case allowlist',
+        'deployment success used as Preview correctness'
+      ],
+      implementationBoundary: [
+        'apps/asyra-framework-site/**',
+        'apps/asyra-framework-site/vercel.json',
+        'apps/asyra-framework-site/next.config.ts',
+        'apps/asyra-framework-site/app/layout.tsx',
+        'apps/asyra-framework-site/app/robots.ts',
+        'apps/asyra-framework-site/app/sitemap.ts',
+        'apps/asyra-framework-site/lib/site-origin.ts',
+        'apps/asyra-framework-site/__tests__/launch.test.mjs',
+        'apps/asyra-framework-site/__tests__/e2e/launch-production.spec.ts',
+        'apps/asyra-framework-site/scripts/production-smoke.mjs',
+        'docs/public/generated/**',
+        'docs/examples/**',
+        'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md'
+      ],
+      specRefs: [
+        '#preview-acceptance',
+        '#quality-gates',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'accept-integrated-preview'
+    }),
+    step({
+      id: 'configure-vercel-target',
+      order: 3,
+      ownerPackage: 'Dedicated Framework site hosting target',
+      purpose:
+        'Resolve or create one dedicated Vercel project, freeze its exact ids and production alias, and apply the accepted candidate build and production-only indexing environment contract without changing tracked source.',
+      inputs: ['artifact:launch-contract', 'artifact:accepted-preview'],
+      outputs: ['artifact:configured-vercel-target'],
+      conditions: [
+        'The selected org and project ids differ from the read-only Asyra Design link.',
+        'The project root and build settings resolve the Framework site workspace and repository workspace dependencies.',
+        'NEXT_PUBLIC_SITE_INDEXING=true exists only as a project-scoped production setting.',
+        'No token, secret, or provider credential is written to tracked files or printed.'
+      ],
+      bypasses: [
+        'Local project metadata may remain ignored and ephemeral; the accepted tracked configuration and recorded non-secret ids are the review authority.'
+      ],
+      allowedContributors: [
+        'authenticated Vercel project API or CLI facts',
+        'accepted app-owned Next.js and Vercel configuration',
+        'accepted public origin'
+      ],
+      forbiddenContributors: [
+        'root .vercel link mutation',
+        'existing Asyra Design project id or alias',
+        'unapproved custom domain or analytics',
+        'unreviewed provider default presented as contract',
+        'tracked website source or configuration change after Preview acceptance'
+      ],
+      implementationBoundary: [
+        'authenticated Vercel project and environment operations',
+        'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md',
+        '.vercel/project.json read-only; never mutate'
+      ],
+      specRefs: [
+        '#authorization-boundary',
+        '#deployment-and-verification-contract',
+        '#executable-launch-cases'
+      ],
+      failureOwnerStepId: 'configure-vercel-target'
+    }),
+    step({
+      id: 'deploy-accepted-candidate',
+      order: 4,
+      ownerPackage: 'Immutable production deployment',
+      purpose:
+        'Deploy the exact accepted commit and configured target, retain immutable deployment identity and the prior healthy rollback target, and promote only the reviewed candidate.',
+      inputs: [
+        'artifact:accepted-preview',
+        'artifact:configured-vercel-target'
+      ],
+      outputs: ['artifact:production-deployment', 'artifact:rollback-target'],
+      conditions: [
+        'The deployed source commit equals the accepted Preview commit.',
+        'The deployment build succeeds under the project-owned Node and Yarn contract.',
+        'The stable production alias resolves the new immutable deployment only after provider success.',
+        'The immediately prior healthy deployment remains resolvable for rollback.'
+      ],
+      bypasses: [
+        'A first project deployment records rollback as unpromote/delete-current rather than fabricating a previous healthy production.'
+      ],
+      allowedContributors: [
+        'accepted commit',
+        'configured Vercel target',
+        'provider deployment and alias records'
+      ],
+      forbiddenContributors: [
+        'dirty or different source commit',
+        'provider dashboard edit outside reviewed configuration',
+        'deployment token or environment value in output',
+        'promotion before build success'
+      ],
+      implementationBoundary: [
+        'authenticated Vercel project and deployment operations',
+        'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md'
+      ],
+      specRefs: [
+        '#deployment-and-verification-contract',
+        '#executable-launch-cases',
+        '#quality-gates'
+      ],
+      failureOwnerStepId: 'deploy-accepted-candidate'
+    }),
+    step({
+      id: 'verify-production',
+      order: 5,
+      ownerPackage: 'Anonymous production verification',
+      purpose:
+        'Fail closed on anonymous route, TLS, redirect, headers, cache, indexing, metadata, sitemap, search, examples, Atlas, external-link, accessibility, responsive, or performance drift.',
+      inputs: ['artifact:production-deployment', 'artifact:rollback-target'],
+      outputs: ['artifact:verified-production'],
+      conditions: [
+        'The stable alias and immutable deployment use TLS and return the same accepted site.',
+        'Robots permits production indexing and sitemap and metadata URLs use the stable accepted origin.',
+        'Every public route, search path, example, release fact, Roadmap, Asyra Design link, and Runtime Atlas case works anonymously.',
+        'Security, cache, accessibility, responsive, reduced-motion, performance, and failure behavior gates pass.'
+      ],
+      bypasses: [
+        'Provider authentication, dashboard state, or logged-in browser evidence never substitutes anonymous checks.'
+      ],
+      allowedContributors: [
+        'anonymous HTTPS responses',
+        'production browser execution',
+        'bounded header, SEO, route, accessibility, and performance tests'
+      ],
+      forbiddenContributors: [
+        'authenticated-only success',
+        'Preview URL used as production proof',
+        'manual screenshot as sole evidence',
+        'failed candidate left promoted after a blocking result'
+      ],
+      implementationBoundary: [
+        'apps/asyra-framework-site/__tests__/e2e/launch-production.spec.ts',
+        'apps/asyra-framework-site/scripts/production-smoke.mjs',
+        'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md',
+        'anonymous production URL read-only verification',
+        'authorized rollback operation on blocking failure'
+      ],
+      specRefs: [
+        '#deployment-and-verification-contract',
+        '#executable-launch-cases',
+        '#quality-gates'
+      ],
+      failureOwnerStepId: 'verify-production'
+    }),
+    step({
+      id: 'record-launch-operations',
+      order: 6,
+      ownerPackage: 'Launch operations record',
+      purpose:
+        'Record the verified canonical URL, immutable deployment and source identities, indexing state, rollback procedure, operational exclusions, and acceptance evidence without recording credentials.',
+      inputs: [
+        'artifact:verified-production',
+        'artifact:production-deployment',
+        'artifact:rollback-target'
+      ],
+      outputs: ['artifact:accepted-public-website'],
+      conditions: [
+        'The public URL and source commit are exact and anonymously re-verifiable.',
+        'Rollback uses recorded provider deployment identity or first-deployment unpromotion procedure.',
+        'No analytics or monitoring ownership is implied when those services remain excluded.'
+      ],
+      bypasses: [
+        'Provider-native deployment status and logs are sufficient operational evidence; no new monitoring vendor is required.'
+      ],
+      allowedContributors: [
+        'verified production artifact',
+        'provider deployment and rollback ids',
+        'Launch plan status and evidence'
+      ],
+      forbiddenContributors: [
+        'credential or secret value',
+        'unverified vanity URL',
+        'unapproved monitoring or incident commitment'
+      ],
+      implementationBoundary: [
+        'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md'
+      ],
+      specRefs: [
+        '#operational-contract',
+        '#quality-gates',
+        '#definition-of-done'
+      ],
+      failureOwnerStepId: 'record-launch-operations'
+    })
+  ]),
+  artifacts: Object.freeze(
+    [
+      ['artifact:launch-contract', 'freeze-launch-contract'],
+      ['artifact:accepted-preview', 'accept-integrated-preview'],
+      ['artifact:configured-vercel-target', 'configure-vercel-target'],
+      ['artifact:production-deployment', 'deploy-accepted-candidate'],
+      ['artifact:rollback-target', 'deploy-accepted-candidate'],
+      ['artifact:verified-production', 'verify-production'],
+      ['artifact:accepted-public-website', 'record-launch-operations']
+    ].map(([id, ownerStepId]) => Object.freeze({ id, ownerStepId }))
+  ),
+  routes: Object.freeze(
+    [
+      [
+        'freeze-launch-contract',
+        'accept-integrated-preview',
+        'artifact:launch-contract'
+      ],
+      [
+        'accept-integrated-preview',
+        'configure-vercel-target',
+        'artifact:accepted-preview'
+      ],
+      [
+        'configure-vercel-target',
+        'deploy-accepted-candidate',
+        'artifact:configured-vercel-target'
+      ],
+      [
+        'accept-integrated-preview',
+        'deploy-accepted-candidate',
+        'artifact:accepted-preview'
+      ],
+      [
+        'deploy-accepted-candidate',
+        'verify-production',
+        'artifact:production-deployment'
+      ],
+      [
+        'deploy-accepted-candidate',
+        'verify-production',
+        'artifact:rollback-target'
+      ],
+      [
+        'verify-production',
+        'record-launch-operations',
+        'artifact:verified-production'
+      ],
+      [
+        'deploy-accepted-candidate',
+        'record-launch-operations',
+        'artifact:production-deployment'
+      ],
+      [
+        'deploy-accepted-candidate',
+        'record-launch-operations',
+        'artifact:rollback-target'
+      ]
+    ].map(([from, to, artifactId], index) =>
+      Object.freeze({
+        id: `launch-route-${String(index + 1).padStart(2, '0')}`,
+        from,
+        to,
+        producedArtifacts: Object.freeze([artifactId])
+      })
+    )
+  ),
+  invariants: Object.freeze([
+    'The Framework site project and Asyra Design project remain distinct.',
+    'Preview acceptance and production deployment resolve one exact source commit.',
+    'Only production permits indexing and every absolute public URL uses the accepted stable origin.',
+    'No credential, secret, private endpoint, or internal-only document is published.',
+    'Anonymous production evidence is required before the stable alias is accepted.',
+    'A blocking verification result restores or unpromotes the failed candidate.',
+    'Custom DNS, analytics, monitoring vendors, new secrets, and package publication remain excluded.'
+  ])
+})

--- a/docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md
+++ b/docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md
@@ -3,16 +3,18 @@
 ## Status
 
 Final child plan of the
-[Asyra Framework Website Program](asyra-framework-website-plan.md). Preview
-closure is authorized only as part of a future implementation task. The
-integrated release train requires a pre-publication Release Candidate Preview
-and a final post-registry Preview after generated fact reconciliation.
-Production deployment, domain mutation, external service creation, and other
-external writes require separate explicit user authorization at execution time.
+[Asyra Framework Website Program](asyra-framework-website-plan.md).
+Implementation is active on the dedicated Launch child branch. The user granted
+explicit authority in this integrated release task to create one separate
+Vercel project for the Framework site, configure its non-secret indexing flag,
+deploy the accepted candidate to production, verify it anonymously, and roll it
+back if a release-blocking production check fails. This authority does not
+extend to custom DNS, analytics, monitoring vendors, new secrets, package
+publication, or mutation of the existing Asyra Design project.
 
-Implementation requires an exact launch Inspector, environment and ownership
-contract, executable deployment cases, rollback path, and bounded Definition
-of Done.
+The exact launch Inspector, environment and ownership contract, executable
+deployment cases, rollback path, and bounded Definition of Done are frozen in
+[the Launch flow Inspector](asyra-website-launch-and-operations-flow-inspector.data.cjs).
 
 ## Goal
 
@@ -43,6 +45,52 @@ visual design. It cannot rewrite failed upstream work during launch closure.
   applicable approval.
 - No publication, tag, package release, merge, push, or unrelated external
   operation is implied by website deployment authority.
+
+For this task, production project creation, the project-scoped
+`NEXT_PUBLIC_SITE_INDEXING=true` setting, Preview and production deployment,
+stable provider alias assignment, anonymous verification, rollback, child PR
+push, CI, and merge are explicitly authorized. The root `.vercel` link and
+`https://asra.vercel.app` remain owned by Asyra Design and are immutable inputs.
+
+## Bounded Task Contract
+
+This child owns launch-only configuration, integrated Preview acceptance, a
+dedicated Vercel target, production deployment, canonical-origin metadata,
+robots and sitemap publication, security and cache headers, anonymous
+production verification, rollback proof, and the final public URL record.
+Observable completion requires one exact source commit to pass local and CI
+Preview gates, deploy through a project that is not the Asyra Design project,
+and pass every anonymous production case before it is recorded as accepted.
+
+Discovery is fixed to the accepted integration commit, the nine child plans,
+generated content and example inventories, the Framework site workspace, root
+hosting configuration and read-only existing project metadata, Vercel's
+authenticated project/deployment facts, and the launch gates named below.
+Upstream product semantics, package publication, custom DNS, analytics,
+monitoring services, new secrets, and Asyra Design deployment configuration are
+excluded. A source change after Preview acceptance, target collision, missing
+rollback candidate, secret exposure, or failed anonymous production gate is a
+stop condition.
+
+## Executable Launch Cases
+
+1. `distinct-project-preservation`: the Framework site resolves to a dedicated
+   project and the existing Asyra Design project id and stable alias remain
+   unchanged.
+2. `integrated-preview-acceptance`: one exact integration commit passes content,
+   examples, Atlas, build, type, lint, test, route, accessibility, responsive,
+   visual, clean-consumer, and release-readiness gates.
+3. `immutable-production-candidate`: production deploys the same accepted Git
+   commit and reviewed configuration, without an unreviewed rebuild source.
+4. `production-indexing-metadata`: production alone permits indexing and emits
+   canonical absolute sitemap, robots, social, and metadata URLs from the
+   accepted public origin.
+5. `anonymous-production-surface`: an unsigned visitor can load all public
+   routes, search, examples, Asyra Design evidence, releases, Roadmap, and every
+   Runtime Atlas case with required headers and budgets.
+6. `rollback-readiness`: the immediately previous healthy deployment remains a
+   resolvable rollback target; any blocking production result restores it or
+   leaves the failed candidate unpromoted.
 
 ## Preview Acceptance
 
@@ -90,16 +138,19 @@ that contradict the separately owned repository policy.
 
 1. Freeze hosting, environment, authorization, domain, rollback, and launch
    Inspector contracts.
-2. Build the pre-publication candidate and complete integrated Release
-   Candidate Preview acceptance.
-3. After authorized package/CLI/root release stages, reconcile only generated
-   public facts and complete final Preview acceptance.
-4. Present final Preview evidence and unresolved external decisions to the
-   user.
-5. Obtain explicit production-deployment authorization.
-6. Deploy the exact accepted final candidate.
-7. Run production verification and either accept or roll back.
-8. Record the verified public URL and approved operational ownership.
+2. Complete every tracked hosting, stable-origin, metadata, indexing, header,
+   smoke, and production-browser input before freezing the candidate.
+3. Build the candidate, reconcile generated public facts, open the child PR,
+   and accept one exact pushed commit only after local and CI Preview gates
+   pass.
+4. Resolve or create the authorized dedicated Vercel project and configure its
+   production-only non-secret environment without changing tracked source.
+5. Deploy the exact accepted candidate and retain its immutable deployment
+   identity and real rollback path.
+6. Run anonymous production verification and either accept or immediately
+   restore/unpromote the candidate.
+7. Record the verified public URL, exact source, deployment identity, rollback
+   procedure, evidence, and excluded operational ownership.
 
 ## Quality Gates
 

--- a/docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md
+++ b/docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md
@@ -4,17 +4,71 @@
 
 Final child plan of the
 [Asyra Framework Website Program](asyra-framework-website-plan.md).
-Implementation is active on the dedicated Launch child branch. The user granted
-explicit authority in this integrated release task to create one separate
-Vercel project for the Framework site, configure its non-secret indexing flag,
-deploy the accepted candidate to production, verify it anonymously, and roll it
-back if a release-blocking production check fails. This authority does not
-extend to custom DNS, analytics, monitoring vendors, new secrets, package
-publication, or mutation of the existing Asyra Design project.
+Implementation and production acceptance completed on August 10, 2026. The
+user granted explicit authority in this integrated release task to create one
+separate Vercel project for the Framework site, configure its non-secret
+indexing flag, deploy the accepted candidate to production, verify it
+anonymously, and roll it back if a release-blocking production check fails.
+This authority does not extend to custom DNS, analytics, monitoring vendors,
+new secrets, package publication, or mutation of the existing Asyra Design
+project.
 
 The exact launch Inspector, environment and ownership contract, executable
 deployment cases, rollback path, and bounded Definition of Done are frozen in
 [the Launch flow Inspector](asyra-website-launch-and-operations-flow-inspector.data.cjs).
+
+## Accepted Production Record
+
+- Public URL: `https://asyra-framework.vercel.app`
+- Immutable deployment URL:
+  `https://asyra-framework-k2r6q54s3-karote00s-projects.vercel.app`
+- Accepted website source:
+  `172fc1b5fa2fa57c40ab4daf72e4624e5d7f8a29`
+- Vercel deployment: `dpl_94LGWe6K5fu1hkztDgiPnpHp2ak8`
+- Dedicated project: `asyra-framework`
+  (`prj_IGSQKq4oQQPeXXQ948hiORc5BBAg`) in `karote00s-projects`
+  (`team_HpJaUNDTB6ZDFDRJMCnEkp4W`)
+- Existing Asyra Design project: unchanged
+  (`prj_rMVZ3Pq4G3cb0dPDZmDpYfZNAElJ`, `https://asra.vercel.app`)
+
+The accepted source passed Pull Request #125 `validate`, Framework release
+readiness, ordinary E2E, Collaboration E2E, Asyra Design Preview, and Framework
+site Preview checks before production deployment. The dedicated target uses
+Node `24.x`, Yarn `4.3.1` through Corepack, the generated Framework-site Turbo
+owner task, and the app-owned `dist` output. The tracked build contract and
+provider project settings were read back as equal before deployment.
+
+Production verification passed all 49 anonymous public route and metadata
+smoke checks, all three Launch production browser cases, and all 20 maintained
+site browser cases. The maintained cases cover search, Landing, documentation,
+Asyra Design evidence, releases, Roadmap, all six Runtime Atlas cases,
+accessibility, responsive layouts, reduced motion, no-client-JavaScript
+reading, and the bounded runtime and resource budgets. Synchronized agent
+review additionally inspected the live desktop Landing and an accepted Runtime
+Atlas execution; formal `390x844`, `320px`, and `200%` reflow cases own mobile
+evidence.
+
+Both accepted production URLs return the same anonymously accessible HTML over
+verified TLS. The stable alias exposes the reviewed CSP, permissions, referrer,
+HSTS, MIME-sniffing, framing, cache, robots, sitemap, and canonical metadata
+contracts. `NEXT_PUBLIC_SITE_INDEXING=true` exists only for the Production
+environment. Vercel Authentication is scoped to `preview`, so Preview URLs
+remain protected while the stable and immutable production URLs remain public.
+
+This is the first healthy production deployment. Its first-deployment rollback
+is exact unpromotion or deletion of
+`dpl_94LGWe6K5fu1hkztDgiPnpHp2ak8`, followed by anonymous verification that the
+stable alias no longer serves the rejected candidate. The exact deletion path
+was proven before acceptance against the failed candidate
+`dpl_HhMZzbYkmAKYCGpc1e7U58EgPcuW`, whose deployment lookup returned `404`
+after deletion. For the next release, the deployment recorded here becomes the
+previous healthy rollback target and must remain resolvable until the new
+candidate passes production verification.
+
+No custom DNS, analytics, monitoring vendor, new secret, package publication,
+or Asyra Design hosting mutation was introduced. The operations-record and
+canonical-oracle test commits follow the deployed source without changing the
+accepted website runtime and must pass the final child PR checks before merge.
 
 ## Goal
 

--- a/docs/ai/framework/plans/completed/render-delta-update-plan.md
+++ b/docs/ai/framework/plans/completed/render-delta-update-plan.md
@@ -354,7 +354,10 @@ requests one browser garbage collection. This prevents allocations owned by
 fixture creation, module loading, and Collaboration setup from becoming a
 runner-dependent pause inside a later strategy sample. The measured 12-frame
 product flow, sample counts, total, p95, cold/steady max budgets, and ordinary
-App composition remain unchanged.
+App composition remain unchanged. The test then completes one unmeasured normal
+Render frame and waits two animation frames before installing timers, so the
+first canvas/GPU flush after the test-only collection belongs to setup rather
+than an arbitrary measured product frame.
 
 For this bounded 12-frame sample, p50 and p95 use the lower sample quantile at
 `floor((sampleCount - 1) * ratio)`. The maximum sample retains its own explicit

--- a/docs/ai/framework/plans/completed/render-delta-update-plan.md
+++ b/docs/ai/framework/plans/completed/render-delta-update-plan.md
@@ -349,15 +349,12 @@ be idle and confirms that the session remains connected. This excludes fixture
 setup publication work from the measured Render phases without changing the
 ordinary App composition or any formal timing threshold.
 
-After that setup boundary and before installing the phase timers, Playwright
-requests one browser garbage collection. This prevents allocations owned by
-fixture creation, module loading, and Collaboration setup from becoming a
-runner-dependent pause inside a later strategy sample. The measured 12-frame
-product flow, sample counts, total, p95, cold/steady max budgets, and ordinary
-App composition remain unchanged. The test then completes one unmeasured normal
-Render frame and waits two animation frames before installing timers, so the
-first canvas/GPU flush after the test-only collection belongs to setup rather
-than an arbitrary measured product frame.
+Pull-request CI runs this timing fixture with the exact Playwright-managed
+Chromium binary installed by the workflow. The remaining functional E2E suite
+continues to use the configured Google Chrome channel. This pins the timing
+runner without changing the measured 12-frame product flow, sample counts,
+total, p95, cold/steady max budgets, ordinary App composition, or zero-retry
+policy.
 
 For this bounded 12-frame sample, p50 and p95 use the lower sample quantile at
 `floor((sampleCount - 1) * ratio)`. The maximum sample retains its own explicit

--- a/docs/ai/framework/plans/completed/render-delta-update-plan.md
+++ b/docs/ai/framework/plans/completed/render-delta-update-plan.md
@@ -349,6 +349,13 @@ be idle and confirms that the session remains connected. This excludes fixture
 setup publication work from the measured Render phases without changing the
 ordinary App composition or any formal timing threshold.
 
+After that setup boundary and before installing the phase timers, Playwright
+requests one browser garbage collection. This prevents allocations owned by
+fixture creation, module loading, and Collaboration setup from becoming a
+runner-dependent pause inside a later strategy sample. The measured 12-frame
+product flow, sample counts, total, p95, cold/steady max budgets, and ordinary
+App composition remain unchanged.
+
 For this bounded 12-frame sample, p50 and p95 use the lower sample quantile at
 `floor((sampleCount - 1) * ratio)`. The maximum sample retains its own explicit
 oracle, so the p95 and max budgets remain independent. The first vector

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -236,7 +236,7 @@ test('CI isolates the render performance budget before parallel functional E2E',
 
   assert.match(
     runner,
-    /playwright test --config playwright\.config\.ts e2e\/render-delta-performance\.spec\.ts --workers=1/
+    /E2E_RENDER_PERFORMANCE_BROWSER=chromium \\\s*yarn workspace @asyra\/asyra-design playwright test --config playwright\.config\.ts e2e\/render-delta-performance\.spec\.ts --workers=1/
   )
   assert.match(runner, /E2E_SKIP_PERFORMANCE=true yarn test:e2e/)
 })

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -100,7 +100,8 @@ npx wait-on "$E2E_APP_URL" --timeout 60000
 # then run the remaining functional suite with its deterministic CI policy.
 if [ "${CI:-}" = "true" ]; then
   echo "Step 10: Running isolated render performance gate..."
-  yarn workspace @asyra/asyra-design playwright test --config playwright.config.ts e2e/render-delta-performance.spec.ts --workers=1
+  E2E_RENDER_PERFORMANCE_BROWSER=chromium \
+    yarn workspace @asyra/asyra-design playwright test --config playwright.config.ts e2e/render-delta-performance.spec.ts --workers=1
   echo "Step 11: Running functional Playwright tests..."
   E2E_SKIP_PERFORMANCE=true yarn test:e2e
 else


### PR DESCRIPTION
## Summary
- freeze the website launch, target-separation, rollback, and anonymous verification contract
- add stable-origin metadata, production-only indexing, security headers, canonical routes, and dedicated site Vercel configuration
- add production smoke/browser gates and expose the verified Asyra Design reference product

## Local evidence
- yarn test:local
- yarn react:build
- yarn lint:ci
- 49-route Preview smoke
- 17/17 Landing, platform, and Runtime Atlas browser tests
- synchronized desktop/mobile/Atlas screenshot review