### PR TITLE
docs(flow-inspector): plan contract-based development risk management

### DIFF
--- a/.changeset/flow-inspector-risk-management-plans.md
+++ b/.changeset/flow-inspector-risk-management-plans.md
@@ -1,0 +1,6 @@
+---
+---
+
+Revise the Flow Inspector roadmap and phase plans around concrete implementation
+steps, behavioral conformance, cross-flow CI, and bounded human and AI execution.
+This planning record does not change Framework packages or assign release versions.

--- a/docs/ai/tools/flow-inspector/PLANS.md
+++ b/docs/ai/tools/flow-inspector/PLANS.md
@@ -3,28 +3,46 @@ Never record completed plans here.
 # Flow Inspector Plans
 
 This file tracks active and future work for the Flow Inspector tool family.
+The product direction was revised on 2026-09-07: materialize a Plan as concrete
+implementation steps and executable flow contracts to manage human and AI
+development risk. Open-source usefulness, reproducibility, and controlled
+delegation are the success criteria.
 
 ## Active Target
 
-No active implementation target. Dynamic Control Plane work remains deferred.
+No active implementation target. This revision updates planning only. Dynamic
+Control Plane implementation remains deferred until a bounded activation
+selects the proof flows, product specification, exact architecture Inspector,
+behavioral cases, owner boundaries, runner/CI policy, and required gates.
 
-## Completed Plans
+## Next Implementation Candidate
 
-- Static Workspace `0.2.0` P2:
-  `docs/ai/tools/flow-inspector/plans/completed/flow-inspector-static-workspace-0.2.0-closure-plan.md`.
+1. [Contract Verification and CI Plan](plans/flow-inspector-control-plane-evidence-and-ci-plan.md)
+   - Phase 3: two related real flows, preflight checks, behavioral conformance,
+     negative proofs, and minimal controlled actions with attributable evidence.
+   - Phase 4: an operational step board, common API/CLI, contract evolution,
+     mandatory all-flow CI within the declared supported set, and shared viewing.
+   - First checkpoint: a shared-owner change breaks a retained flow, the real
+     gate rejects it at the correct step, and a conforming correction passes.
 
-## Deferred Plans
+## Dependent Implementation Candidate
 
-1. Dynamic evidence, reconciliation, and CI — future Control Plane
+2. [Agent Execution and Integrations Plan](plans/flow-inspector-control-plane-actions-and-integrations-plan.md)
+   - Phase 5: enforceable agent task scope, capabilities, resource limits,
+     progress checks, stopping, recovery, and handoff.
+   - Phase 6: small-team operations, selected ticket/PR integrations, hardening,
+     and reproducible open-source adoption.
+   - Entry depends on the preceding conformance/action/CI foundation, not on
+     agent controls or integrations that this plan has yet to implement.
 
-- Plan:
-  `docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-evidence-and-ci-plan.md`.
+Both existing plan filenames remain stable. No schema, runtime, package,
+dependency, license, or publication change is implied by the planning revision.
 
-2. Actions, delivery, and integrations — future Control Plane
+## Roadmap and Baseline References
 
-- Plan:
-  `docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-actions-and-integrations-plan.md`.
-
-## Roadmap Authority
-
-- `docs/ai/tools/flow-inspector/plans/flow-inspector-workflow-control-plane-roadmap.md`.
+- [Workflow Control Plane Roadmap](plans/flow-inspector-workflow-control-plane-roadmap.md)
+  owns cross-phase direction, boundaries, activation decisions, and provisional
+  effort ranges. The phase plans own their delivery cases and DoD.
+- [Static Workspace 0.2.0 record](plans/completed/flow-inspector-static-workspace-0.2.0-closure-plan.md)
+  records the completed Phase 0-2 baseline; its static-only contract remains
+  unchanged.

--- a/docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-actions-and-integrations-plan.md
+++ b/docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-actions-and-integrations-plan.md
@@ -1,78 +1,226 @@
-# Flow Inspector Control Plane Actions and Integrations Plan
+# Flow Inspector Control Plane Agent Execution and Integrations Plan
 
-## Status
+## Status and Objective
 
-Deferred until the dynamic Evidence, Reconciliation, and CI Plan completes.
-This plan owns executable actions and integrations and is not part of the
-completed static `v0.2.0` companion release.
+Deferred until the
+[Contract Verification and CI Plan](flow-inspector-control-plane-evidence-and-ci-plan.md)
+completes. Revised on 2026-09-07; the existing filename remains stable. This
+plan extends an implemented action, evidence, and CI foundation rather than
+requiring its own future agent controls to exist at entry.
 
-## Objective
+Enable a human to delegate a concrete step to an AI agent with enforceable
+scope and resource limits, observable progress, and trustworthy delivery.
+Extend the same board to small-team work and selected ticket/PR operations.
+The [roadmap](flow-inspector-workflow-control-plane-roadmap.md) owns risk,
+contract, versioning, and open-source product direction.
 
-Extend the proven state/action system to visual evidence, protected delivery
-workflows, CI, and optional external adapters without weakening authorization,
-audit, or canonical truth ownership.
+## Entry Criteria and Scope
 
-## Entry Criteria
+- Real behavioral conformance, negative proofs, cross-flow regression, and the
+  selected required CI aggregate have passed the preceding plan's gates.
+- UI, CLI, and API already use one typed action owner with capability checks,
+  bounded runner lifecycle, provenance, basic audit, and crash-safe ingestion.
+- Flow versions, accepted-baseline protection, mapping review, and the
+  supported regression set are operational within the declared trial scope.
+- For Phase 5, select one agent backend and its tool/process interface.
+- Before Phase 6, select the shared workspace access model and one ticket
+  provider with explicit initial operations. Those decisions do not block the
+  earlier agent proof.
+- Before agent execution, define the exact containment, usage measurement,
+  cancellation, recovery, and handoff contract, supported adversarial cases,
+  and owner implementation boundary. Unknown capabilities remain unsupported.
 
-- mapping reconciliation and complete freshness are proven;
-- UI, CLI, and API expose identical status and action behavior;
-- action security and audit boundaries have survived representative local use;
-  and
-- each selected integration has an explicit product need and owner.
+The Control Plane stays tool-owned and independent of product runtimes.
+Provider adapters live outside its conformance authority. Existing standing
+authorization applies within its recorded scope; this plan does not authorize
+publication, secret changes, package installation, or unrestricted tool use.
 
-## Phase 5 — Typed Actions and Delivery Flow
+The slices below sequence delivery work. Activation must map each implementation
+segment to one exact Inspector owner; a slice heading is not a multi-owner
+implementation allowance.
 
-- add the typed action registry, local runner, timeout, cancellation,
-  capability, confirmation, and audit boundaries;
-- add focused test and evidence actions;
-- ingest and explain visual-review artifacts and screenshots;
-- run registered visual-review actions through the established execution path;
-- ingest CI results without making a CI vendor the panel truth owner;
-- add Git diff/review preparation and final completion panels;
-- require current evidence, resolved mapping candidates, and reviewed diff at
-  completion gates; and
-- add commit, push, release, or deployment actions only with their existing
-  explicit authorization, confirmation, capability, secret, and audit
-  boundaries.
+## Phase 5 - Bounded Agent Execution
 
-## Phase 6 — External Adapters and Hardening
+### Slice 1 - Task admission and enforceable capabilities
 
