### PR TITLE
Complete M3 formal analysis acceptance and plan M3.5 workflow usability

### DIFF
--- a/.changeset/sim-formal-analysis-acceptance.md
+++ b/.changeset/sim-formal-analysis-acceptance.md
@@ -1,0 +1,4 @@
+---
+---
+
+Complete private Asyra Sim M3 formal analysis acceptance and record the planned M3.5 workflow usability milestone. No versioned package is affected.

--- a/apps/asyra-sim/e2e/__tests__/formal-outcomes.spec.ts
+++ b/apps/asyra-sim/e2e/__tests__/formal-outcomes.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test, type Page } from '@playwright/test'
+import { MethodIds, MethodVersions } from '../../src/constants'
+
+async function createSphereStudy(
+  page: Page,
+  distance: string,
+  threshold: string
+) {
+  await page.goto('/')
+  await expect(page.getByRole('status')).toHaveText('Local runtime ready')
+  await page.getByRole('button', { name: 'New workcell', exact: true }).click()
+  for (const [name, x, role] of [
+    ['Primary sphere', '0', 'tool'],
+    ['Obstacle sphere', distance, 'fixture']
+  ]) {
+    await page.getByRole('button', { name: 'Add fixture', exact: true }).click()
+    await page.getByLabel('Object name').fill(name)
+    await page.getByLabel('Object name').press('Enter')
+    await page.getByLabel('Body role').selectOption(role)
+    await page.getByLabel('Mount position (m) X', { exact: true }).fill(x)
+    await page
+      .getByLabel('Mount position (m) X', { exact: true })
+      .press('Enter')
+    await page.getByLabel('Shape 1 type').selectOption('sphere')
+    await expect(page.getByLabel('Shape 1 radius (m)')).toHaveValue('0.1')
+  }
+  await page.getByRole('button', { name: 'Experiments', exact: true }).click()
+  await page.getByLabel('Experiment name').fill('Formal sphere study')
+  await page
+    .getByLabel('Analysis method')
+    .selectOption(
+      `${MethodIds.ORIGINAL_PART_CLEARANCE}@${MethodVersions.ORIGINAL_PART_CLEARANCE}`
+    )
+  await page.getByLabel('Minimum clearance (mm)').fill(threshold)
+  await page.keyboard.press('Tab')
+  await page.locator('summary').filter({ hasText: 'Analysis scope' }).click()
+  await page.getByLabel('Primary sphere analysis role').selectOption('primary')
+  await page
+    .getByLabel('Obstacle sphere analysis role')
+    .selectOption('influencing')
+  await page.getByLabel('Primary-to-influencing collision').check()
+  await page.locator('summary').filter({ hasText: 'Analysis scope' }).click()
+  await page
+    .getByRole('button', { name: 'Create experiment', exact: true })
+    .click()
+}
+
+for (const [outcome, distance, threshold, coverage, label, verdict] of [
+  [
+    'collision',
+    '0.15',
+    '20',
+    'complete',
+    'Collision - established penetration',
+    'does not meet'
+  ],
+  [
+    'clearance',
+    '0.21',
+    '20',
+    'complete',
+    'Clearance violation',
+    'does not meet'
+  ],
+  ['clear', '1', '20', 'complete', 'No issue within interval', 'meets'],
+  ['unresolved', '0.2', '0', 'partial', 'Unresolved', 'cannot determine']
+]) {
+  test(`ordinary original method exposes ${outcome} and replays the same retained evidence`, async ({
+    page
+  }, info) => {
+    await createSphereStudy(page, distance, threshold)
+    await page
+      .getByRole('button', { name: 'Run formal analysis', exact: true })
+      .click()
+    const result = page.getByTestId('analysis-result')
+    await expect(result.getByLabel('User verdict')).toHaveText(verdict)
+    await expect(
+      result
+        .locator('.result-grid > div')
+        .filter({ has: page.getByText('Execution', { exact: true }) })
+        .locator('dd')
+    ).toHaveText('completed')
+    await expect(
+      result
+        .locator('.result-grid > div')
+        .filter({ has: page.getByText('Coverage', { exact: true }) })
+        .locator('dd')
+    ).toHaveText(coverage)
+    await expect(page.locator('.retention-actions')).toContainText(
+      'Retained in this project'
+    )
+    const pair = result.locator('.evidence-pair')
+    await pair.locator('summary').click()
+    await expect(pair).toContainText(label)
+    await expect(pair).toContainText('Witness time: 0 s')
+    const retainedText = await result.innerText()
+    const history = await page.getByTestId('history-depth').innerText()
+    await pair
+      .getByRole('button', { name: 'Replay witness', exact: true })
+      .click()
+    await expect(page.locator('.viewport-summary')).toContainText(
+      'Historical run replay - 0.0000 s'
+    )
+    await page.getByRole('button', { name: 'Fit all', exact: true }).click()
+    await pair.scrollIntoViewIfNeeded()
+    await page.screenshot({ path: info.outputPath(`${outcome}-overview.png`) })
+    await pair.screenshot({ path: info.outputPath(`${outcome}-detail.png`) })
+    if (outcome === 'clearance') {
+      await page
+        .getByRole('button', { name: 'Switch to dark mode', exact: true })
+        .click()
+      await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark')
+      await page.setViewportSize({ width: 600, height: 960 })
+      await pair.scrollIntoViewIfNeeded()
+      await expect(
+        pair.getByRole('button', { name: 'Replay witness', exact: true })
+      ).toBeVisible()
+      await page.screenshot({
+        path: info.outputPath('clearance-dark-narrow.png')
+      })
+      await pair.screenshot({
+        path: info.outputPath('clearance-dark-narrow-detail.png')
+      })
+    }
+    expect(await result.innerText()).toBe(retainedText)
+    await expect(page.getByTestId('history-depth')).toHaveText(history)
+    await info.attach('review-state.json', {
+      contentType: 'application/json',
+      body: JSON.stringify({
+        url: page.url(),
+        viewport: page.viewportSize(),
+        dpr: 1,
+        camera: 'Fit all',
+        outcome,
+        sphereRadiusM: 0.1,
+        centerDistanceM: Number(distance),
+        thresholdMm: Number(threshold),
+        independentGapM: Math.max(0, Number(distance) - 0.2),
+        result: retainedText,
+        replayTime: 0,
+        screenshots: [`${outcome}-overview.png`, `${outcome}-detail.png`],
+        additionalReview:
+          outcome === 'clearance'
+            ? '600x960 dark mode: clearance-dark-narrow.png and clearance-dark-narrow-detail.png'
+            : null,
+        pipeline:
+          'ordinary Core Features / production original-part Worker / frozen result replay / CUSTOM'
+      })
+    })
+  })
+}
+
+test('ordinary original-part timeout is retained without success and permits another run', async ({
+  page
+}, info) => {
+  await page.goto('/')
+  await expect(page.getByRole('status')).toHaveText('Local runtime ready')
+  await page.getByRole('button', { name: 'Experiments', exact: true }).click()
+  await page.getByLabel('Wall-time budget (ms)').fill('100')
+  await page.keyboard.press('Tab')
+  await page
+    .getByRole('button', { name: 'Run formal analysis', exact: true })
+    .click()
+  const result = page.getByTestId('analysis-result')
+  await expect(result).toContainText('timed-out')
+  await expect(result).toContainText('partial')
+  await expect(result.getByLabel('User verdict')).not.toHaveText('meets')
+  await expect(page.locator('.retention-actions')).toContainText(
+    'Retained in this project'
+  )
+  await expect(
+    page.getByRole('button', { name: 'Cancel analysis', exact: true })
+  ).toHaveCount(0)
+  await result.scrollIntoViewIfNeeded()
+  await page.screenshot({ path: info.outputPath('timeout.png') })
+  await page.getByLabel('Wall-time budget (ms)').fill('30000')
+  await page.keyboard.press('Tab')
+  await expect(result).toContainText('Historical inputs differ')
+  await page
+    .getByRole('button', { name: 'Run formal analysis', exact: true })
+    .click()
+  await page
+    .getByRole('button', { name: 'Cancel analysis', exact: true })
+    .click()
+  await expect(result).toContainText('cancelled')
+  await expect(result).toContainText('partial')
+  await expect(result.getByLabel('User verdict')).not.toHaveText('meets')
+  await expect(page.locator('.retention-actions')).toContainText(
+    'Retained in this project'
+  )
+  await result.scrollIntoViewIfNeeded()
+  await page.screenshot({ path: info.outputPath('cancelled.png') })
+})

