### PR TITLE
Deploy Framework site from artifact changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,23 +78,3 @@ jobs:
 
       - name: Verify release records
         run: yarn release:records
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    needs: validate
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Yarn
-        run: corepack enable && yarn set version 4.3.1
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ chrome-dev-perf-trace.json
 tmp/
 apps/*/test-results/
 apps/*/playwright-report/
+apps/*/visual-review-records/
 apps/asyra-framework-site/artwork/
 apps/asyra-framework-site/public/illustrations/*
 !apps/asyra-framework-site/public/illustrations/*-photoroom-*.webp

--- a/apps/asyra-framework-site/__tests__/vercel-deployment.test.mjs
+++ b/apps/asyra-framework-site/__tests__/vercel-deployment.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  isFrameworkSiteBuildInput,
+  shouldBuildFrameworkSite
+} from '../scripts/vercel-ignore-build.mjs'
+
+test('Framework site deployment follows every artifact input owner', () => {
+  for (const file of [
+    'apps/asyra-framework-site/app/page.tsx',
+    'apps/asyra-framework-site/public/illustrations/hero.webp',
+    'docs/public/generated/package-reference.json',
+    'packages/core/src/core.ts',
+    'packages/core/package.json',
+    '.yarn/releases/yarn-4.3.1.cjs',
+    '.yarnrc.yml',
+    'package.json',
+    'turbo.json',
+    'yarn.lock'
+  ]) {
+    assert.equal(isFrameworkSiteBuildInput(file), true, file)
+  }
+})
+
+test('Framework site deployment ignores changes outside its artifact graph', () => {
+  for (const file of [
+    '.github/workflows/e2e.yml',
+    'apps/asyra-design/src/app/index.tsx',
+    'docs/ai/framework/PLANS.md',
+    'scripts/release-full.js'
+  ]) {
+    assert.equal(isFrameworkSiteBuildInput(file), false, file)
+  }
+})
+
+test('one relevant file is sufficient to deploy an otherwise unrelated commit', () => {
+  assert.equal(
+    shouldBuildFrameworkSite([
+      'docs/ai/framework/PLANS.md',
+      'docs/public/reference/support-release.md'
+    ]),
+    true
+  )
+  assert.equal(
+    shouldBuildFrameworkSite([
+      'docs/ai/framework/PLANS.md',
+      'scripts/release-full.js'
+    ]),
+    false
+  )
+})

--- a/apps/asyra-framework-site/scripts/vercel-ignore-build.mjs
+++ b/apps/asyra-framework-site/scripts/vercel-ignore-build.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/* global console, process */
+
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(import.meta.dirname, '../../..')
+
+const exactBuildInputs = new Set([
+  '.yarnrc.yml',
+  'package.json',
+  'turbo.json',
+  'yarn.lock'
+])
+
+const buildInputPrefixes = [
+  '.yarn/releases/',
+  'apps/asyra-framework-site/',
+  'docs/public/',
+  'packages/'
+]
+
+export const isFrameworkSiteBuildInput = (file) =>
+  exactBuildInputs.has(file) ||
+  buildInputPrefixes.some((prefix) => file.startsWith(prefix))
+
+export const shouldBuildFrameworkSite = (files) =>
+  files.some(isFrameworkSiteBuildInput)
+
+const readChangedFiles = () =>
+  execFileSync(
+    'git',
+    ['diff', '--name-only', '--diff-filter=ACDMRTUXB', 'HEAD^', 'HEAD', '--'],
+    { cwd: repositoryRoot, encoding: 'utf8' }
+  )
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean)
+
+const run = () => {
+  let changedFiles
+
+  try {
+    changedFiles = readChangedFiles()
+  } catch {
+    console.log(
+      'Unable to resolve the previous commit; build the Framework site'
+    )
+    process.exit(1)
+  }
+
+  const buildInputs = changedFiles.filter(isFrameworkSiteBuildInput)
+  if (buildInputs.length === 0) {
+    console.log('No Framework site build inputs changed; ignore this build')
+    process.exit(0)
+  }
+
+  console.log('Framework site build inputs changed:')
+  for (const file of buildInputs) console.log(`- ${file}`)
+  process.exit(1)
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  run()
+}

--- a/apps/asyra-framework-site/vercel.json
+++ b/apps/asyra-framework-site/vercel.json
@@ -4,9 +4,8 @@
   "installCommand": "cd ../.. && corepack yarn install --immutable",
   "buildCommand": "cd ../.. && corepack yarn turbo run build:asyra-framework-site --filter=@asyra/asyra-framework-site",
   "outputDirectory": "dist",
+  "ignoreCommand": "node scripts/vercel-ignore-build.mjs",
   "git": {
-    "deploymentEnabled": {
-      "*": false
-    }
+    "deploymentEnabled": true
   }
 }