-- add outbox-based task, source-control, CI, and communication adapters selected
-  by explicit scope;
-- support retry, deduplication, delivery state, and replay-safe audit history;
-- resolve secrets indirectly and redact them from config, results, logs, and
-  artifacts;
-- isolate adapter failure from canonical panel state;
-- profile and harden large-workspace storage, watchers, process cleanup, and
-  crash recovery; and
-- validate that the permission-shaped architecture can evolve toward team RBAC
-  and remote runners without redesigning evidence or action identity.
+Bind a task to one concrete owner step, flow version, source baseline, objective,
+allowed mutations, input/output contract, required validation, capabilities,
+budgets, and stop conditions. Read upstream and downstream contracts before
+admission. Independent steps may run concurrently only with declared resource
+and mutation-conflict rules; overlapping writes cannot rely on last-writer wins.
+
+Integrate the selected agent through controlled tools and runners. Enforce file,
+process, network, and secret access at the actual execution boundary, and
+verify candidate writes against scope. Include path traversal, symlink escape,
+unregistered commands, and indirect process/network effects in the supported
+boundary tests. A prompt or post-run diff alone is insufficient containment.
+
+Bind permission to the task, actor, action, source, and current policy. Existing
+success history does not grant broader capabilities automatically. Repository,
+ticket, log, and model content cannot authorize new scope or change the gate.
+An agent may propose a contract revision, but accepting a revision that expands
+its own assignment or weakens its required proof needs the designated separate
+authority. Candidate test execution must not inherit control-plane secrets.
+
+### Slice 2 - Resource limits, progress, and stopping
+
+Enforce the selected elapsed-time, tool-call, attempt, and concurrency limits.
+For token or cost limits, document the backend's measurement fidelity and
+maximum in-flight exposure. A backend with unavailable usage cannot advertise
+hard token enforcement; use an explicitly bounded supported mode or do not
+admit a task requiring that guarantee.
+
+Persist cumulative consumption across retries, restarts, and handoffs. Check
+admission before each operation; define bounded cancellation for active work.
+Progress records reference reviewable changes, produced artifacts, or completed
+checks. Self-reported completion and repeated equivalent edits are not proof
+of progress.
+
+Repeated failure, stalled progress, incompatible assumptions, proposed scope
+expansion, permission revocation, or exhausted budget stops further admission.
+Replanning remains inside the task contract; a material expansion requires a
+decision from the scope owner. Do not reset a budget by creating another run.
+Human and AI work use the same conformance and delivery standard.
+
+### Slice 3 - Recovery, handoff, and accepted delivery
+
+Cancellation and timeout must stop or settle owned child processes. Preserve
+partial changes, evidence, failures, consumed budget, and unresolved external
+effects. Recovery must not overwrite unrelated user changes or another task's
+work. Define task-owned rollback separately from external compensation;
+uncertain external effects require reconciliation before retry.
+
+Provide a handoff that lets a human or successor agent continue from the same
+contract, source, remaining budget, and known evidence without repeating broad
+discovery. Abandoned and failed tasks remain distinguishable from completed
+work. A resumed task revalidates changed inputs and permissions.
+
+Completion invokes the preceding plan's verifier and applicable all-flow CI
+gate on the intended delivery revision. A model assertion, passing focused
+test, or finished tool call cannot mark the task delivered. Commit, push,
+release, deployment, and external communication remain separate typed actions
+with their applicable authorization and audit requirements.
+
+Agent checkpoint: delegate a real bounded task, observe autonomous progress,
+reject an out-of-scope action and a behavioral regression, exercise a resource
+stop and handoff, then accept a conforming result without losing existing flow
+protection. Preserve these as formal cases plus a reproducible demonstration.
+
+## Phase 6 - Team Board, Integrations, and Open-Source Adoption
+
+### Slice 4 - Shared context and everyday lifecycle operations
+
+Extend the preceding plan's shared baseline view with the selected access model,
+responsibility assignment, and supported team operations. Managers inspect the
+goal, available capability, remaining work, blockers, and impact; developers
+inspect the concrete step and its actions. Different views must refer to the
+same contract/source version and expose last observation and stale state.
+
+Choose a small explicit ticket/PR operation set before implementation, such as
+linking a ticket, reading/updating its state, inspecting a PR and CI result,
+and requesting a supported review action. Supported operations execute from a
+card and report progress, result, and failure there. Unsupported operations may
+link out. A collection of external links cannot close the supported action DoD.
+
+Specify field ownership, inbound updates, versions, conflict policy, deleted
+tickets, and permission loss. External ticket edits may update work fields;
+they cannot silently rewrite a flow contract or turn failed verification green.
+Technical ownership and team assignment remain distinct. Do not require full
+enterprise accounts or real-time graph co-editing to prove small-team use.
+
+### Slice 5 - Reliable adapters and runtime hardening
+
+Use the existing typed action and audit boundary for adapters. Outbound work
+has durable outbox identity, deduplication, bounded retries, and reconciliation
+for uncertain completion. Incoming updates include source identity and version
+handling to avoid stale overwrite and synchronization loops. Test partial
+success, duplicate callbacks, reordered delivery, offline recovery, and crash
+after an external effect but before local acknowledgement.
+
+Resolve secrets indirectly; redact config, results, logs, and artifacts.
+Connector failure remains visible without becoming a second conformance owner.
+Required external evidence that is unavailable cannot satisfy a completion
+condition. CI ingestion already exists; this slice adds selected provider
+conveniences rather than delaying core CI correctness until now.
+
+Profile supported graph size, history volume, concurrent tasks, subscriptions,
+artifact storage, watchers, and cleanup. Fix measured bottlenecks while
+preserving truth and the preceding phases' recovery guarantees. Apply retention
+rules that preserve delivered contract and verdict history while making any
+expired detailed artifact explicit. No hidden broad test loop is acceptable.
+
+### Slice 6 - Reproducible open-source use
+
+Provide installation and a local example whose core verification requires no
+paid service. Include a controllable demonstration agent for deterministic
+boundary tests and separately exercise the selected real agent backend before
+claiming that integration supported. External credentials and provider charges,
+when applicable, are explicit optional integration requirements.
+
+Document how users define a concrete flow, connect existing behavioral tests,
+add boundary observations, run CI, and extend actions/adapters. Show successful
+work, an intentional violation, a budget stop, and a recoverable handoff.
+Explain supported guarantees and unverified boundaries in the product itself.
+
+Check the selected license, distribution, contribution instructions, dependency
+obligations, and publication scope before an explicitly authorized open-source
+release. Individuals and companies should be able to understand and extend
+the risk-control mechanisms. Payment willingness is not an acceptance gate.
 
 ## Definition of Done
 
-- visual and CI evidence use the same provenance and freshness model as tests;
-- every dangerous delivery action is denied without explicit authorization and
-  required confirmation;
-- adapter failure never changes canonical node truth and can be retried safely;
-- no external service becomes the owner of mappings, results, or status;
-- secrets do not appear in persisted public state or ordinary logs; and
-- performance and recovery gates pass for the supported workspace scale.
+- A real agent completes a scoped step under the same executable contract and
+  regression policy as a human; task completion is backed by actual evidence.
+- Unsupported tool paths and tested scope, filesystem, process, network, and
+  secret violations are denied before their prohibited effects occur.
+- Missing usage telemetry never produces a false hard-budget claim. Applicable
+  limits stop admission and bounded cancellation settles active owned work.
+- Retry, restart, and handoff preserve cumulative consumption; repeated failure
+  or no progress cannot create an unbounded task loop.
+- A contract/gate weakening proposal cannot authorize itself. Revoked or stale
+  capabilities cannot execute a protected action.
+- Partial work can be inspected and resumed or recovered without damaging
+  unrelated changes. External uncertainty is reconciled before replay.
+- A shared-owner regression identifies affected retained flows and prevents
+  delivery until conformance or an authorized requirement revision is proven.
+- Supported ticket/PR actions work from the card, including inbound edits,
+  conflict, deletion, permission loss, retry, and partial-failure cases.
+- Repeated callbacks and crashes do not duplicate external effects or erase
+  audit history. Secrets are absent from ordinary logs and public artifacts.
+- Manager, developer, API, and agent views agree on the selected baseline and
+  expose work progress separately from verification and delivered capability.
+- Another user can reproduce the example and its negative cases. Measured
+  supervision, rework, resource use, and maintenance effort are reported against
+  a defined baseline without requiring a commercial adoption target.
+- Performance, process cleanup, restart, and retention gates pass at the
+  explicitly supported scale. Existing static compatibility remains intact.
 
-## Stop Conditions
+## Exclusions and Stop Conditions
 
-- an integration requires weakening action registry or secret boundaries.
-- Git or release actions treat a UI click as standing publication authority.
-- adapter state is required to derive canonical pass/fail status.
-- team RBAC or hosted multi-tenancy expands scope without a separately approved
-  product contract.
+Multiple agent backends, additional ticket/CI vendors, arbitrary workflow
+automation, remote runner fleets, enterprise RBAC, hosted multi-tenancy, and
+unrestricted autonomous publication require separate scope decisions.
 
-## Estimated Duration
+Stop the affected slice when enforcement depends only on agent obedience, an
+external tool can bypass the task boundary, resource measurement cannot support
+the promised limit, cancellation leaves uncontrolled work, scope can expand
+without its owner, missing evidence is treated as success, or an integration
+must weaken credentials, authorization, or conformance rules to operate.
 
-Approximately 4–7 weeks after the Reconciliation and UI plan is accepted,
-depending on the number of adapters selected. Team RBAC, remote runners, and
-hosted multi-tenancy remain separate version 2 work.
+## Effort and Closure
+
+The roadmap provisionally allocates another 8-14 engineering person-weeks for
+this bounded agent and small-team trial. Re-estimate after Phase 3 and before
+agent activation using the chosen backend's containment, telemetry, and
+cancellation capabilities. Adapter count and per-flow behavioral work are
+separate cost drivers; full existing-flow migration is excluded.
+
+Phase 5 and Phase 6 have separate checkpoints. Close the accepted bounded
+trial without adding unselected providers or team features. Public release is
+a later explicit operation after the selected open-source readiness work.
 
 ## References
 
 - [Workflow Control Plane Roadmap](flow-inspector-workflow-control-plane-roadmap.md)
