### PR TITLE
ci: group Dependabot update lanes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
       interval: 'weekly'
     labels:
       - 'dependencies'
+    groups:
+      # Keep routine Action updates together while reviewing workflow changes
+      # separately from application dependencies.
+      github-actions-version-updates:
+        applies-to: 'version-updates'
+        patterns:
+          - '*'
+      # Security updates stay independent from scheduled version maintenance.
+      github-actions-security-updates:
+        applies-to: 'security-updates'
+        patterns:
+          - '*'
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -13,3 +25,17 @@ updates:
       interval: 'weekly'
     labels:
       - 'dependencies'
+    groups:
+      # Major version updates are intentionally unmatched and remain isolated.
+      npm-minor-and-patch:
+        applies-to: 'version-updates'
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Security updates stay independent from scheduled version maintenance.
+      npm-security-updates:
+        applies-to: 'security-updates'
+        patterns:
+          - '*'

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -60,6 +60,31 @@ test('GitHub Actions use least privilege and immutable action revisions', () => 
   assert.match(dependabot, /interval: ['"]weekly['"]/)
 })
 
+test('Dependabot separates routine, major, and security update lanes', () => {
+  const dependabot = readText('.github/dependabot.yml')
+
+  assert.match(
+    dependabot,
+    /github-actions-version-updates:\n\s+applies-to: ['"]version-updates['"]\n\s+patterns:\n\s+- ['"]\*['"]/
+  )
+  assert.match(
+    dependabot,
+    /github-actions-security-updates:\n\s+applies-to: ['"]security-updates['"]\n\s+patterns:\n\s+- ['"]\*['"]/
+  )
+  assert.match(
+    dependabot,
+    /npm-minor-and-patch:\n\s+applies-to: ['"]version-updates['"]\n\s+patterns:\n\s+- ['"]\*['"]\n\s+update-types:\n\s+- ['"]minor['"]\n\s+- ['"]patch['"]/
+  )
+  assert.match(
+    dependabot,
+    /npm-security-updates:\n\s+applies-to: ['"]security-updates['"]\n\s+patterns:\n\s+- ['"]\*['"]/
+  )
+  assert.doesNotMatch(
+    dependabot,
+    /npm-minor-and-patch:[\s\S]*?update-types:[\s\S]*?- ['"]major['"]/
+  )
+})
+
 test('workspace manifests omit confirmed unused dependencies', () => {
   const designSystem = readJSON('packages/design-system/package.json')
   const preset = readJSON('packages/preset/package.json')


### PR DESCRIPTION
## Summary

- group routine npm minor and patch version updates into one weekly PR
- leave npm major version updates unmatched so they remain isolated
- group routine GitHub Actions version updates into one weekly PR
- keep npm and GitHub Actions security updates separate from routine maintenance
- add a formal automation contract for the policy

## Validation

- Dependabot YAML syntax validation
- `yarn test:scripts` (98/98)
- `git diff --check`

This PR does not modify, close, or merge the currently open Dependabot PRs.