### PR TITLE
fix(ci): skip Draft PR checks and run when ready

### DIFF
--- a/.changeset/ready-pr-ci.md
+++ b/.changeset/ready-pr-ci.md
@@ -1,0 +1,4 @@
+---
+---
+
+Skip CI and E2E jobs for Draft pull requests and validate when marked ready for review.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       run_balanced_ai_correctness:
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   e2e-tests:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -65,6 +66,7 @@ jobs:
         run: bash scripts/run-e2e.sh
 
   collaboration-e2e-tests:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
   validate:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
@@ -69,6 +70,7 @@ jobs:
           node tools/flow-inspector/control-plane/cli.cjs ci-trial
 
   framework-release-readiness:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/docs/ai/workflows/package-release-validation.md
+++ b/docs/ai/workflows/package-release-validation.md
@@ -247,3 +247,10 @@ product-wide browser contract is broader than package publication. The
 Collaboration E2E suite runs in a separate CI job so an ordinary-suite failure
 cannot prevent the package-specific collaboration gate from reporting its own
 result.
+
+Both PR workflows skip all jobs while a pull request is Draft. Opening or
+updating a ready PR and marking a Draft PR ready for review trigger validation;
+CI also retains its label-change triggers. Draft runs may appear as skipped in
+GitHub Actions. Main-branch push validation, scheduled E2E, and manual E2E
+dispatch remain enabled independently of PR readiness. Converting an already
+running PR back to Draft does not cancel its existing run.

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -103,6 +103,41 @@ test('GitHub Actions use least privilege and immutable action revisions', () => 
   assert.match(dependabot, /interval: ['"]weekly['"]/)
 })
 
+test('PR workflows skip Draft jobs and run when the PR becomes ready', () => {
+  for (const workflowPath of [
+    '.github/workflows/main.yml',
+    '.github/workflows/e2e.yml'
+  ]) {
+    const workflow = readText(workflowPath)
+    const events = workflow.match(/pull_request:\n\s+types: \[([^\]]+)\]/)[1]
+    for (const event of [
+      'opened',
+      'synchronize',
+      'reopened',
+      'ready_for_review'
+    ]) {
+      assert.ok(events.split(', ').includes(event), `${workflowPath}: ${event}`)
+    }
+    const jobs = workflow.split('\njobs:\n')[1].split(/(?=^ {2}[\w-]+:\n)/m)
+    for (const job of jobs.filter((block) => block.trim())) {
+      assert.match(
+        job,
+        /^ {4}if: github.event_name != 'pull_request' \|\| github.event.pull_request.draft == false$/m,
+        `${workflowPath}: ${job.split('\n')[0]}`
+      )
+    }
+  }
+})
+
+test('Draft filtering preserves non-PR CI triggers and label validation', () => {
+  const ci = readText('.github/workflows/main.yml')
+  const e2e = readText('.github/workflows/e2e.yml')
+  assert.match(ci, /push:\n {4}branches:\n {6}- main/)
+  assert.match(ci, /types: \[[^\]]*labeled, unlabeled/)
+  assert.match(e2e, /^ {2}workflow_dispatch:/m)
+  assert.match(e2e, /^ {2}schedule:\n {4}- cron: '0 18 \* \* \*'/m)
+})
+
 test('CI bounds workspace test concurrency without dropping test owners', () => {
   const workflow = readText('.github/workflows/main.yml')
   const scripts = readJSON('package.json').scripts


### PR DESCRIPTION
Draft pull requests currently execute the full CI and E2E jobs on creation and updates. Both workflows now skip every job while Draft and listen for `ready_for_review`, so marking the PR ready starts validation without another commit.

Main-branch pushes, scheduled/manual E2E, existing PR update and label triggers, and check names remain unchanged. Converting a running PR back to Draft does not cancel an existing run.

Validation:
- Existing automation suite passed before changes; the new readiness regression failed against the original workflow.
- Updated automation suite: 26 passed; naming gate: 11 passed; focused ESLint and diff checks passed.
- Created this PR as Draft: all four jobs skipped ([CI](https://github.com/karote00/asyra/actions/runs/34329521229), [E2E](https://github.com/karote00/asyra/actions/runs/34329521113)).
- Marked the same commit ready without pushing another commit: both workflows started automatically.
- Ready run: `validate` and `framework-release-readiness` passed ([CI](https://github.com/karote00/asyra/actions/runs/34329565221)); `e2e-tests` and `collaboration-e2e-tests` passed ([E2E](https://github.com/karote00/asyra/actions/runs/34329565182)).
- Verified commit: `a987311035ac420f1bab14698fe0b26bc1ae5e40`.