-- [Evidence and CI Plan](flow-inspector-control-plane-evidence-and-ci-plan.md)
+- [Contract Verification and CI Plan](flow-inspector-control-plane-evidence-and-ci-plan.md)
+- [Flow Inspector contract](../FLOW_INSPECTOR.md)

--- a/docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-evidence-and-ci-plan.md
+++ b/docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-evidence-and-ci-plan.md
@@ -1,78 +1,205 @@
-# Flow Inspector Control Plane Evidence and CI Plan
+# Flow Inspector Control Plane Contract Verification and CI Plan
 
-## Status
+## Status and Objective
 
-Deferred until the Static Workspace Preview Plan completes. This plan begins
-the dynamic Control Plane and is not part of the completed static `v0.2.0`
-companion release.
+Deferred implementation candidate, revised on 2026-09-07. Static Workspace
+`v0.2.0` is complete; activation now depends on the decisions and readiness
+below, not on unfinished static work. This revision authorizes no runtime or
+CI changes by itself. The existing filename is retained for incoming links.
 
-## Objective
+Prove that a concrete implementation Plan can be checked before work, verified
+against real behavior, and retained as a mandatory regression contract. Deliver
+a usable step board with test and CI actions after the core proof. The
+[roadmap](flow-inspector-workflow-control-plane-roadmap.md) owns product
+direction, lifecycle semantics, risk boundaries, and effort assumptions.
 
-Make control-plane status robust under test and source evolution, then expose
-the same trustworthy state and actions through one workspace-level Web UI.
+## Entry Criteria and Bounded Scope
 
-## Entry Criteria
+- Retain the completed static workspace, schema version 2, stable target/step
+  identities, and standalone compatibility.
+- Select one repository, two related real flows, one shared implementation
+  owner, one test runner, and one CI provider. Identify actual behavioral tests
+  separately from Inspector structure or prose checks.
+- Write the thin Control Plane product specification and exact architecture
+  Inspector, including positive, negative, empty, invalid, conditional,
+  provenance, and permission cases. Confirm owner boundaries before code.
+- Decide the proof's persistence, snapshot attribution, expected-case discovery,
+  result ordering, minimal action policy, recovery, and required aggregate gate.
+- Freeze each implementation owner slice and its formal gates. Existing
+  in-scope CI or test-wrapper defects require a failing regression before a
+  correction; unrelated repository cleanup is excluded.
 
-- Static Workspace Phase 0–2 gates are complete.
-- Every current-project Inspector has a stable catalog identity and can be
-  loaded through the shared workspace.
-- Preview usage has confirmed which active and reusable release Inspectors
-  require dynamic evidence and CI enforcement.
+The implementation root is `tools/flow-inspector/control-plane/`. Direct
+product-owned behavioral adapters and tests belong with their semantic owners;
+the bounded activation names those paths explicitly. The UI may reuse the
+existing shell through a separately contracted dynamic surface. Do not make
+the static viewer own task state or product runtimes depend on the tool.
 
-## Phase 3 — Evidence, Status, and Reconciliation
+The slices below sequence delivery work. Activation must map each implementation
+segment to one exact Inspector owner; a slice heading is not a multi-owner
+implementation allowance.
 
-- define test/evidence registry and node-evidence mappings;
-- ingest provenance-bearing results and derive dynamic node status;
-- detect test rename, move, content change, split, merge, missing selector, and
-  newly observed evidence;
-- produce confidence-bearing mapping candidates without modifying formal
-  mappings;
-- support explicit accept/reject/reconcile actions with complete audit history;
-- add `needs-review` and complete `blocked` derivation;
-- propagate evidence changes across every linked node and panel;
-- implement the accepted dependency- and configuration-aware freshness model;
-  and
-- prevent ambiguous, stale, or unmapped observations from producing a trusted
-  passed state.
+## Phase 3 - Core Contract Proof
 
-## Phase 4 — CI Enforcement and Dynamic Workspace UI
+### Slice 1 - Concrete steps and preflight
 
-- add the local service, API/CLI, and dynamic state projection;
-- render graph routes, node status, causes, provenance, evidence, artifacts,
-  and cross-panel impact in the existing workspace shell;
-- provide mapping-candidate review and reconciliation;
-- reload configuration and result state without broad automatic test runs; and
-- prove that UI, CLI, API, and CI present the same canonical state.
+Represent each selected step's implementation responsibility, inputs, outputs,
+owner, consumers, conditions, bypasses, failure owner, and completion evidence.
+Reference target authorities instead of copying them into panel configuration.
+Separate work dependencies, runtime routes, reuse, and evidence links.
 
-The first UI prioritizes legibility and operational usefulness. Cinematic
-visual polish, hosted collaboration, and a plugin marketplace are not required.
+Check missing producers, incompatible handoffs, conflicting responsibilities,
+and conditional paths before admitting dependent work. Unresolved predicates
+or feasibility assumptions require a bounded proof; they cannot be marked
+ready by an AI guess. Readiness permits implementation whose completion tests
+are not yet green. It does not permit contradictory or undefined contracts.
+
+### Slice 2 - Actual behavior and negative proofs
+
+Use product-owned adapters to exercise the existing runtime and observe public
+boundaries. Prove required outcomes and interactions, including forbidden
+effects and failure routes. Existing tests may discharge requirements when
+their assertions actually protect the contract. Add missing formal cases
+before any bug-fix implementation.
+
+For the selected shared owner, demonstrate a valid baseline, a violation that
+breaks a consumer flow, correct owner attribution, and a conforming correction.
+Formal negative cases cover omitted required behavior, corrupt handoff,
+premature publication, forbidden branching, and incomplete compensation where
+applicable. State which cases apply to the chosen flows and justify any
+inapplicable case before activation. No mock graph execution may substitute
+for the actual product. Preserve the cases for later regression.
+
+### Slice 3 - Minimal action and evidence foundation
+
+Build the common action request, actor/capability check, registered runner,
+timeout/cancel/settlement, artifact capture, and audit path needed by this
+proof. Initial actions execute selected tests, read results, prepare a diff,
+and explicitly accept or reject mapping changes under policy. They do not
+admit autonomous source-writing agents or external delivery mutations.
+
+Ingest results with source snapshot, contract and mapping versions, scenario,
+configuration, runner environment, execution attempt, actor, and artifact
+identity. Validate actual discovery against required cases. Handle duplicates,
+late results, interrupted writes, and restart without fabricating completion.
+Distinguish work progress, execution state, conformance, and delivery state.
+
+Proof checkpoint: a shared-owner violation must fail a real flow gate and
+explain the affected step; a missing result or unauthorized action must also
+fail safely. Review adapter effort and execution cost here before widening UI
+or integration work.
+
+## Phase 4 - Usable Board and Mandatory CI
+
+### Slice 4 - Versions, mappings, and retained obligations
+
+Retain delivered contract versions while a draft evolves under the same flow
+identity. Show scope/output changes and affected consumers. Compare removals
+against the accepted baseline so deleting a required step, test, or mapping
+cannot silently remove protection. Define retirement separately from deletion.
+
+Implement deterministic candidates for rename, move, content change, split,
+merge, deletion, missing selector, and unknown evidence. Candidate acceptance
+checks authorization and current version, records before/after values and
+reason, and invalidates affected conclusions. Lower confidence or unresolved
+identity prevents trusted pass; do not require sophisticated heuristic matching
+to close the phase when an explicit unresolved result is correct.
+
+### Slice 5 - All-flow aggregate and shared truth
+
+Extend the Phase 3 result format with CI ingestion here. Wire a required aggregate
+for every currently supported flow obligation in the activated repository
+scope, including retained completed flows. A trial onboarding only the two
+proof flows must label that coverage explicitly; it cannot claim the whole
+repository is protected. Broader onboarding is a separately bounded migration.
+
+Compare expected cases, observed discovery, execution, outcomes, and provenance.
+Necessary missing, skipped, cancelled, timed-out, zero-match, unresolved, and
+failed results prevent acceptance. Check the actual test outcome even when an
+outer script masks its failure. Verify the provider's required-check and merge
+revision behavior; do not infer enforcement from workflow YAML alone.
+
+Use the accepted base to protect the supported set and gate policy from silent
+weakening in a candidate change. Keep runner credentials outside candidate
+code. Deduplicate equivalent executions and preserve applicable expensive-gate
+guards and checkpoints. Focused local feedback remains available; broad tests
+are not continuously driven by watchers. Complete the minimal recovery and
+bounded process cleanup before claiming this gate reliable.
+
+### Slice 6 - In-board actions and a reproducible trial
+
+Expose the same state and actions through the API, CLI, and one workspace UI.
+Step cards provide test/CI launch, execution progress, artifact and error
+inspection, and retry through the established action owner. Results return to
+the initiating card. Mapping review is an explicit action through that owner.
+
+Provide manager views of goal, current capability, remaining concrete work,
+blockers, and potential versus confirmed downstream impact. A shared read view
+or exported verified snapshot identifies its team baseline and observation time.
+It does not mix developer dirty-worktree results with delivered state. Full
+shared editing and accounts are not required here.
+
+Ship a reproducible local example of success, intentional contract violation,
+CI rejection, and correction, with the supported boundary visible. Document
+how existing tests connect to the example. No paid service or AI provider is
+required to understand and run this core demonstration.
 
 ## Definition of Done
 