--- a/docs/ai/framework/plans/__tests__/asyra-website-launch-and-operations-flow-inspector.contract.test.cjs
+++ b/docs/ai/framework/plans/__tests__/asyra-website-launch-and-operations-flow-inspector.contract.test.cjs
@@ -64,7 +64,7 @@ test('accepted Preview owns every tracked launch input before its commit is froz
   })
 })
 
-test('dedicated target configuration changes provider state without changing accepted source', () => {
+test('dedicated target configuration owns reviewed Git deployment selection', () => {
   const target = step('configure-vercel-target')
   const source = JSON.stringify(target)
   assert.match(source, /org and project ids differ/i)
@@ -72,19 +72,24 @@ test('dedicated target configuration changes provider state without changing acc
   assert.match(source, /No token, secret, or provider credential/i)
   assert.match(source, /root \.vercel link mutation/i)
   assert.match(source, /tracked website source or configuration change/i)
+  assert.match(source, /tracked artifact inputs rather than release versions/i)
   assert.deepEqual(target.implementationBoundary, [
     'authenticated Vercel project and environment operations',
+    'apps/asyra-framework-site/vercel.json',
+    'apps/asyra-framework-site/scripts/vercel-ignore-build.mjs',
+    '.github/workflows/main.yml',
     'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md',
     '.vercel/project.json read-only; never mutate'
   ])
 })
 
-test('deployment uses the accepted source, stable alias, and a real rollback path', () => {
+test('deployment uses accepted Git commits, the stable alias, and a real rollback path', () => {
   const source = JSON.stringify(step('deploy-accepted-candidate'))
   assert.match(
     source,
-    /deployed source commit equals the accepted Preview commit/i
+    /Preview deployments use pull request commits and Production deployments use accepted main-branch commits/i
   )
+  assert.match(source, /artifact inputs.*never requires a release-version change/i)
   assert.match(source, /stable production alias/i)
   assert.match(source, /prior healthy deployment remains resolvable/i)
   assert.match(source, /first project deployment.*unpromote\/delete-current/i)

--- a/docs/ai/framework/plans/asyra-website-launch-and-operations-flow-inspector.data.cjs
+++ b/docs/ai/framework/plans/asyra-website-launch-and-operations-flow-inspector.data.cjs
@@ -40,7 +40,8 @@ module.exports = Object.freeze({
       outputs: ['artifact:launch-contract'],
       conditions: [
         'The Framework site uses a dedicated Vercel project and never mutates the existing Asyra Design project id or stable alias.',
-        'One exact source commit and reviewed configuration own Preview and production acceptance.',
+        'Every Preview and production deployment identifies one exact source commit and reviewed configuration.',
+        'Repository-configured Git automation may deploy changed Framework-site artifact inputs after the applicable pull request or main-branch gates pass.',
         'Production indexing is project-scoped and enabled only for the accepted production environment.',
         'Custom DNS, analytics, monitoring vendors, new secrets, and package publication remain excluded.'
       ],
@@ -131,6 +132,7 @@ module.exports = Object.freeze({
       conditions: [
         'The selected org and project ids differ from the read-only Asyra Design link.',
         'The project root and build settings resolve the Framework site workspace and repository workspace dependencies.',
+        'Git deployment is enabled only for the dedicated Framework site project and the app-owned ignore command selects builds from tracked artifact inputs rather than release versions.',
         'NEXT_PUBLIC_SITE_INDEXING=true exists only as a project-scoped production setting.',
         'No token, secret, or provider credential is written to tracked files or printed.'
       ],
@@ -151,6 +153,9 @@ module.exports = Object.freeze({
       ],
       implementationBoundary: [
         'authenticated Vercel project and environment operations',
+        'apps/asyra-framework-site/vercel.json',
+        'apps/asyra-framework-site/scripts/vercel-ignore-build.mjs',
+        '.github/workflows/main.yml',
         'docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md',
         '.vercel/project.json read-only; never mutate'
       ],
@@ -173,7 +178,8 @@ module.exports = Object.freeze({
       ],
       outputs: ['artifact:production-deployment', 'artifact:rollback-target'],
       conditions: [
-        'The deployed source commit equals the accepted Preview commit.',
+        'Preview deployments use pull request commits and Production deployments use accepted main-branch commits from the same reviewed Git integration.',
+        'A deployment is selected by Framework-site artifact inputs and never requires a release-version change.',
         'The deployment build succeeds under the project-owned Node and Yarn contract.',
         'The stable production alias resolves the new immutable deployment only after provider success.',
         'The immediately prior healthy deployment remains resolvable for rollback.'
@@ -355,7 +361,8 @@ module.exports = Object.freeze({
   ),
   invariants: Object.freeze([
     'The Framework site project and Asyra Design project remain distinct.',
-    'Preview acceptance and production deployment resolve one exact source commit.',
+    'Every Preview and production deployment resolves one exact source commit and reviewed Git configuration.',
+    'Continuous deployment selection follows tracked Framework-site artifact inputs rather than release-version cadence.',
     'Only production permits indexing and every absolute public URL uses the accepted stable origin.',
     'No credential, secret, private endpoint, or internal-only document is published.',
     'Anonymous production evidence is required before the stable alias is accepted.',

--- a/docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md
+++ b/docs/ai/framework/plans/asyra-website-launch-and-operations-plan.md
@@ -17,6 +17,14 @@ The exact launch Inspector, environment and ownership contract, executable
 deployment cases, rollback path, and bounded Definition of Done are frozen in
 [the Launch flow Inspector](asyra-website-launch-and-operations-flow-inspector.data.cjs).
 
+On August 28, 2026, the user additionally authorized repository-configured
+continuous Git deployments for the dedicated Framework site project. Pull
+request commits may create Preview deployments and accepted `main` commits may
+create Production deployments when the tracked Framework-site artifact inputs
+change. This standing automation authority is scoped to the existing dedicated
+Framework site project and does not extend to the Asyra Design project, custom
+DNS, analytics, monitoring, new secrets, or package publication.
+
 ## Accepted Production Record
 
 - Public URL: `https://asyra-framework.vercel.app`
@@ -187,6 +195,33 @@ contract, and public disclosure where required.
 The website must expose verified security, support, license, release, and
 contribution-policy links. It must not offer public issue or contribution flows
 that contradict the separately owned repository policy.
+
+### Continuous Git deployment selection
+
+The dedicated Framework site uses Vercel Git integration for Preview and
+Production deployments. Deployment selection follows the website artifact
+graph, not a release-version comparison:
+
+- `apps/asyra-framework-site/**` owns the site application, configuration, and
+  public assets;
+- `docs/public/**` owns the rendered documentation and generated public facts;
+- `packages/**` owns the Framework runtime bundled by Runtime Atlas;
+- `.yarn/releases/**`, `.yarnrc.yml`, `package.json`, `turbo.json`, and
+  `yarn.lock` own the shared build and dependency environment.
+
+The app-owned `scripts/vercel-ignore-build.mjs` compares the current commit to
+its first parent. It continues the build when any owned input changed and
+ignores the build otherwise. If the comparison cannot be resolved, it fails
+open by continuing the build. A package or root version change is neither
+required nor sufficient by itself: deployment occurs because a tracked
+artifact input changed.
+
+Pull request deployments remain Preview deployments. Production deployment is
+limited to accepted commits on `main`; repository branch protection and CI own
+pre-merge correctness, while Vercel owns the immutable build and alias update.
+Deployment success never substitutes for the required CI, site, content, or
+production verification gates. The previous healthy Production deployment
+remains the rollback target.
 
 ## Implementation Stages
 

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -171,6 +171,22 @@ test('CI, E2E, and release validation own their bounded integration gates', () =
   assert.match(releaseValidation, /yarn release:app:check --prod=\$\{appName\}/)
 })
 
+test('Framework site Git deployments follow artifact inputs instead of release versions', () => {
+  const siteVercel = readJSON('apps/asyra-framework-site/vercel.json')
+  const ignoreBuild = readText(
+    'apps/asyra-framework-site/scripts/vercel-ignore-build.mjs'
+  )
+  const ci = readText('.github/workflows/main.yml')
+
+  assert.equal(siteVercel.git.deploymentEnabled, true)
+  assert.equal(siteVercel.ignoreCommand, 'node scripts/vercel-ignore-build.mjs')
+  assert.match(ignoreBuild, /apps\/asyra-framework-site/)
+  assert.match(ignoreBuild, /docs\/public/)
+  assert.match(ignoreBuild, /packages/)
+  assert.doesNotMatch(ignoreBuild, /version/i)
+  assert.doesNotMatch(ci, /^ {2}deploy:/m)
+})
+
 test('Vite builds rely on dedicated lint gates and native Vercel output configuration', () => {
   const designManifest = readJSON('apps/asyra-design/package.json')
   const designViteConfig = readText('apps/asyra-design/vite.config.ts')


### PR DESCRIPTION
## Summary
- enable Vercel Git deployments for the dedicated Framework site project
- deploy from Framework site artifact inputs instead of release-version cadence
- remove the empty GitHub Actions deploy job
- ignore local visual-review records
- synchronize the Launch and Operations contract

## Validation
- Launch Inspector contract: 10 passed
- deployment/workspace automation: 29 passed
- Framework site tests: 58 passed, 14 opt-in skips
- Framework site typecheck passed
- Framework site production build generated 51 static pages
- lint passed with 0 errors
- Vercel ignore command selected this deployment commit