--- a/apps/asyra-sim/e2e/__tests__/starter-experiments.spec.ts
+++ b/apps/asyra-sim/e2e/__tests__/starter-experiments.spec.ts
@@ -156,7 +156,7 @@ test('a focused interval keeps all workcell parts, reports real findings and rep
   })
   await pair.locator('summary').click()
   await expect(pair.locator('.interval-evidence').first()).toContainText(
-    'finding'
+    'Collision - established penetration'
   )
   await pair.getByRole('button', { name: 'Replay pair', exact: true }).click()
   await expect(page.locator('.viewport-summary')).toContainText(
@@ -166,6 +166,23 @@ test('a focused interval keeps all workcell parts, reports real findings and rep
     `Undo steps: ${Number(history?.match(/\d+/)?.[0]) + 1}`
   )
   await page.screenshot({ path: info.outputPath('collision-replay.png') })
+  const recorded = await result.innerText()
+  const canvas = page.getByTestId('workcell-canvas').locator('canvas')
+  await canvas.hover()
+  await page.mouse.wheel(0, -700)
+  await expect(page.locator('.viewport-summary')).toContainText(
+    'Historical run replay - 3.8000 s'
+  )
+  expect(await result.innerText()).toBe(recorded)
+  await expect(page.getByTestId('history-depth')).toHaveText(
+    `Undo steps: ${Number(history?.match(/\d+/)?.[0]) + 1}`
+  )
+  await page.screenshot({
+    path: info.outputPath('collision-replay-closeup.png')
+  })
+  await pair.screenshot({
+    path: info.outputPath('collision-evidence-detail.png')
+  })
   await info.attach('collision-review', {
     contentType: 'application/json',
     body: JSON.stringify({
@@ -181,7 +198,13 @@ test('a focused interval keeps all workcell parts, reports real findings and rep
       overlays: 'default grid and historical pair highlights',
       result: await result.innerText(),
       pipeline: 'normal Features / original-part Worker / CUSTOM renderer',
-      screenshots: ['collision-result.png', 'collision-replay.png']
+      screenshots: [
+        'collision-result.png',
+        'collision-replay.png',
+        'collision-replay-closeup.png',
+        'collision-evidence-detail.png'
+      ],
+      closeup: 'Camera-only wheel deltaY -700 from default replay view'
     })
   })
 })

--- a/apps/asyra-sim/src/analysis/methods/__tests__/continuous-query.test.ts
+++ b/apps/asyra-sim/src/analysis/methods/__tests__/continuous-query.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { IDENTITY_POSE } from '../../../domain/math'
 import { convexDistance } from '../convex-query'
+import { queryOriginalPartPair } from '../original-part-method'
 import {
   validateTrajectory,
   validateWorkcell,
@@ -327,3 +328,70 @@ describe('complete-time pair evidence', () => {
     ).toThrow('covered')
   })
 })
+
+// Independent oracle: two radius-1/8 spheres, one translating from -8 to 8.
+// Over [a,b], the nearest x coordinate is zero if the interval spans the
+// midpoint, otherwise the nearer endpoint. No production pose/distance helper
+// computes these expected values. All fixture constants are binary fractions.
+it.each([0, 3599])(
+  'original method bounds every leaf and its witness at time origin %s',
+  (origin) => {
+    const duration = 1 / 1024
+    const radius = 1 / 8
+    for (const offset of [0, 1 / 2]) {
+      const primitive = {
+        ...sphere,
+        geometry: { kind: 'sphere' as const, radius }
+      }
+      const query = input(
+        [
+          { ...moving, colliders: [primitive] },
+          {
+            ...fixed,
+            pose: { ...IDENTITY_POSE, position: [0, offset, 0] },
+            colliders: [primitive]
+          }
+        ],
+        {
+          version: 1,
+          keyframes: [
+            { time: origin, joints: { moving: -8 } },
+            { time: origin + duration, joints: { moving: 8 } }
+          ]
+        }
+      )
+      const result = queryOriginalPartPair(query, settings)
+      let cursor = origin
+      for (const leaf of result.leaves) {
+        expect(leaf.start).toBe(cursor)
+        expect(leaf.end).toBeGreaterThanOrEqual(leaf.start)
+        cursor = leaf.end
+        const x0 = -8 + (16 * (leaf.start - origin)) / duration
+        const x1 = -8 + (16 * (leaf.end - origin)) / duration
+        const nearest =
+          x0 <= 0 && x1 >= 0 ? 0 : Math.min(Math.abs(x0), Math.abs(x1))
+        const minimum = Math.max(0, Math.hypot(nearest, offset) - 2 * radius)
+        expect(leaf.lower).toBeLessThanOrEqual(minimum)
+        if (leaf.upper !== null)
+          expect(leaf.upper).toBeGreaterThanOrEqual(minimum)
+        if (leaf.penetration) {
+          expect(leaf.witnessTime).not.toBeNull()
+          const time = leaf.witnessTime as number
+          // Exact strict contact window from |x(t)| < 1/4.
+          expect(time).toBeGreaterThan(origin + (duration * 31) / 64)
+          expect(time).toBeLessThan(origin + (duration * 33) / 64)
+          expect(offset).toBe(0)
+        }
+      }
+      expect(cursor).toBe(origin + duration)
+      if (offset === 0)
+        expect(result.leaves.some((leaf) => leaf.penetration)).toBe(true)
+      else {
+        expect(result.coverage).toBe('complete')
+        expect(result.lower).toBeLessThanOrEqual(1 / 4)
+        expect(result.upper).toBeGreaterThanOrEqual(1 / 4)
+        expect(result.leaves.every((leaf) => leaf.state === 'clear')).toBe(true)
+      }
+    }
+  }
+)

--- a/apps/asyra-sim/src/ui/results/__tests__/analysis-result-view.test.ts
+++ b/apps/asyra-sim/src/ui/results/__tests__/analysis-result-view.test.ts
@@ -304,3 +304,115 @@ it('compares authored inputs using the shared executable result and treats curre
     reader.dispose()
   }
 })