-- formal drift cases cover rename, move, change, split, merge, deletion, and
-  unknown evidence;
-- candidate generation is deterministic enough to explain and never mutates
-  formal intent automatically;
-- cross-panel many-to-many propagation is correct;
-- opening or switching panels cannot change canonical truth;
-- dynamic UI and CI consume the same evidence, freshness, and status authority;
-  and
-- representative human and AI workflows demonstrate reduced repo discovery
-  and unnecessary broad test runs.
+- The selected flows contain concrete judgeable implementation steps and
+  preflight rejects the declared invalid handoffs and missing prerequisites.
+- Real runtime cases prove outcomes and required interactions; intentional
+  violations fail the expected gate and identify the canonical owner step.
+- One shared-owner change demonstrates cross-flow regression and recovery;
+  potential impact is not mislabeled as confirmed failure.
+- Missing/zero-match/skipped/partial results cannot pass, even behind a
+  successful wrapper. Mandatory CI behavior is verified for the selected
+  protected source/integration revision and reported scope.
+- Results from different dirty worktrees, changed in-flight source, mismatched
+  contract versions, or late old attempts do not overwrite current truth.
+- Duplicate ingestion and interruption between state/audit writes are safe;
+  restart cannot turn incomplete execution into success.
+- Contract or mapping changes invalidate the appropriate evidence. Removal of
+  required obligations is visible and subject to accepted-baseline policy.
+- Drift cases cover rename, move, content change, split, merge, deletion, and
+  unknown observations without automatic formal mapping mutation.
+- All linked nodes receive evidence updates; panel switching has no effect on
+  truth. UI, CLI, API, and CI produce equivalent explanations.
+- Cards can execute tests and CI, inspect failures, and retry within their
+  declared permissions. Denied actions produce no unauthorized effects.
+- The example can be reproduced by another user and the shared baseline is
+  understandable without manually reconstructing ticket history.
+- The bounded static compatibility gates remain green. No future agent,
+  connector, or commercial capability is required for closure.
 
-## Stop Conditions
+## Exclusions and Stop Conditions
 
-- candidate confidence is treated as authorization to change formal mapping.
-- UI introduces a second status or action owner.
-- watchers continuously rerun broad test suites.
-- completion requires Git mutation, CI release gates, or external adapters
-  reserved for the next plan.
+Autonomous source-writing agents, token-budget enforcement, bidirectional
+ticket/PR mutations, protected delivery actions, full team accounts, hosted
+tenancy, and additional provider families belong to later work. The common
+action policy, minimal audit, strict CI ingestion, and recovery required above
+are not deferred to that work.
 
-## Estimated Duration
+Stop the affected slice if a static/prose check substitutes for behavior,
+the product is simulated instead of exercised, scope or policy weakens itself,
+an ambiguous/absent result can pass, provider status substitutes for required
+case outcomes, or the milestone requires mutation outside its accepted owners.
+Replan within scope after repeated failed implementation iterations.
 
-Approximately 4–7 weeks after the Static Workspace Preview is accepted.
+## Effort and Next Activation
+
+Use the roadmap's low-confidence ranges: 2-4 engineering person-weeks for the
+core proof and another 6-10 for the operational trial under its stated
+assumptions. Record actual adapter and test execution costs at the Phase 3
+checkpoint. Existing Inspector count is not an estimate of behavioral coverage.
+
+The next plan may begin once this plan's conformance, controlled action,
+versioned evidence, and mandatory CI foundation are proven. Agent containment
+and ticket synchronization are outputs of that next plan, not its prerequisites.
 
 ## References
 
 - [Workflow Control Plane Roadmap](flow-inspector-workflow-control-plane-roadmap.md)
+- [Agent Execution and Integrations Plan](flow-inspector-control-plane-actions-and-integrations-plan.md)
 - [Static Workspace 0.2.0 Closure Plan](completed/flow-inspector-static-workspace-0.2.0-closure-plan.md)
+- [Flow Inspector contract](../FLOW_INSPECTOR.md)

--- a/docs/ai/tools/flow-inspector/plans/flow-inspector-workflow-control-plane-roadmap.md
+++ b/docs/ai/tools/flow-inspector/plans/flow-inspector-workflow-control-plane-roadmap.md
@@ -1,390 +1,423 @@
 # Flow Inspector Workflow Control Plane Roadmap
 
-## Status
+## Status and Authority
 
-Approved long-term roadmap. This file owns the cross-phase product direction
-and boundaries; it is not the execution plan for an individual phase and does
-not change the existing Flow Inspector schema or viewer contract.
+Product direction revised on 2026-09-07 following the owner's risk-management
+and open-source objectives. This roadmap owns cross-phase direction and
+boundaries. The two phase plans own delivery scope and acceptance milestones.
+Updating these plans does not activate implementation or claim that the future
+Control Plane is already available.
 
-The first delivery target began as `v0.1.0-preview` and completed static
-`v0.2.0` Phase 2 closure on 2026-08-29.
-It integrates current-project Inspectors behind one sidebar and shared viewer
-without execution state, CI comparison, machine interfaces, or actions. It may
-accompany the current Asyra Framework release wave, but it is optional,
-independently versioned, and never blocks Framework package publication. The
-bounded execution plan is:
-[`flow-inspector-static-workspace-0.2.0-closure-plan.md`](completed/flow-inspector-static-workspace-0.2.0-closure-plan.md).
+Static Workspace `v0.2.0` Phase 2 completed on 2026-08-29. Its read-only schema,
+standalone HTML compatibility, independent versioning, and optional Framework
+release relationship remain unchanged. See the
+[completed static plan](completed/flow-inspector-static-workspace-0.2.0-closure-plan.md).
 
-The preview implementation root is fixed at `tools/flow-inspector/workspace/`.
-The later dynamic product is separately rooted at
-`tools/flow-inspector/control-plane/`. Both are tool-owned and remain outside
-`packages/` and the Framework Changesets publication allowlist. After preview
-validation, extraction to a separate repository remains an explicit future
-decision.
-
-The current static contract remains authoritative for architecture inspection:
-[`../FLOW_INSPECTOR.md`](../FLOW_INSPECTOR.md). That contract intentionally
-excludes execution state, test paths, locks, and closure state. This future plan
-adds a separate workflow control-plane layer that may reference static
-Inspector targets and steps through stable identifiers without turning the
-architecture map into an execution ledger.
+The static workspace remains at `tools/flow-inspector/workspace/`; the dynamic
+service belongs at `tools/flow-inspector/control-plane/`. Neither becomes a
+Framework or App runtime dependency or enters the Framework Changesets
+publication allowlist. Repository extraction and publication remain explicit
+future release decisions.
 
 ## Product Objective
 
-Build an AI-native workflow verification dashboard for humans, AI agents, and
-local or CI automation. The product is not merely a UML viewer or CI report. It
-is a control plane in which each panel represents a governed feature, system,
-or delivery flow and each node exposes the current evidence-backed state,
-applicable work, precise validation actions, failures, and next routes.
+Materialize a Plan as a flow that humans and AI agents can inspect, act within,
+and verify. The primary outcome is controlled development risk: a team can
+delegate bounded work while detecting incompatible plans, scope drift,
+unproductive execution, and damage to previously delivered capabilities.
 
-The product should reduce repeated repository scans and unnecessary full-suite
-runs. A user or agent should be able to inspect persisted, provenance-bearing
-state first, identify the affected nodes and evidence, and run only the actions
-declared for those nodes.
+The product promise spans the complete lifecycle:
 
