### PR TITLE
fix(site): activate and verify Google services deployment

### DIFF
--- a/.changeset/site-google-deployment-verification.md
+++ b/.changeset/site-google-deployment-verification.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add an explicit enabled Google services deployment check and setup guidance for
+the private website, and keep its mobile image tests compatible with the declared
+Node types.

--- a/apps/asyra-framework-site/__tests__/e2e/mobile-image-delivery.spec.ts
+++ b/apps/asyra-framework-site/__tests__/e2e/mobile-image-delivery.spec.ts
@@ -1,8 +1,12 @@
 import { stat } from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { expect, test } from '@playwright/test'
 
-const siteRoot = path.resolve(import.meta.dirname, '../..')
+const siteRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..'
+)
 
 for (const width of [320, 390, 412, 520, 680, 800]) {
   test(`${width}px mobile images select a bounded sharp source on a fresh load`, async ({

--- a/apps/asyra-framework-site/docs/google-services.md
+++ b/apps/asyra-framework-site/docs/google-services.md
@@ -21,6 +21,11 @@ Vercel supplies `VERCEL_ENV`. The site-specific Turbo task forwards these
 variables to Next.js. Rebuild after configuration changes because metadata,
 scripts, and response headers are emitted at build time.
 
+Creating a GA4 stream or a Search Console property does not configure Vercel.
+Check that both identifier variables actually exist in the site's Production
+environment before deploying. A Ready deployment with empty configuration
+intentionally omits the Google tags and cannot collect visits or verify GSC.
+
 The identifiers become public in the site's HTML. Never place a Google password,
 OAuth token, service-account key, or Analytics API secret in these variables.
 
@@ -68,6 +73,23 @@ Run the existing site unit tests, build, route smoke, and these E2E tests:
 The Google E2E test intercepts the external library, so it checks site integration
 and navigation stability without sending test data to Google. It does not prove
 that GA4 received real events; the account-side live check remains necessary.
+
+For the configured official deployment, run the explicit enabled-services gate
+with the identifiers copied from its GA4 stream and GSC HTML-tag panel:
+
+```bash
+SITE_URL=https://asyra-framework.vercel.app \
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-YOURMEASUREMENTID \
+GOOGLE_SITE_VERIFICATION=your-html-meta-content \
+yarn workspace @asyra/asyra-framework-site test:google-services
+```
+
+This command requires both identifiers and checks the deployed verification
+meta tag, Google library request, initialization, and internal navigation. Do
+not use the default disabled-services test as evidence that Production collects
+data. Run this gate after the deployment is Ready, then finish GSC ownership
+verification and submit `/sitemap.xml`. Report processing is a separate step;
+waiting for reports cannot repair missing deployment configuration.
 
 For isolated worktrees, supply `SITE_URL` explicitly and use a free port.
 Screenshots belong under Playwright's app-owned output directory.

--- a/apps/asyra-framework-site/package.json
+++ b/apps/asyra-framework-site/package.json
@@ -16,6 +16,7 @@
     "test:contracts": "node --test ../../tools/flow-inspector/inspectors/__tests__/asyra-website-landing-flow-inspector.contract.test.cjs ../../tools/flow-inspector/inspectors/__tests__/asyra-website-platform-flow-inspector.contract.test.cjs ../../tools/flow-inspector/inspectors/__tests__/asyra-runtime-atlas-flow-inspector.contract.test.cjs",
     "test:routes": "node scripts/route-smoke.mjs",
     "test:e2e": "playwright test --config playwright.config.ts",
+    "test:google-services": "GOOGLE_SERVICES_TEST_ENABLED=1 playwright test --config playwright.config.ts google-services.spec.ts",
     "test:production": "node scripts/production-smoke.mjs && playwright test --config playwright.config.ts",
     "test:local": "yarn test:contracts && node --test __tests__/*.test.mjs",
     "test:artwork:local": "LOCAL_ARTWORK_TESTS=1 yarn test:local",


### PR DESCRIPTION
Production had no GA4 tag or GSC verification meta because the Vercel Production identifiers were never configured. The existing enabled-services E2E reproduced the missing meta before the settings were added. The correct identifiers have now been saved in Vercel Production; merging triggers the deployment that activates them.

Adds an explicit `test:google-services` command and deployment instructions so enabled collection is checked deliberately. Also fixes the existing mobile E2E path resolution to compile with the declared Node types; a clean site build previously failed on `ImportMeta.dirname`.

Validation:
- Clean production build: 9/9 build tasks passed.
- Site contract and unit suite passed (69 unit tests passed; 15 optional artwork tests skipped).
- Google enabled-services E2E: reproduced failure against current Production, passed against configured local production build.
- Mobile image E2E: 6/6 passed.
- Route smoke: 46 public pages and three discovery surfaces passed.
- Site ESLint, naming checks and diff checks passed.

Post-merge verification completed on production commit `7ce3ca9ad6dd276d199c35b3cde5805b5884af82`: all eight PR checks passed before merge; Vercel production deployment succeeded; enabled Google-services E2E and the 46-page production smoke passed. GA4 Realtime now shows active users and `page_view`, `session_start`, and `first_visit` events. GSC HTML-tag ownership verification succeeded, and the submitted sitemap was successfully processed with 46 discovered pages. Standard report processing remains separate from live collection.