+
+it('distinguishes retained penetration, clearance and unresolved intervals with exact replay times', async () => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  const example = createSyntheticExample()
+  const draft = createSyntheticExperimentDraft(example)
+  const snapshot = createExperimentSnapshot({
+    snapshotId: 'mixed-evidence',
+    candidateId: 'candidate',
+    experimentId: 'experiment',
+    workcell: example.workcell,
+    definition: { ...draft, revision: 1, rule: { ...draft.rule, revision: 1 } },
+    methods: INSTALLED_METHOD_CATALOG.descriptors,
+    acknowledgedWarningCodes: []
+  })
+  const leaves = [
+    {
+      start: 0,
+      end: 2,
+      lower: 0,
+      upper: 0,
+      witnessTime: 1.123456789,
+      penetration: true,
+      state: 'finding' as const,
+      reason: 'Established static witness.'
+    },
+    {
+      start: 2,
+      end: 4,
+      lower: 0,
+      upper: 0.01,
+      witnessTime: 3,
+      penetration: false,
+      state: 'finding' as const,
+      reason: 'Established static witness.'
+    },
+    {
+      start: 4,
+      end: 8,
+      lower: 0,
+      upper: null,
+      witnessTime: null,
+      penetration: false,
+      state: 'unresolved' as const,
+      reason: 'No retained witness.'
+    }
+  ]
+  const result = terminalAnalysisResult(
+    snapshot,
+    [
+      {
+        pairId: snapshot.pairs[0].id,
+        evidence: {
+          coverage: 'partial',
+          lower: 0,
+          upper: 0,
+          evaluations: 2,
+          leaves
+        }
+      }
+    ],
+    {
+      runId: 'mixed-run',
+      startedAt: 0,
+      endedAt: 1,
+      execution: 'cancelled',
+      error: 'Cancelled'
+    }
+  )
+  const before = JSON.stringify({ snapshot, result })
+  const host = document.createElement('div')
+  const root = createRoot(host)
+  const replay = vi.fn()
+  try {
+    await act(() =>
+      root.render(
+        createElement(AnalysisResultView, {
+          run: { snapshot, result },
+          stale: false,
+          onReplay: replay
+        })
+      )
+    )
+    const pair = host.querySelector<HTMLDetailsElement>('.evidence-pair')
+    if (!pair) throw new Error('Missing pair')
+    await act(() => {
+      pair.open = true
+      pair.dispatchEvent(new Event('toggle'))
+    })
+    expect(pair.textContent).toContain('Collision - established penetration')
+    expect(pair.textContent).toContain('Clearance violation')
+    expect(pair.textContent).toContain('Unresolved')
+    expect(pair.textContent).toContain('Witness time: 1.123456789 s')
+    expect(pair.textContent).toContain('No retained witness')
+    expect(pair.textContent).toContain('not first contact')
+    const buttons = [...pair.querySelectorAll('button')].filter((button) =>
+      /^Replay (witness|interval start)$/.test(button.textContent ?? '')
+    )
+    expect(buttons).toHaveLength(3)
+    for (let index = 0; index < buttons.length; index++) {
+      await act(() => buttons[index].click())
+      expect(replay).toHaveBeenLastCalledWith(
+        snapshot,
+        leaves[index].witnessTime ?? leaves[index].start,
+        [snapshot.pairs[0].a.bodyId, snapshot.pairs[0].b.bodyId]
+      )
+    }
+    expect(JSON.stringify({ snapshot, result })).toBe(before)
+  } finally {
+    await act(() => root.unmount())
+    vi.unstubAllGlobals()
+  }
+})

--- a/apps/asyra-sim/src/ui/results/pair-evidence-view.tsx
+++ b/apps/asyra-sim/src/ui/results/pair-evidence-view.tsx
@@ -2,6 +2,14 @@ import { useState } from 'react'
 import type { ExperimentSnapshot } from '../../analysis/contracts'
 import type { OfficialPairEvidence } from '../../analysis/methods/official-method'
 import { formatDistance } from './format-distance'