-## Product Boundaries
+- before implementation, check whether concrete responsibilities and handoffs
+  can satisfy the declared goal;
+- during implementation, expose progress and constrain actions, changes, and
+  resource use to the accepted task;
+- before delivery, require evidence that actual behavior conforms to the flow;
+- after delivery, retain the contract and continuously protect supported
+  capabilities through regression gates; and
+- when requirements change, expose affected steps and contracts before
+  accepting the new scope.
 
-### Static architecture contract
+Managers use the board to understand the goal, available capability, remaining
+work, blockers, and downstream impact. Developers and agents use the same step
+cards to obtain implementation boundaries, run checks, inspect failures, and
+perform supported lifecycle actions. Their completion standard is the same;
+their capabilities may differ according to explicit policy.
 
-The existing Flow Inspector continues to own read-only architecture facts:
+The intended distribution is open source for individuals and companies to try,
+use, and extend. Success is useful risk reduction, understandable guarantees,
+and affordable adoption and maintenance. Payment willingness and monetization
+are not activation or acceptance gates. Licensing, packaging, and publication
+are separate release work, not implied by this planning revision.
 
-- owners, inputs, outputs, routes, predicates, artifacts, invariants, and
-  acceptance contracts;
-- target-owned semantic references and failure ownership; and
-- generic rendering and structural validation independent of runtime state.
+## Product and Architecture Boundaries
 
-It does not own pass/fail status, action execution, test mapping, task progress,
-permissions, notifications, or audit history.
+The materialized Plan is a connected product experience, with distinct owners:
 
-### Workflow control plane
+| Concern                                                                  | Authority                                         |
+| ------------------------------------------------------------------------ | ------------------------------------------------- |
+| Goal, supported behavior, scope, and completion conditions               | Target-owned product specification                |
+| Step responsibilities, routes, inputs, outputs, and failure ownership    | Target architecture Inspector                     |
+| Whether actual behavior satisfies those contracts                        | Target-owned formal tests and behavioral adapters |
+| Task execution, permissions, budgets, evidence, status, and integrations | Tool-owned Control Plane                          |
+| Display and machine access                                               | UI, API, and CLI projections of those authorities |
 
-The future product owns dynamic operational concerns:
+The current [static contract](../FLOW_INSPECTOR.md) remains schema version 2.
+Do not add test paths, execution status, permissions, budgets, or run history
+to it. The Control Plane references stable target and step identities and
+versioned contract sources. The same card may display architecture and work
+state without duplicating ownership or making the static viewer executable.
 
-- panels and operational nodes linked to stable Inspector target/step ids when
-  an architecture contract exists;
-- evidence registry, test registry, node-evidence mapping, result ingestion,
-  freshness, and derived node status;
-- typed actions, execution lifecycle, permissions, confirmations, artifacts,
-  and audit events;
-- machine-readable API, JSON, and CLI surfaces; and
-- a local UI and optional external-system adapters.
+Existing product runtimes perform product behavior. Test-side adapters observe
+their public boundaries; the Control Plane does not reimplement the product or
+require production packages to import the tool. A workflow without an
+architecture Inspector may be represented operationally, but must not claim
+architecture or behavioral conformance without the corresponding contract and
+proof. Existing legacy Inspectors remain visibly distinct during adoption.
 
-A control-plane panel may also represent a workflow that has no Flow Inspector
-architecture target. It must not fabricate architecture ownership in order to
-gain operational features.
+## Flow and Step Model
 
-## Core Product Model
+### Concrete work with a stable goal
 
-### 1. Panel graph
+A flow has a stable identity, a goal and beneficiary, a responsible owner,
+accepted scope, completion conditions, and explicit versions. It can describe
+a feature, a system capability, or a delivery workflow. Relevance to its goal
+alone does not authorize adding work to the current scope.
 
-- Each panel governs one feature, system, task family, or delivery flow.
-- Nodes have stable ids, types, descriptions, prerequisites, and supported
-  actions.
-- Directed routes may move forward, branch, converge, terminate, or return to
-  an earlier node when an explicit condition fails.
-- Graph state describes operational progress; it must not redefine product
-  semantics or architecture ownership.
-- A workspace-level service loads multiple panels. The architecture must not
-  require one server or watcher per panel.
+Each step card represents a concrete implementation responsibility with a
+judgeable outcome. A stage heading containing unrelated tickets is not a
+substitute for a step. A card identifies:
 
-### 2. Evidence graph
+- its semantic owner and assigned human or agent;
+- inputs, their producers, preconditions, and permitted bypasses;
+- behavior to implement and the allowed implementation boundary;
+- required outputs, consumers, forbidden behavior, and failure ownership;
+- completion conditions and the formal evidence that proves them; and
+- available actions, current work, and relevant execution limits.
 
-- Tests, visual reviews, logs, screenshots, profiles, artifacts, manual
-  confirmations, and CI results are typed evidence.
-- Nodes and evidence have a many-to-many relationship. One node may require
-  several tests, and one test may affect several nodes across panels.
-- Test and evidence results are workspace events, not properties of whichever
-  panel happens to be open in the UI.
-- A panel is a projection of the global evidence store plus its declared
-  mappings and freshness policy.
-- Every usable result records provenance such as source revision, branch,
-  command/action, timestamp, actor, environment, and artifact references.
+The granularity is the smallest useful responsibility whose handoff and outcome
+can be judged, not every internal function. Tickets may link to a step, but do
+not define its product semantics. Views may group steps for readability without
+losing their individual implementation contracts.
 
-### 3. Registries and mappings
+### Relationships and feasibility
 
-The model separates identity, intent, and observation:
+Relationships distinguish implementation prerequisites, runtime handoffs,
+shared capabilities, and shared evidence. A runtime loop is not automatically
+a work-scheduling dependency cycle. Routes define conditional connectivity;
+visual order alone does not determine execution.
 
-- the test/evidence registry gives each runnable or ingestible item a stable
-  identity and selector;
-- panel links declare which evidence protects or informs which nodes and the
-  link role, such as required, primary, regression signal, or advisory;
-- observation state records what the latest runner actually discovered and
-  executed; and
-- mapping candidates record probable rename, move, split, merge, or newly
-  observed relationships without silently rewriting declared intent.
+Preflight checks detect missing producers, incompatible handoffs, conflicting
+owners, unhandled failure or bypass routes, and unsatisfied prerequisites where
+these are formally expressible. Concurrent interactions use declared causal
+constraints rather than one assumed total event order. Unresolved feasibility,
+performance, or external-system assumptions remain visible and require a
+bounded experiment or review before dependent work can advance.
 
-Test files do not need to know about panels. Panel owners own their evidence
-requirements and links; test owners own stable registry identity and runnable
-selectors; tooling validates both sides.
+An upstream change identifies potentially affected consumers. A potentially
+affected flow, a confirmed failing flow, and blocked implementation work are
+different conclusions and must explain their evidence. Shared test membership
+alone does not prove a runtime dependency.
 
-Formal mappings cannot be changed automatically from a low-confidence guess.
-Human or AI acceptance is an explicit action with before/after values, actor,
-reason, confidence, and audit identity. Unmapped observations remain isolated
-as unmapped evidence or candidates and cannot silently affect panel health.
+### Progress, conformance, and delivery
 
-### 4. Derived node status
+Keep separate dimensions for work progress, behavioral verification, execution
+lifecycle, dependency blockage, and delivery availability. A passing test does
+not imply that a PR is merged or a capability is deployed. Counts of completed
+cards do not alone establish that a flow is usable.
 
-Node status is derived from declared requirements, current mappings, evidence
-freshness, route conditions, and execution results. It is not a manually
-maintained green/red flag.
+Verification retains `passed`, `failed`, `stale`, `unknown`, `needs-review`, and
+`blocked` with explicit reasons and provenance. A flow passes only when every
+applicable required condition has current successful evidence. Before coding,
+the product specification must define aggregation for conflicting states,
+conditional branches, empty requirements, retries, skipped or partial results,
+and simultaneous failure and blockage. Preserve all relevant causes; a display
+precedence rule must not hide a failure or turn an unverified result into pass.
 
-The minimum status vocabulary is:
+Managers and developers read the same selected source and contract version.
+Draft work, a delivered baseline, and current deployed availability must remain
+distinguishable, with observation times and unresolved evidence shown.
 
-- `passed`: all required evidence is current and successful;
-- `failed`: current required evidence contains a relevant failure;
-- `stale`: previously valid evidence is no longer trustworthy for the current
-  source, configuration, mapping, or dependency state;
-- `unknown`: required evidence has not been observed or cannot be resolved;
-- `needs-review`: mapping drift, ambiguous evidence, or an explicit review gate
-  prevents a trusted conclusion; and
-- `blocked`: a prerequisite, permission, dependency, or route condition
-  prevents the node from advancing.
+## Executable Contract Verification
 
