### PR TITLE
docs: link the Asyra website from README

### DIFF
--- a/.changeset/readme-website-link.md
+++ b/.changeset/readme-website-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add the Asyra website to the root README's introductory navigation links.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ coordinates the shared infrastructure around them: intent routing,
 registration, transactions, rollback, Undo/Redo, validation, persistence
 boundaries, and downstream projections.
 
+- <a href="https://asyra-framework.vercel.app" target="_blank" rel="noopener noreferrer">Visit the Asyra website</a>
 - <a href="https://asyra-design.vercel.app/?fileId=demo" target="_blank" rel="noopener noreferrer">Try Asyra Design</a>
 - [Read the documentation](docs/public/index.md)
 - [Install `@asyra/core`](#package-first-composition)


### PR DESCRIPTION
## Summary

- Add the official Asyra website as the first introductory README link.
- Preserve the existing demo, documentation, and installation links.
- Use the required safe new-tab HTML anchor.

## Validation

- Website returns HTTP 200
- Prettier checks passed
- Public README validation passed (23 surfaces, 146 links)
- README input tests: 5 passed
- Changeset PR check passed
- git diff --check passed