+import type { IntervalEvidence } from '../../analysis/methods/continuous-query'
+
+function intervalLabel(interval: IntervalEvidence): string {
+  if (interval.penetration) return 'Collision - established penetration'
+  if (interval.state === 'finding') return 'Clearance violation'
+  if (interval.state === 'unresolved') return 'Unresolved'
+  return 'No issue within interval'
+}
 
 export function PairEvidenceView({
   pair,
@@ -80,15 +88,29 @@ export function PairEvidenceView({
               className="interval-evidence grid gap-[5px] pt-3 text-[10px] text-sim-muted [&_button]:justify-self-start"
               key={page * 20 + index}
             >
+              <strong>{intervalLabel(interval)}</strong>
+
               <strong>
-                {interval.state} - {interval.start.toFixed(6)}–
-                {interval.end.toFixed(6)} s
+                Interval: {interval.start}–{interval.end} s
               </strong>
 
               <span>
                 {formatDistance(interval.lower)} ≤ minimum ≤{' '}
                 {formatDistance(interval.upper)}
               </span>
+
+              <span>
+                {interval.witnessTime === null
+                  ? 'No retained witness'
+                  : `Witness time: ${interval.witnessTime} s`}
+              </span>
+
+              {interval.state === 'finding' && (
+                <span>
+                  This is an established witness, not first contact or every
+                  contact in this interval.
+                </span>
+              )}
 
               <span>{interval.reason}</span>
 

--- a/docs/ai/apps/asyra-sim/PLANS.md
+++ b/docs/ai/apps/asyra-sim/PLANS.md
@@ -23,8 +23,9 @@
 1. [Asyra Sim first-release roadmap](plans/asyra-sim-roadmap.md)
    - M1-M3 are closed. M3 passed all six owner exit criteria on 2026-09-08;
      see [the M3 completion record](plans/completed/m3-formal-analysis.md).
-     Next is a separately bounded M4 contract/evidence review, starting with
-     its first unproven owner. Existing code or a completed PR is not M4 acceptance.
+     Next is [M3.5 workflow usability](plans/m3-5-workbench-flow.md), planned
+     after user acceptance of M3 on 2026-09-09. M3.5 is not implemented.
+     M4 follows with its own bounded contract/evidence review.
    - M5 packaging and M6 independent pilot/release review remain later work.
      Historical packaging evidence remains in roadmap section 1.2 and
      [LOCAL_CANDIDATE.md](release/LOCAL_CANDIDATE.md).

--- a/docs/ai/apps/asyra-sim/PLANS.md
+++ b/docs/ai/apps/asyra-sim/PLANS.md
@@ -21,10 +21,10 @@
 ## Active Work
 
 1. [Asyra Sim first-release roadmap](plans/asyra-sim-roadmap.md)
-   - M1 is closed and M2 Import Contract Completion passed milestone acceptance
-     on 2026-09-07. Next is a separately bounded M3 review of the existing
-     static/continuous/clearance method contracts and evidence, starting with
-     the first unproven owner. A completed PR is not acceptance of M2-M4.
+   - M1-M3 are closed. M3 passed all six owner exit criteria on 2026-09-08;
+     see [the M3 completion record](plans/completed/m3-formal-analysis.md).
+     Next is a separately bounded M4 contract/evidence review, starting with
+     its first unproven owner. Existing code or a completed PR is not M4 acceptance.
    - M5 packaging and M6 independent pilot/release review remain later work.
      Historical packaging evidence remains in roadmap section 1.2 and
      [LOCAL_CANDIDATE.md](release/LOCAL_CANDIDATE.md).
@@ -33,6 +33,12 @@
      of this PR. No new Framework 3D profile is enabled by closeout.
 
 ## Completed Work
+
+- [M3 official collision and clearance methods](plans/completed/m3-formal-analysis.md)
+  - Closed 2026-09-08: independent temporal oracles and explicit formal finding
+    types/witness times, preserving the existing solver and frozen history.
+    All six owners accepted; 650 App tests, 27 distinct browser cases and
+    inspected screenshots pass. No in-scope blocker; M4-M6 remain separate.
 
 - [M2 executable experiments and import contract](plans/completed/m2-import-contract.md)
   - Closed 2026-09-08, including Core integration, automatic persistence and

--- a/docs/ai/apps/asyra-sim/README.md
+++ b/docs/ai/apps/asyra-sim/README.md
@@ -14,9 +14,9 @@ single robot workcell**, not a complete factory simulator.
   and PLANS.md for implementation evidence and remaining public-release gates.
 - The development workbench was merged as PR #156. See
   [the completed plan](plans/completed/development-workbench.md). M1 is closed
-  and M2 import-contract acceptance is complete; the next bounded milestone is
-  M3 contract/evidence review. See [PLANS.md](PLANS.md). The R0 release gates
-  remain open; this is not a released product.
+  and M2 import-contract and M3 formal-method acceptance are complete; the next
+  bounded milestone is M4 contract/evidence review. See [PLANS.md](PLANS.md).
+  The R0 release gates remain open; this is not a released product.
 - The hosted workbench uses the permanent domain `asyra-sim.vercel.app` and
   production branch `main`. See [hosting and browser-local data boundaries](release/HOSTED_PREVIEW.md).
 - App workspace: `apps/asyra-sim/`, alongside `apps/asyra-design/`.
@@ -44,7 +44,8 @@ Before resuming implementation, read the requested
 [Core integration review](validation/CORE_INTEGRATION_REVIEW.md). It records the publication/persistence and upstream projection gaps found at
 `a379a0ee2` and their completed corrections. See the
 [M2 closeout](plans/completed/m2-import-contract.md) for final acceptance;
-new implementation starts from the separately bounded M3 review.
+M3 acceptance is archived in [its completion record](plans/completed/m3-formal-analysis.md);
+new implementation starts from a separately bounded M4 review.
 
 | Question                                                                         | Document                                                        |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------- |

--- a/docs/ai/apps/asyra-sim/README.md
+++ b/docs/ai/apps/asyra-sim/README.md
@@ -15,7 +15,7 @@ single robot workcell**, not a complete factory simulator.
 - The development workbench was merged as PR #156. See
   [the completed plan](plans/completed/development-workbench.md). M1 is closed
   and M2 import-contract and M3 formal-method acceptance are complete; the next
-  bounded milestone is M4 contract/evidence review. See [PLANS.md](PLANS.md).
+  bounded milestone is [M3.5 workflow usability](plans/m3-5-workbench-flow.md). See [PLANS.md](PLANS.md).
   The R0 release gates remain open; this is not a released product.
 - The hosted workbench uses the permanent domain `asyra-sim.vercel.app` and
   production branch `main`. See [hosting and browser-local data boundaries](release/HOSTED_PREVIEW.md).
@@ -45,7 +45,7 @@ Before resuming implementation, read the requested
 `a379a0ee2` and their completed corrections. See the
 [M2 closeout](plans/completed/m2-import-contract.md) for final acceptance;
 M3 acceptance is archived in [its completion record](plans/completed/m3-formal-analysis.md);
-new implementation starts from a separately bounded M4 review.
+the next task prepares M3.5 contracts before its UI implementation.
 
 | Question                                                                         | Document                                                        |
 | -------------------------------------------------------------------------------- | --------------------------------------------------------------- |

--- a/docs/ai/apps/asyra-sim/decisions/releases/unreleased.md
+++ b/docs/ai/apps/asyra-sim/decisions/releases/unreleased.md
@@ -206,3 +206,20 @@ Pending saves disable both save entry points and guard duplicate dispatch.
   execution validity remains separate. The roadmap stays active for M3-M6.
   User-authorized push and PR review follow closeout; no merge, Changeset,
   version bump, tag, publication or deployment is authorized by this decision.
+
+
+### 2026-09-08 - Close M3 official collision and clearance acceptance
+
+- Context: merged implementation and earlier test counts did not establish M3
+  acceptance. A bounded review compared the six owners against current numerical,
+  runtime and Inspector contracts before changing code.
+- Decision: accept M3 under the frozen local profile after independent interval
+  oracles, a test-first formal finding/witness presentation correction, 650 App
+  tests and 27 distinct browser cases with inspected screenshots. Archive the
+  owner conclusions and operational cases in
+  `docs/ai/apps/asyra-sim/plans/completed/m3-formal-analysis.md`.
+- Consequences: retain the existing solver, method version, complete original
+  geometry, Core transaction/persistence ownership and immutable history. No
+  numerical/resource limit was relaxed. M4 begins with its own bounded review;
+  M5/M6 and independent numerical, reference-hardware and release gates remain
+  open. Closeout authorizes no remote or release operation.

--- a/docs/ai/apps/asyra-sim/decisions/releases/unreleased.md
+++ b/docs/ai/apps/asyra-sim/decisions/releases/unreleased.md
@@ -223,3 +223,17 @@ Pending saves disable both save entry points and guard duplicate dispatch.
   numerical/resource limit was relaxed. M4 begins with its own bounded review;
   M5/M6 and independent numerical, reference-hardware and release gates remain
   open. Closeout authorizes no remote or release operation.
+
+
+### 2026-09-09 - User accepts M3 and inserts M3.5 workflow usability
+
+- Context: the user accepted M3 after the live seven-run demonstration, but found
+  the crowded panel and preflight/replay/retention transitions hard to understand.
+- Decision: retain M3 closeout and add
+  `docs/ai/apps/asyra-sim/plans/m3-5-workbench-flow.md` before M4. Plan a single
+  run entry with automatic admission, focused tabs and clearer result evidence.
+  M3.5 implementation has not started; contract readiness comes first.
+- Consequences: this supersedes the earlier next-step recommendation to start M4
+  immediately. Preserve numerical owners, full geometry, history and persistence.
+  The user authorized committing and pushing M3 and the M3.5 plan, followed by
+  current-commit CI verification before review. No merge or release is authorized.

--- a/docs/ai/apps/asyra-sim/plans/asyra-sim-roadmap.md
+++ b/docs/ai/apps/asyra-sim/plans/asyra-sim-roadmap.md
@@ -259,36 +259,19 @@ pair sets, missing colliders, background/influencing objects, and excluded pairs
 Do not implement a general scheduling engine, arbitrary workflow loops,
 vendor-controller interpretation, or inverse kinematics.
 
-## 6. M3: Official Collision and Clearance Methods
+## 6. M3: Official Collision and Clearance Methods - Complete
 
-### User Outcome
+Closed 2026-09-08 within the frozen local profile. All six owner exit criteria
+are accepted: static/continuous/clearance evidence, Worker lifecycle, result
+validation/rules and ordinary result/replay. Existing sufficient implementations
+were retained; independent time/distance oracles and explicit formal finding
+labels/witness times close the actual evidence/presentation gaps.
 
-Run a complete local geometry experiment and identify collisions, insufficient
-clearance, and regions that remain unresolved.
-
-### Owner Slices
-
-1. Static method owner: supported shape pairs and independent analytical oracles.
-2. Continuous trajectory method owner: complete time coverage, rotation,
-   high-speed crossings, and time bounds.
-3. Clearance owner: distance bounds and witnesses, thresholds, and numerical
-   uncertainty.
-4. Runner: worker protocol, budgets, cancellation/timeouts, failures, and resource
-   cleanup.
-5. Result validator/rule evaluator: keep evidence, coverage, execution, and
-   verdict distinct.
-6. Result view/replay: project the same canonical findings, locate times, zoom
-   into local details, and display unknown states.
-
-Do not defer these owners' formal tests to a single final UI integration.
-Generate a Step Execution Card from the actual Inspector for each segment and
-complete its bounded review before advancing.
-
-This milestone must produce meaningful examples of collision, clearance
-violation, fully analyzed cases with no issues found, unresolved results,
-timeouts, and cancellation. Test every numerical promise under the frozen
-profile. Do not implement collision response, contact forces, or a dynamics
-engine that rewrites the user's trajectory.
+650 App tests and 27 distinct browser cases pass, with inspected overview/detail
+screenshots and unchanged numerical/resource limits. Full scope, commands,
+owner conclusions and operational acceptance are archived in
+[M3 formal analysis](completed/m3-formal-analysis.md).
+M4-M6 and independent release gates remain separate.
 
 ## 7. M4: Variant Comparison, Versions, and Private Extensions
 

--- a/docs/ai/apps/asyra-sim/plans/asyra-sim-roadmap.md
+++ b/docs/ai/apps/asyra-sim/plans/asyra-sim-roadmap.md
@@ -136,13 +136,14 @@ or changing other Apps, environments, packages, or repository-wide support polic
 | M1 Workcell foundations                  | Create, manipulate, save, and reopen a simple 3D workcell                        | Consistent canonical state, transforms, and transactions                   |
 | M2 Experiments and trajectories          | Import paths, select scope, and configure methods and thresholds                 | Correct units, interpolation, snapshots, and preflight                     |
 | M3 Formal analysis                       | Obtain collision, clearance, and unresolved results with replay                  | Formal numerical evidence and continuous-time completeness                 |
+| M3.5 Workflow usability | Configure, run, read results and replay without losing context | Single run entry, focused panels and truthful result states |
 | M4 Comparison and pluggability           | Compare three variants, export, replace methods, and preserve experiment context | Consistent results, traceable versions, and independent module integration |
 | M5 Quality and delivery                  | A controlled-pilot candidate that installs or starts locally                     | Offline, security, performance, consumer, and documentation gates          |
 | M6 Independent pilots and release review | Non-developers complete the workflow independently and understand its limits     | All G1–G8 gates in FIRST_RELEASE are satisfied                             |
 | R0 Public Alpha                          | A publicly released, free local experiment tool with a limited scope             | Still not production approval or industrial safety certification           |
 | M7 and beyond                            | Expand according to real needs                                                   | Choose one evidence-backed capability increment at a time                  |
 
-The required sequence is `M0 → M1 → M2 → M3 → M4 → M5 → M6 → R0`.
+The required sequence is `M0 → M1 → M2 → M3 → M3.5 → M4 → M5 → M6 → R0`.
 Tests, supporting documentation, and resource cleanup accompany each owner
 implementation; they must not all be deferred to M5. Independent test design,
 sample preparation, and pilot arrangements may begin earlier; implementation
@@ -272,6 +273,16 @@ screenshots and unchanged numerical/resource limits. Full scope, commands,
 owner conclusions and operational acceptance are archived in
 [M3 formal analysis](completed/m3-formal-analysis.md).
 M4-M6 and independent release gates remain separate.
+
+## 6.5. M3.5: Understandable Experiment Workflow - Planned
+
+User acceptance of M3 was confirmed on 2026-09-09 after the live demonstration.
+The next bounded milestone addresses a single Run action with automatic
+preflight, Setup/Preview/Results tabs, stable controls and clearer retained
+results/replay. See [the M3.5 plan](m3-5-workbench-flow.md) for owner sequence,
+permanent product cases, gates and exclusions. No M3.5 implementation is claimed;
+first reconcile its thin product contract and exact UI Inspector route.
+M3 numerical acceptance remains closed. M4-M6 are not completed by this plan.
 
 ## 7. M4: Variant Comparison, Versions, and Private Extensions
 

--- a/docs/ai/apps/asyra-sim/plans/completed/m3-formal-analysis.md
+++ b/docs/ai/apps/asyra-sim/plans/completed/m3-formal-analysis.md
@@ -1,0 +1,195 @@
+# M3: Official Collision and Clearance Methods
+
+## Closeout - 2026-09-08
+
+M3 is complete within the frozen local runtime and numerical profile. All six
+owner exit criteria are accepted with no remaining in-scope blocker. The bounded
+review retained existing sufficient implementations, added independent temporal
+oracles, and corrected the formal result view's missing finding distinction and
+witness-time presentation. This is not an independent numerical certification,
+reference-hardware qualification, or R0 release approval.
+
+Baseline: PR #169 merged at `a70c0bdece5734eac938fa1cc3387a13829526cb`, also
+`origin/main` after the requested fetch. Branch:
+`codex/asyra-sim-m3-formal-analysis`; worktree:
+`/Users/asa/Desktop/workspace/asra/.worktrees/asyra-sim-m3-formal-analysis`.
+The original checkout's untracked `docs/reports/` and all other worktrees were
+preserved. Implementation commits are `c98ccd7e2` (method oracle) and `80bf40eb4`
+(formal finding presentation and ordinary browser cases).
+
+## Bounded contract and owner conclusions
+
+Discovery compared the current robot-workcell, original-part, numerical-method,
+runtime-profile and Core integration contracts with the dedicated R0 Inspector,
+current implementation and permanent owner tests. Authorized scope was M3
+method evidence and the confirmed formal result presentation omission, with
+one Inspector owner completed at a time. No new product semantics, cache,
+solver rewrite, geometry substitution, budget/precision change, historical
+migration, Framework change or dependency addition was needed. The existing
+method identity remains `original-part-clearance-v1@1.0.1`.
+
+| M3 owner | Discovery classification and current evidence |
+| --- | --- |
+| Static method | Implemented with sufficient owner evidence: `convex-query.test.ts` covers all six unordered native shape pairs, analytical distances, common rigid transforms, symmetry, strict overlap, touching and scale/coordinate limits. `original-mesh.test.ts` and `workpiece-contact.test.ts` cover complete original triangles, holes, containment, traversal parity and penetration despite warning witnesses. No production change. |
+| Continuous trajectory | Implemented; existing crossing/rotation/partition/budget tests are retained. Added independent binary-fraction sphere oracles in `continuous-query.test.ts`, checking every leaf's distance bounds, contiguous time coverage and the strict penetration witness window at zero and near the upper time envelope. Both added tests pass unchanged production code. They are analytical checks, not dense-sampling clearance claims. |
+| Clearance | Implemented with sufficient owner evidence: native analytical distance bounds, threshold equality/contact uncertainty, original-mesh uncertainty and penetration precedence pass. Distance tolerance remains a target; actual interval bounds and unknowns remain authoritative. No production change. |
+| Runner | Implemented; current runner/resource/Feature tests pass startup-inclusive deadlines, the fixed 250 ms grace, cancellation, crashes, malformed/late/contradictory output, global limits and cleanup. Production-browser uncooperative Worker and ordinary timeout/cancellation gates also pass on this worktree's 3020 service. |
+| Result validator / rule evaluator | Implemented with sufficient owner evidence: current result and acceptance suites prove independent execution/coverage/evidence/verdict, partial-result preservation, unknown truth tables, forged-history rejection and once-per-pair admission. No production change. |
+| Result view / replay | Actual presentation gap: both penetration and insufficient clearance appeared only as `finding`, without an explicit witness time. A permanent UI regression failed first. The view now projects the retained state/penetration flag into distinct labels and shows exact interval/witness times, without recomputing geometry or changing replay inputs. Unit proof preserves the same snapshot/time/body identities and immutable result. Ordinary browser acceptance, overview/detail screenshot inspection and frozen replay pass. |
+
+The first three roadmap owners share Inspector `method`; runner and validator
+share `run`; formal presentation/replay uses `ui`. Cards were checked against
+the actual input/output routes before each segment and again at completion:
+
+- `method`: detached snapshot/domain inputs and abort/budget produce method
+  evidence. Only `analysis/methods/__tests__/continuous-query.test.ts` changed.
+  Pure independent binary-fraction sphere oracles check all leaf bounds,
+  contiguous coverage and the strict analytical penetration time window at
+  time origins 0 and 3599 seconds. Expected values do not call production pose
+  or distance helpers. Existing source-mesh, rotational and resource tests
+  remain. All 71 method tests pass without a solver change.
+- `run`: snapshot, method evidence and Feature abort produce validated result
+  and progress. All 61 analysis/Feature tests pass unchanged, including result
+  work counts and unknown verdicts; 13 browser Worker/numerical cases prove
+  actual runtime arithmetic, dispatch, budget behavior and forced termination.
+  No canonical transaction spans execution and no fallback method is added.
+- `ui`: accepted result/snapshot feed ordinary controls; replay forwards the
+  exact frozen snapshot, witness time and body IDs. Eight baseline view tests
+  passed while omitting the defect; the new mixed collision/clearance/unknown
+  regression failed before the fix, then all nine passed. The view reads
+  retained `penetration` and `state`, not geometry or thresholds to recalculate
+  findings. It shows original interval/witness values and explicitly says a
+  witness is not first contact or an enumeration of all contacts. Input and
+  saved formats remain unchanged. Formal UI/E2E and screenshot gates pass.
+
+Final bounded review found no owner-boundary violation, current-diff regression,
+new retained computation, fixture-specific product path or unproved solver
+change. Permanent existing mesh preparation, admitted-result, live reuse and
+canonical projection work-count/invalidation tests ran in the full App suite.
+
+## Verification
+
+- 650 App tests across 117 files pass (647 existing plus two analytical cases
+  and one mixed-evidence presentation regression).
+- App build/typecheck and lint pass; 11 naming, 100 Inspector contracts and two
+  test-placement checks pass. The existing Vite large-chunk advisory remains.
+- 27 distinct browser cases pass, with one worker, no retries and the unchanged
+  180-second global guard, in the bounded batches below. Repeated visual runs
+  are not counted twice.
+- Agent screenshot review passed separately from automated assertions:
+  collision/clearance/clear/unknown pair details, original-part collision report
+  and replay, camera-only closeup, timeout/cancelled results, historical reopening,
+  and a 600-pixel dark-mode finding view. Source-space tests remain geometry
+  authority; screenshots do not prove the solver's numerical guarantees.
+
+Environment: macOS 26.6.2, Node 24.13.0, Yarn 4.3.1, installed Chrome
+152.0.7977.82, SwiftShader, DPR 1. Ordinary review is 1440 x 960 with default
+camera or explicit Fit all. Navigation also covers 960 x 960; the finding view
+covers 600 x 960 dark mode. The original collision closeup uses camera-only
+wheel deltaY -700 from its default replay view and preserves evidence/history.
+No native-GPU or reference-Mac-mini performance claim is made.
+
+Commands from the worktree root:
+
+```sh
+yarn workspace @asyra/asyra-sim test:local
+yarn workspace @asyra/asyra-sim build
+yarn workspace @asyra/asyra-sim lint
+yarn lint:naming
+yarn workspace @asyra/flow-inspector test:contracts
+node --test scripts/__tests__/test-file-placement.test.mjs
+APP_URL=http://127.0.0.1:3020 yarn workspace @asyra/asyra-sim test:e2e e2e/__tests__/formal-outcomes.spec.ts e2e/__tests__/starter-experiments.spec.ts --grep 'ordinary original|focused interval' --output=.artifacts/m3-visual-final
+APP_URL=http://127.0.0.1:3020 yarn workspace @asyra/asyra-sim test:e2e src/analysis/__tests__/runner.browser.spec.ts src/analysis/__tests__/budget-baseline.browser.spec.ts src/analysis/methods/__tests__/runtime.browser.spec.ts src/domain/__tests__/runtime.browser.spec.ts --output=.artifacts/m3-worker
+APP_URL=http://127.0.0.1:3020 yarn workspace @asyra/asyra-sim test:e2e e2e/__tests__/experiments.spec.ts e2e/__tests__/resources.spec.ts e2e/__tests__/retained-runs.spec.ts --output=.artifacts/m3-integration
+APP_URL=http://127.0.0.1:3020 yarn workspace @asyra/asyra-sim test:e2e e2e/__tests__/viewport-navigation.spec.ts --grep 'Fit all share' --output=.artifacts/m3-navigation
+```
+
+Root logs are `.artifacts/m3-{full,method,run,ui-baseline,ui-red,ui-green,build,lint-final,naming-final,inspector,placement}.log`.
+Browser logs are `.artifacts/m3-{visual-final,worker,integration,navigation}.log`;
+images and test state attachments are under
+`apps/asyra-sim/.artifacts/m3-{outcomes,visual-final,worker,integration,navigation}/`.
+These are local generated evidence, not a distribution. Permanent tests and
+oracles are committed; existing historical reports and method versions are not
+rewritten.
+
+## Operational acceptance
+
+Use the normal App at `http://127.0.0.1:3020`. After explicit user approval,
+M2 PID 13928 was stopped. The long-lived M3 Vite process is PID 46794 with cwd
+`/Users/asa/Desktop/workspace/asra/.worktrees/asyra-sim-m3-formal-analysis/apps/asyra-sim`.
+A short-lived Playwright-owned M3 service ran the first outcome batch; the final
+batches use PID 46794. Check the actual PID/cwd before any later takeover.
+
+### Complete original-part collision and local replay
+
+1. Select the initial `A - Baseline workcell` candidate and open **Experiments**.
+2. Select **Tool and table collision** (initial option suffix ` - r1`). Set
+   **Start time (s)** to `3.8` and **End time (s)** to `4.2`; finish each field
+   with Enter/blur. Keep all 11 parts, the 46-pair scope, method, threshold,
+   source geometry and default numerical budgets.
+3. Run preflight, then **Run formal analysis**. Expect **Issue found**,
+   execution `completed`, coverage `complete`, `46/46` pairs with evidence,
+   and `2 / 0` finding/unresolved pairs.
+4. In **Pair evidence and replay**, click **Next pairs** twice. Expand
+   **gripper - fixture table**. Its intervals identify **Collision - established
+   penetration**, including witness time `3.8 s`. **Replay pair** shows
+   **Historical run replay - 3.8000 s** and highlights the two frozen bodies.
+   Expand workpiece/table to inspect its own separate retained finding.
+5. Zoom with the wheel or use **Fit all**; history and the formal result remain
+   unchanged. Change minimum clearance to `30 mm`: the old result becomes
+   historical; it remains replayable with its original frozen inputs.
+
+### Four independent static outcomes through ordinary fields
+
+Create **New workcell**, then use **Add fixture** twice. For each body, commit
+**Object name**, **Body role**, **Mount position (m) X** and **Shape 1 type**.
+Use native sphere parts, radius `0.1 m`, other position components zero:
+
+- `Primary sphere`: role `tool`, X `0`.
+- `Obstacle sphere`: role `fixture`, X as below.
+
+Open **Experiments**, name the study **Formal sphere study**, select
+`original-part-clearance-v1@1.0.1`, and set **Minimum clearance (mm)**.
+Under **Analysis scope**, set Primary sphere to `primary`, Obstacle sphere to
+`influencing`, and enable **Primary-to-influencing collision**. Create the
+experiment and run formal analysis. No trajectory text is needed for this
+static workcell. These are authored primitives, not surrogates for imported
+parts.
+
+| Obstacle X (m) | Threshold (mm) | Expected retained result |
+| --- | --- | --- |
+| 0.15 | 20 | Collision - established penetration; completed/complete; does not meet |
+| 0.21 | 20 | Clearance violation; approximately 10 mm bounds; completed/complete; does not meet |
+| 1 | 20 | No issue within interval; approximately 800 mm bounds; completed/complete; meets |
+| 0.2 | 0 | Exact contact uncertainty; Unresolved; completed/partial; cannot determine |
+
+Expand the pair to see the distinct label, retained bounds and witness `0 s`.
+**Replay witness** uses **Historical run replay - 0.0000 s**. Fit all and
+light/dark or panel-size changes do not alter evidence/history. Reuse the same
+study for manual variants by completing the object/threshold edit and starting
+a new run; old results retain their original settings.
+
+### Timeout and cancellation
+
+1. Return to the initial baseline candidate's default **Synthetic clearance study**
+   study. Set **Wall-time budget (ms)** to `100` and finish the edit.
+2. Run formal analysis. Expect `timed-out`, `partial`, no `meets` verdict,
+   and automatic **Retained in this project**. Received pair counts can vary;
+   omitted pairs remain explicitly without evidence. This is an intentionally
+   low user budget within the frozen profile, not a changed solver limit.
+3. Restore `30000 ms`, finish the edit, run again, then click **Cancel analysis**
+   while running. Expect `cancelled`, `partial`, no `meets` verdict and retained
+   terminal evidence. The new run must remain available after the prior timeout.
+4. **Runs & compare** permits reading retained results. Reopening portable
+   history and replay are covered by the existing retained-runs browser gate;
+   this does not accept M4's broader comparison/extension milestone.
+
+## Next boundary
+
+M1 and M2 stay closed. The 3020 coordination blocker is resolved and no M3
+functional/evidence blocker remains in this bounded acceptance set. Continue
+only with a separately authorized M4 contract/evidence review, starting with its
+first unproven owner rather than assuming existing comparison/extensions are
+accepted. M5 packaging, representative/reference-hardware resources, independent
+numerical review, M6 pilots, maintenance policy and public release remain open.
+No Changeset, version bump, push, PR, merge, tag, publish or deploy was performed.

--- a/docs/ai/apps/asyra-sim/plans/completed/m3-formal-analysis.md
+++ b/docs/ai/apps/asyra-sim/plans/completed/m3-formal-analysis.md
@@ -193,3 +193,16 @@ first unproven owner rather than assuming existing comparison/extensions are
 accepted. M5 packaging, representative/reference-hardware resources, independent
 numerical review, M6 pilots, maintenance policy and public release remain open.
 No Changeset, version bump, push, PR, merge, tag, publish or deploy was performed.
+
+
+## User acceptance follow-up - 2026-09-09
+
+The user accepted M3 after observing the original-part collision/replay,
+insufficient clearance, complete no-issue, unresolved contact, timeout and
+cancellation journeys. Seven runs were retained in the demonstration project.
+This is additional user acceptance, not a replacement for the formal evidence
+above. The next-step recommendation in the historical closeout is superseded by
+[M3.5 workflow usability](../m3-5-workbench-flow.md), planned before M4.
+The user now authorizes commit/push of M3 and the M3.5 plan and requests CI
+verification before review; the earlier no-push statement records the original
+closeout checkpoint. M4-M6 remain open.

--- a/docs/ai/apps/asyra-sim/plans/completed/m3-formal-analysis.md
+++ b/docs/ai/apps/asyra-sim/plans/completed/m3-formal-analysis.md
@@ -12,7 +12,7 @@ reference-hardware qualification, or R0 release approval.
 Baseline: PR #169 merged at `a70c0bdece5734eac938fa1cc3387a13829526cb`, also
 `origin/main` after the requested fetch. Branch:
 `codex/asyra-sim-m3-formal-analysis`; worktree:
-`/Users/asa/Desktop/workspace/asra/.worktrees/asyra-sim-m3-formal-analysis`.
+`.worktrees/asyra-sim-m3-formal-analysis`.
 The original checkout's untracked `docs/reports/` and all other worktrees were
 preserved. Implementation commits are `c98ccd7e2` (method oracle) and `80bf40eb4`
 (formal finding presentation and ordinary browser cases).
@@ -116,7 +116,7 @@ rewritten.
 
 Use the normal App at `http://127.0.0.1:3020`. After explicit user approval,
 M2 PID 13928 was stopped. The long-lived M3 Vite process is PID 46794 with cwd
-`/Users/asa/Desktop/workspace/asra/.worktrees/asyra-sim-m3-formal-analysis/apps/asyra-sim`.
+`.worktrees/asyra-sim-m3-formal-analysis/apps/asyra-sim`.
 A short-lived Playwright-owned M3 service ran the first outcome batch; the final
 batches use PID 46794. Check the actual PID/cwd before any later takeover.
 

--- a/docs/ai/apps/asyra-sim/plans/m3-5-workbench-flow.md
+++ b/docs/ai/apps/asyra-sim/plans/m3-5-workbench-flow.md
@@ -1,0 +1,122 @@
+# M3.5: Understandable Experiment Workflow
+
+Status: planned on 2026-09-09; implementation has not started.
+M3 is accepted and closed. This bounded usability milestone precedes M4.
+
+## User outcome and scope
+
+A user can configure an experiment, start one analysis, distinguish preview from
+formal evidence, understand the result, and replay its witnesses without losing
+context. The observed problem is the crowded right panel and unclear transitions
+between preflight, playback, retained results and replay, not a solver defect.
+
+This plan records the requested direction, not an already implemented contract.
+Before code edits, update the thin behavior contract in
+[robot-workcell-v0.md](../specs/robot-workcell-v0.md) and the matching `ui` route in
+the [R0 Inspector](../../../../../tools/flow-inspector/inspectors/asyra-sim-r0-flow-inspector.html).
+Read each full affected owner contract and produce a Step Execution Card before
+its tests or implementation. Preserve `snapshot`, `run`, storage and rendering
+ownership; change their contracts only if a concrete necessary handoff requires
+an independently bounded owner step.
+
+## Planned interaction
+
+- Provide three right-panel tabs: **Setup**, **Preview**, and **Results**.
+  Keep the selected candidate and experiment visible above them. Object editing
+  remains contextual and must not discard pending completed edits.
+- Setup contains experiment inputs, scope, trajectory and clearance requirements.
+  Put method details, numerical tolerances and resource budgets in an advanced
+  section without changing values or hiding blocking diagnostics.
+- Use one primary **Run analysis** action. Invoke existing preflight admission
+  automatically, then start only a valid current snapshot. A separate preflight
+  action is not required in the ordinary journey. Keep workload/resource
+  information accessible; warnings and required acknowledgements still apply.
+- For invalid input, show persistent actionable errors, expose the owning Setup
+  section and focus the relevant field. Do not rely on a transient toast, allocate
+  a Worker for invalid data, or fall back to the last valid input.
+- Keep run/cancel controls and progress in a stable location. Completion offers
+  **View results** without unexpectedly switching tabs or stealing editing focus.
+  Timeout, cancellation and Worker failure remain distinct terminal outcomes.
+- Preview contains live playback and time controls, with a clear explanation that
+  playback does not establish complete continuous-time clearance.
+- Results leads with verdict, execution and coverage, then finding pairs and
+  unresolved pairs. Keep all pairs, scope, bounds and method/source declarations
+  accessible through progressive disclosure. Preserve exact pair identities and
+  complete records while changing presentation order only.
+- Replay changes the central scene to the selected run's frozen snapshot/time;
+  keep Results and the selected evidence visible. Identify historical replay
+  explicitly and provide an obvious return to current editing/preview.
+- Present automatic retention as secondary **Saved to this project** status.
+  Distinguish saving, acknowledged retention and retryable failure. Expose run
+  history from Results without making comparison part of this milestone.
+- After input edits, label old results as belonging to earlier inputs and offer
+  rerun. Keep their snapshot, method/version, sources and findings immutable.
+
+## Owner sequence and boundaries
+
+1. Contract readiness: reconcile the interaction above with the current product
+   spec and complete `ui` Inspector inputs, outputs, conditions, bypasses,
+   contributors, implementation boundary and failure owner. This is the first
+   implementation task, not a claim that a planning document proves readiness.
+2. UI admission: connect the single Run action to current preflight/Feature
+   orchestration and persistent field errors. Prove current-input execution,
+   duplicate-click prevention and warning acknowledgement behavior.
+3. UI navigation: introduce tabs and stable controls with fine-grained registered
+   projections, keyboard/focus behavior and narrow-screen layout. Preserve
+   completed field commits through tab switches, Undo/Redo and refresh.
+4. Result presentation/replay: reorganize the same canonical result, surface
+   findings and unresolved pairs first, clarify retention/freshness, and preserve
+   snapshot-based replay and access to every pair.
+
+Complete tests, corrections and bounded review for one owner slice before
+advancing. Production edits are limited to the App workbench UI and necessary
+existing App orchestration handoffs, their permanent tests and current contracts.
+No parallel canonical state, history, geometry or conclusion computation is
+allowed. Preserve Feature/Core transactions, direct persistence publications,
+registerUIContextProperty and fine-grained subscriptions. Do not use React.memo,
+extra debounce, per-Feature saving, ordinary Save/Apply controls or repeated
+parsing/conversion of still-valid input. Any reuse claim requires permanent
+work-count, correctness and invalidation tests.
+
+## Permanent acceptance cases and gates
+
+For bugs or contract mismatches, first check existing formal tests. Strengthen
+missing regressions and demonstrate failure before changing production code.
+
+- One Run action accepts valid current inputs and starts exactly one run; invalid
+  trajectory, mapping, units, interval or empty scope starts none and shows the
+  responsible field. Correcting an error restores eligibility without blocking
+  unrelated fields. Resource warnings retain their original policy.
+- Setup/Preview/Results navigation preserves inputs, editing completion,
+  selection and execution state. Undo/Redo and reload restore source text,
+  mappings and units. Tab navigation alone does not create canonical commits.
+- Demonstrate collision, insufficient clearance, complete no-issue, numerical
+  uncertainty, timeout, cancellation and Worker failure through ordinary UI.
+  Execution, coverage and verdict remain separate; partial/unknown cannot pass.
+- Result ordering retains every pair exactly once, including mixed collision,
+  clearance and unresolved evidence. A distance witness never hides penetration.
+  Replay uses the same findings and frozen inputs after edits and history reopen;
+  no second solver or conclusion runs for presentation.
+- Retention success/failure/retry and input freshness remain visible and truthful;
+  completion during editing does not steal focus or discard an edit.
+- Run focused owner unit/integration tests, affected normal App E2E, full App
+  tests, build/typecheck/lint, naming, Inspector contracts and test placement.
+  Inspect synchronized desktop/narrow-screen screenshots, keyboard operation,
+  relevant detail views and all terminal states using port 3020. Verify the
+  service PID/cwd/version and respect ownership before starting or taking over.
+
+Done means these journeys pass permanent gates and inspected live-app views, with
+an updated operation guide and user review. Tabs merely rendering is not closure.
+
+## Exclusions and stop conditions
+
+Do not reopen accepted M3 numerical work without a new formal defect. No solver
+rewrite, precision/budget relaxation, source-geometry reduction, precise contact
+region invention, dependency/tool changes, Framework/Preset extraction, M4
+comparison/extensions, M5 packaging or M6 pilots/release work is included.
+
+Stop for an out-of-scope prerequisite, conflicting owner contract or a necessary
+product decision not covered here. Do not expand from new review discoveries.
+M4 starts only after this separately tracked usability work is accepted; M4-M6
+and independent release gates remain open. Planning/closeout does not authorize
+merge, tag, publish or deploy.


### PR DESCRIPTION
## Summary
Formal result details previously rendered penetration and insufficient clearance with the same generic finding label. They now distinguish collision, clearance violation and unresolved evidence, expose exact witness times, and replay the same immutable findings.

Adds independent continuous-time distance/coverage oracles and permanent browser cases for collision, clearance, complete no-issue, uncertainty, timeout and cancellation. Closes all six M3 owners under the frozen local profile, with user acceptance. Adds the planned M3.5 workflow usability milestone before M4; its UI implementation has not started.

## Validation
- 650 App tests and 27 distinct browser cases passed; synchronized screenshots inspected at port 3020.
- App build/typecheck/lint, naming, Inspector contracts and test placement passed.
- M3.5 documentation links, bounded diff checks and all 11 naming checks passed.
- Seven additional live demonstration runs retained and reviewed with the user.

Solver implementation, method version, full source geometry, numerical/resource limits and historical evidence remain unchanged. M4–M6 and independent release gates remain open. No merge or release requested.