-Every status response must explain why it was derived and identify the
-evidence, source identity, and policy involved. A passed status without current
-provenance is not valid.
+The central guarantee is implementation conformance to the flow, not merely
+that a list of associated tests ran. Three complementary layers are required:
 
-### 5. Typed action registry
+1. Structural validation checks identities, ownership, routes, and artifact
+   compatibility in the declared model.
+2. Behavioral tests exercise the real product and check completion conditions,
+   boundary inputs, invalid inputs, and failure outcomes.
+3. Boundary observations prove required interactions, handoffs, causal order,
+   and forbidden effects when final output alone cannot prove the contract.
 
-Nodes expose actions through stable action ids and typed registry entries, not
-arbitrary shell strings embedded in UI configuration. Initial action families
-may include:
+Prose matching, file existence, successful mock output, or emitting a step name
+is insufficient behavioral evidence. Natural-language conditions do not become
+reliable predicates automatically. Target owners supply bounded executable
+cases and independent expected outcomes using existing test runners where
+appropriate. Do not generate both expected and actual behavior from the same
+implementation logic, or simulate the declared graph in place of exercising
+the product.
 
-- focused test or evidence execution;
-- opening a source, specification, link, result, or artifact;
-- synchronized visual review;
-- notification and external-tool synchronization;
-- mapping candidate accept/reject/reconcile;
-- Git diff or review preparation; and
-- explicitly protected commit, push, release, or deployment gates.
+The first proof must deliberately violate representative contracts: omit a
+required step, corrupt a handoff, publish too early, take a forbidden branch,
+or leave a rollback incomplete. The corresponding real behavioral gate must
+fail and identify the responsible step. Keep these negative proofs in formal
+project-owned tests. Focused fault injection or mutation checks may support
+this proof without requiring a new third-party testing package.
 
-Every action declares its type, inputs, runner, risk level, required
-capabilities, timeout, cancellation behavior, confirmation policy, expected
-outputs, affected panels/nodes, and audit requirements. Dangerous external or
-Git mutations retain their own explicit authorization boundaries; a panel
-button does not constitute advance authorization.
+Existing tests may be reused when they prove the actual contract. Add missing
+interaction cases instead of duplicating equivalent tests. Code coverage alone
+cannot waive required behavioral proof. Guarantees apply to declared supported
+behavior, cases, environments, and observation boundaries; the UI must expose
+unverified portions rather than claim exhaustive proof of arbitrary behavior.
 
-Action execution produces evidence and audit events through the same ingestion
-boundary as CLI or CI execution. UI and AI clients call the registry contract;
-neither may bypass it to execute arbitrary commands.
+## Evidence, Versions, and CI Enforcement
 
-### 6. Mapping reconciliation
+### Evidence identity and ingestion
 
-Result ingestion compares observed evidence identity with the formal registry
-and links. Rename, move, content change, split, merge, missing selector, or
-unknown test observations produce status updates and mapping candidates.
+Test/evidence identities, executable selectors, node mappings, and observed
+results remain separate. Test owners own selectors and observations; target
+owners own requirements. Links may be required, primary, regression signals,
+or advisory, with many-to-many propagation across flows.
 
-Reconciliation may run after evidence execution, during validation, at task
-closeout, before a protected Git/release action, in CI, or through an explicit
-UI/CLI action. Candidate generation may be automatic; formal mapping mutation
-must be explicit and auditable.
+A result binds to the repository and actual source snapshot, contract version,
+mapping version, scenario and selector, relevant configuration and dependencies,
+runner environment, execution attempt, actor, and immutable artifact identity.
+A commit and branch name alone cannot identify two different dirty worktrees.
+Source changes during execution invalidate attribution unless the run uses an
+isolated immutable snapshot. Old successes remain historical evidence.
 
-### 7. Integrations
+Ingestion must validate provenance, deduplicate deliveries, handle out-of-order
+attempts, and prevent a late old success from replacing a newer relevant
+failure. Results, accepted mapping changes, and their audit records must remain
+consistent across crashes. Incomplete writes and unresolved execution outcomes
+cannot produce pass. Minimal recovery is part of the first evidence owner;
+large-workspace optimization follows profiling later.
 
-Slack, Jira, Linear, GitHub, Teams, email, CI providers, and similar systems are
-adapters, not panel truth owners. They may receive events and return auxiliary
-delivery or task-link state, but canonical node status remains derived from the
-control plane's evidence and mapping contracts.
+Rename, move, split, merge, deletion, changed content, and unknown observations
+produce explainable mapping candidates. Acceptance is explicit, authorized,
+version-checked, and auditable; confidence does not authorize a mutation.
+Changing a mapping invalidates dependent conclusions. Unmapped evidence cannot
+silently contribute to passing a flow.
 
-Outbound integration uses an outbox with retry, deduplication, delivery state,
-and audit history. Secrets are referenced indirectly and never stored in panel
-configuration or result payloads.
+### Evolving and retaining flows
 
-### 8. AI and human surfaces
+Retain immutable delivered contract versions and validation records while new
+work evolves under the same flow identity. Additions, removals, splits, merges,
+and changed outputs must show changed obligations and affected consumers before
+acceptance. A requirement change is distinct from a fix that restores existing
+behavior, and is subject to its own scope authority.
 
-The stable machine-facing surface is at least as important as the graphical
-surface. API/JSON/CLI contracts should support:
+Compare the proposed contract and required-case set against the accepted base.
+Deleting a step, test, selector, or mapping must not silently shrink regression
+protection. An agent cannot authorize its own scope expansion or weaken its
+completion policy to obtain a green result. Approved revisions invalidate or
+reverify affected evidence; unrelated valid evidence may remain applicable only
+under a proven equivalence policy.
 
-- get workspace or panel state;
-- explain one node's status and provenance;
-- find affected nodes for changed files, tests, or evidence;
-- list required or recommended actions;
-- run a declared node action and observe its lifecycle;
-- submit or ingest evidence; and
-- inspect and resolve mapping candidates.
+All completed flows remain available historically. Every currently supported
+delivered contract participates in regression, including completed work outside
+the task at hand. Explicit retirement preserves history and records why a
+contract leaves the supported set. Historical versions are not all assumed to
+be simultaneously supported on the current source.
 
-The UI presents the graph, current status, causes, provenance, available
-actions, execution progress, artifacts, and cross-panel impact. It must not
-derive different truth merely because a different panel is open.
+### All-flow delivery gate
 
-## Permission-Shaped Architecture
+CI ingestion and a mandatory all-flow aggregate check belong to the first
+usable Control Plane, not a later integration-only phase. The aggregate checks
+the entire declared supported set at protected delivery checkpoints. Focused
+step runs provide development feedback but cannot substitute for this gate.
 
-Version 1 may assume a single trusted local user, but it must not assume the
-absence of permissions. Every action, event, and result must be shaped for
-future policy enforcement with actor identity and type, source, capabilities
-used, confirmation record, secret references used, and audit id.
+The gate compares expected cases with actual discovery, execution, and verdicts
+on the intended source or integration revision. Missing results, zero matched
+required tests, accidental skips, cancellation, timeout, invalid provenance,
+unresolved required mappings, and failed assertions all prevent acceptance.
+Do not trust only shell exit codes, a provider's green job, or a skipped check.
+Required aggregate execution and repository protection must be verified for
+the selected CI provider, including combined changes when that is required.
 
-The execution path remains:
+The verifier and authorization policy used to admit a change must not be
+silently weakened by that same change. Isolate candidate code from service
+credentials and evaluate contract or gate-policy changes against the accepted
+base and its authorization rules. CI failure means repair the implementation
+or explicitly revise the requirement; it never automatically approves either.
+
+All-flow means every applicable supported flow obligation, not unlimited
+enumeration of every input and interleaving. Define supported scenarios and
+environment coverage explicitly. Deduplicate equivalent executions under the
+same inputs; honor required expensive gates at their defined checkpoints.
+Watchers update state without continuously rerunning broad suites. Selecting
+only changed tests is an optimization that cannot silently omit required flows.
+
+## Bounded Human and Agent Execution
+
+Every admitted task binds a flow version and owner step to its goal, mutation
+scope, prerequisites, expected outputs, permitted actions, actor capabilities,
+validation requirements, resource limits, and stop conditions. Readiness to
+begin implementation differs from having already passed completion tests.
+
+The common execution path is:
 
 ```text
-request action
--> resolve actor
--> evaluate capabilities and risk
--> resolve connector secret references when applicable
--> obtain required confirmation
--> execute through the registered runner
--> ingest evidence and status effects
--> append audit event
+select contract version and concrete step
+-> check readiness and affected boundaries
+-> bind task scope, actor, capabilities, and budgets
+-> obtain any required authorization
+-> execute through controlled tools and runners
+-> observe progress, resource use, and boundary violations
+-> stop, replan, or hand off when limits or prerequisites fail
+-> verify actual behavior and the required supported-flow regression set
+-> accept an authorized delivery and retain its evidence
 ```
 
-Version 1 may use `local-trusted` policy while retaining this path. A future
-team version may add RBAC, shared workspaces, data visibility, remote runners,
-and organization connector policies without replacing action or evidence
-identity.
+Typed actions declare inputs, runner, effects, capabilities, timeout,
+cancellation, outputs, and audit requirements. UI, CLI, and agents invoke the
+same service contract. Scope enforcement must cover actual filesystem, process,
+network, and credential access through the supported runner. A prompt, an
+allowlist displayed on a card, or a post-run diff alone is not enforcement.
+Unrestricted agent tools outside that boundary cannot be advertised as a
+controlled execution mode. Repository and connector content is input data, not
+authority to grant permissions.
 
-## Freshness and State Rules
+Budgets may cover elapsed time, tokens, tool calls, attempts, and concurrency.
+They accumulate across retries and handoffs. Unsupported or unavailable usage
+measurement must be explicit; do not claim a hard token bound from missing
+telemetry. Stop admission before the next operation exceeds its allowance and
+define cancellation bounds for in-flight operations. Agent progress means
+reviewable artifacts and completed checks, not self-reported completion,
+changed-line counts, or token consumption.
 
-Freshness policy must be designed before a passed state can be trusted. Inputs
-may include source revision, relevant file ownership, dependency changes,
-action configuration, test content fingerprints, panel configuration, mapping
-version, runner environment, and artifact identity.
+Repeated failure, stalled progress, changed assumptions, scope expansion, or
+budget exhaustion triggers bounded replanning or a human handoff. Preserve
+partial work, failures, consumed budget, and next required decisions. Stopping
+must settle owned processes before success, cleanup, or restart is claimed.
+Recovery acts only on task-owned changes; external side effects need explicit
+compensation or human resolution and cannot be assumed rollbackable.
 
-The service reads persisted config, result, mapping, artifact metadata, and
-bounded source-control state by default. It does not continuously rerun tests.
-Tests and visual reviews run only through explicit actions, CLI, CI, or another
-declared automation trigger.
+Trust is task-specific evidence plus enforceable boundaries and explicit
+policy. Past success does not grant an agent unrestricted authority. Higher
+autonomy may be allowed for reversible work with adequate protection, while
+commit, push, release, deployment, and external communication retain their
+applicable authorization boundaries. Standing authorization remains reusable
+within its scope; repeated confirmation is not a substitute for enforcement.
 
-## Proposed Product Surfaces
+## Board, Machine Surfaces, and Integrations
 
-- **Config/schema:** panels, nodes, routes, evidence registry, links, actions,
-  policies, connectors, and stable Inspector references.
-- **State store:** observations, results, derived status inputs, candidates,
-  execution records, artifacts, outbox entries, and audit events.
-- **Core service:** validation, ingestion, reconciliation, freshness, status
-  derivation, action dispatch, and event publication.
-- **CLI/API:** deterministic machine-facing inspection and execution contract.
-- **Workspace dev server:** one local process serving multiple panels and live
-  result updates.
-- **Web UI:** graph exploration, explanation, focused actions, review, and
-  artifact access.
-- **Adapters:** optional CI, source-control, task-tool, and communication
-  integrations outside the core truth model.
+One workspace service owns evidence and state for all panels. UI, API, and CLI
+support step context, contract differences, affected flows, status explanation,
+available actions, execution progress, budgets, artifacts, and handoff state.
+Opening a panel never changes canonical truth. UI updates should subscribe to
+affected state rather than rebuild every panel on every event.
 
-## Version 1 Scope
+Cards provide test and CI actions with progress, results, failure explanation,
+and retry in the board. Supported ticket and PR operations also return their
+outcomes to the originating step. Links remain useful for unsupported actions,
+but link-only navigation does not satisfy an in-board action's acceptance.
 
-Version 1 should prove the control-plane value with:
+Ticket providers may own assignment and ticket workflow fields; Git providers
+own PR facts; runners own execution observations. The Control Plane derives
+flow conformance from registered evidence. Define field ownership and incoming
+updates, stale data, deletion, permission loss, and concurrent edits explicitly.
+Ticket completion never overrides failing behavioral evidence.
 
-- panel graph configuration and conditional routes;
-- stable node, evidence, test, command, and action ids;
-- test registry and node-test many-to-many links;
-- result ingestion with provenance;
-- freshness and derived statuses;
-- mapping drift detection and candidate reconciliation;
-- focused test, open-link, visual-review, and review actions through the typed
-  registry;
-- machine-readable CLI/API/JSON;
-- one workspace-level local service and a functional status/action UI;
-- local-trusted capability checks, confirmation boundaries, and audit log; and
-- validation for broken ids, stale selectors, missing required evidence, and
-  unsafe action declarations.
+Outbound operations use durable outbox entries, bounded retries, deduplication,
+and observable delivery state. Avoid synchronization loops and duplicate
+external effects. Secrets are indirect references and are redacted from logs,
+public state, and artifacts. Connector failure is shown as an integration or
+required-evidence problem; it cannot fabricate a product pass or failure.
 
-Version 1 does not require complete team RBAC, hosted multi-tenancy, a plugin
-marketplace, arbitrary workflow automation, or every external integration.
+Early shared viewing must identify the same team baseline and observation time.
+Full team accounts, remote execution, hosted tenancy, and enterprise policy can
+follow separately. The local proof must not be marketed as complete team
+coordination or containment of processes it does not control.
 
-## Version 2 Candidates
+## Delivery Sequence and Effort
 
-- team accounts, roles, workspace policies, and data visibility;
-- remote and organization-managed runners;
-- shared review and approval workflows;
-- production-grade task, source-control, CI, and communication adapters;
-- organization secret and connector lifecycle management;
-- hosted synchronization and retention policies; and
-- richer cross-panel portfolio and total-release views.
+| Delivery  | Owning plan                           | Required result                                                                                    |
+| --------- | ------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Phase 0-2 | Completed static plan                 | Read-only workspace and preserved standalone entries                                               |
+| Phase 3   | Contract Verification and CI Plan     | Two related flows, real conformance checks, negative proofs, and minimal controlled actions        |
+| Phase 4   | Contract Verification and CI Plan     | Usable board, common API/CLI, versioned evidence, mandatory CI aggregate, and shared baseline view |
+| Phase 5   | Agent Execution and Integrations Plan | A bounded agent task with enforced scope, budgets, stopping, recovery, and handoff                 |
+| Phase 6   | Agent Execution and Integrations Plan | Small-team use, selected ticket/PR integration, and reproducible open-source adoption              |
 
-## Delivery Sequence
+Minimal action authorization, runner lifecycle, audit, CI ingestion, and crash
+consistency are implemented in Phase 3-4. Phase 5 extends that foundation; its
+entry criteria cannot depend on agent controls that it has yet to build.
+Phase 6 hardens and expands proven controls rather than first introducing them.
 
-Implementation is split into three independently closable plans:
+The preliminary estimate is 2-4 engineering person-weeks for the core proof,
+another 6-10 for an operational trial, and another 8-14 for a bounded agent and
+small-team trial. These are low-confidence planning ranges, not calendar
+commitments. The agent runner's actual containment and telemetry capabilities
+must be measured before retaining the last range. Assumptions are a familiar
+TypeScript codebase, one repository, existing test runners, one CI provider,
+one agent backend, and one ticket provider. Full existing-flow onboarding,
+additional languages/providers, hosted tenancy, and enterprise capabilities
+are excluded. Re-estimate after Phase 3 from observed integration and test cost.
 
-1. **Static Workspace Preview Plan — Phase 0 through Phase 2**
-   - current-project Inspector inventory and catalog contract;
-   - one static workspace shell with sidebar, search, dynamic routing, deep
-     links, and selected-target isolation; and
-   - complete static integration while preserving standalone HTML entries.
-   - Release target: independently versioned static `v0.2.0` optional
-     companion to the current Asyra Framework release wave.
-2. **Evidence, Reconciliation, and CI Plan — future Control Plane**
-   - test/evidence mapping, result ingestion, provenance, freshness, dynamic
-     status, mapping reconciliation, and cross-panel propagation; and
-   - API/CLI, dynamic workspace projection, and gradual CI enforcement.
-3. **Actions, Delivery, and Integrations Plan — future Control Plane**
-   - typed test, visual, Git, and delivery actions with permission, execution,
-     confirmation, and audit boundaries; and
-   - outbox-based external adapters, security hardening, and team readiness.
+Separate platform cost, per-flow behavioral-adapter cost, and ongoing CI and
+connector cost. Do not infer migration effort from the number of existing
+cards or from passing static contract tests. Prior estimates of 4-7 weeks per
+deferred plan are superseded by this staged, assumption-bound estimate.
 
-The second plan starts only after the Static Workspace acceptance gates pass.
-The third starts only after dynamic evidence, reconciliation, and CI truth are
-proven. Completing or activating a later plan must not silently expand an
-earlier plan.
+## Activation Decisions and Readiness
 
-## Required Activation Decisions
+Before the first implementation owner slice, select and document:
 
-Before dynamic Control Plane implementation begins, decide:
+- a thin product specification, exact Control Plane architecture Inspector,
+  supported cases, bounded DoD, and owner implementation boundaries;
+- two related real flows and the smallest shared owner that can demonstrate a
+  cross-flow regression, including their existing behavioral test entry points;
+- supported runtime, persistence, source snapshot, artifact retention, and
+  result ordering contracts for the local proof;
+- the first test runner and CI provider, supported scenarios, required-case
+  discovery, aggregate gate wiring, and accepted-baseline policy;
+- initial typed actions, capability enforcement, cancellation and recovery
+  boundaries, with autonomous source-writing agents excluded until Phase 5; and
+- measurable workspace scale and latency/resource budgets for each checkpoint.
 
-- the product/package name, supported runtime environments, and persistence
-  backend;
-- which panel nodes link directly to Flow Inspector steps and which remain
-  operational-only;
-- the exact freshness oracle and changed-file/dependency impact model for v1;
-- the initial action types and which actions are intentionally unsupported;
-- local process and trust boundaries for command execution;
-- the minimum visual-review integration and artifact retention contract; and
-- whether CI ingestion is required for v1 or follows the local proof.
+Later activation selects the agent backend, enforceable budgets and tool
+boundary, shared access model, ticket operations, and open-source packaging.
+Decide persisted identities and compatibility before introducing producers.
+Read the applicable Inspector before each implementation segment, work one
+owner at a time, and test-first every behavioral mismatch. Do not create
+readiness ledgers or extra assertion registries to substitute for executable
+product cases. Activation records a bounded task; it does not authorize all
+future integrations, runtime changes, dependencies, or publication.
 
-## Activation Prerequisites
+## Acceptance and Stop Conditions
 
-- the static `tools/flow-inspector/workspace/` and dynamic
-  `tools/flow-inspector/control-plane/` ownership boundary remains intact;
-- a fresh bounded implementation plan based on the chosen repository's current
-  state;
-- a product specification with supported, boundary, invalid, stale, and
-  permission-denied cases;
-- an exact architecture Inspector for the new service itself, without placing
-  operational status inside Flow Inspector schema version 2;
-- formal contract tests for schema validation, mapping, freshness, status
-  derivation, action authorization, and audit behavior; and
-- threat modeling for local command execution, secrets, artifacts, and future
-  external adapters.
+Phase plans provide the executable acceptance cases. The overall product must
+demonstrate preflight detection, controlled task execution, real conformance,
+supported-flow regression, versioned change, and reproducible adoption.
+Measure manual intervention, rework, escaped regressions, ineffective resource
+consumption, and contract-maintenance effort on representative tasks. A
+baseline and a fixed observation period are required before claiming savings.
 
-## Stop Conditions
+Stop the affected delivery if any of these remains possible:
 
-- UI or AI clients can execute arbitrary shell commands outside the action
-  registry.
-- A passed state can be produced without current provenance.
-- Mapping guesses can silently change formal links or panel health.
-- Opening a panel changes the evidence or status truth being reported.
-- External task or communication tools become the canonical state owner.
-- The implementation mixes static Inspector architecture semantics with
-  dynamic execution state in schema version 2.
-- A dangerous Git, release, deployment, or connector action bypasses explicit
-  authorization, confirmation, secret, or audit boundaries.
-- The proposed watcher or server model reruns broad validation continuously and
-  defeats the product's resource-saving objective.
-
-## Future Definition of Done
-
-A binding Definition of Done must be written after activation decisions. At a
-minimum, v1 must prove:
-
-- deterministic schema validation and graph routing;
-- correct many-to-many evidence propagation across nodes and panels;
-- trustworthy freshness, stale, unknown, needs-review, blocked, failed, and
-  passed derivation with explainable provenance;
-- safe focused execution exclusively through typed registered actions;
-- deterministic candidate generation and explicit mapping reconciliation;
-- equivalent truth through UI, CLI, API, and result ingestion paths;
-- local-trusted permission flow with confirmations and complete audit events;
-- isolated adapter failure with reliable outbox behavior for any shipped
-  integration; and
-- measurable reduction in unnecessary repository discovery or broad test runs
-  for representative AI and human workflows.
+- a prose check or associated-test list is presented as behavioral proof;
+- a necessary step contradiction is hidden or unverified behavior is shown
+  delivered;
+- an actor can expand scope, weaken its gate, or escape the declared controls;
+- missing, skipped, stale, or incorrectly attributed evidence produces pass;
+- removing obligations silently shrinks the supported regression set;
+- retries or handoffs reset budgets, or stopped work continues untracked;
+- a UI or connector becomes a second conformance owner;
+- dynamic state leaks into schema version 2 or product runtimes depend on the
+  Control Plane; or
+- completing the milestone requires unbounded scope beyond its phase contract.
 
 ## References
 
 - [Static Workspace 0.2.0 Closure Plan](completed/flow-inspector-static-workspace-0.2.0-closure-plan.md)
-- [Evidence and CI Plan](flow-inspector-control-plane-evidence-and-ci-plan.md)
-- [Actions and Integrations Plan](flow-inspector-control-plane-actions-and-integrations-plan.md)
+- [Contract Verification and CI Plan](flow-inspector-control-plane-evidence-and-ci-plan.md)
+- [Agent Execution and Integrations Plan](flow-inspector-control-plane-actions-and-integrations-plan.md)
 - [Flow Inspector contract](../FLOW_INSPECTOR.md)
+- [Static Workspace contract](../STATIC_WORKSPACE.md)
 - [Framework Architecture](../../../framework/ARCHITECTURE.md)
 - [Framework Workflow](../../../framework/WORKFLOW.md)
 - [Bounded task scope and closure](../../../framework/rules/bounded-task-scope-and-closure.md)
 - [Inspector contract readiness](../../../framework/rules/inspector-contract-readiness.md)
+- [Inspector step execution](../../../framework/rules/inspector-step-execution.md)


### PR DESCRIPTION
Flow Inspector should materialize a Plan as concrete implementation steps with verifiable contracts, so teams can understand delivery progress and delegate work to humans and AI agents with controlled risk.

This revision updates the existing roadmap, two phase plans, and plan index around that product objective. It defines real behavioral conformance and cross-flow regression as the basis for trust, then sequences bounded execution and everyday developer operations on the same board.

## Changes

- Define concrete step responsibilities, manager/developer views, contract evolution, retained supported flows, and explicit ownership of architecture, execution state, and evidence.
- Sequence Phases 3-4 around two related real flows, negative proofs, minimal controlled actions, versioned evidence, an operational board, and mandatory CI for the declared supported flow set.
- Sequence Phases 5-6 around enforceable agent scope and permissions, cumulative resource budgets, stopping and handoff, small-team use, and ticket/PR integrations.
- Add acceptance cases, activation decisions, and provisional implementation estimates. Open-source usefulness and reproducibility guide success criteria.

## Scope and review

The change contains four planning documents and the required empty Changeset record, which assigns no package release versions. Implementation remains deferred; the completed static v0.2.0 contract and runtime are unchanged. Existing plan filenames remain stable.

Review the roadmap for product boundaries, then the verification/CI plan for the first proof milestone and the agent/integrations plan for delegation controls. Effort estimates remain provisional and must be recalibrated after the core proof.

## Validation

- Scoped Prettier check: passed.
- All 26 relative document links and referenced anchors: passed.
- Staged diff whitespace check: passed.
- Confirmed all four planning files match the reviewed source-workspace versions exactly.
- Changeset PR gate: reproduced the original missing-record failure, then passed after adding the required record.
- Changeset gate regression tests: 5 passed. The Changesets parser confirms an empty release list.

GitHub checks passed on `3e31428b4`: validate, Framework release readiness, general E2E, collaboration E2E, and both Vercel previews. Runtime tests were not rerun locally for this documentation-only change.

