### PR TITLE
Prepare trusted Changesets for verified candidate PR delivery

### DIFF
--- a/.changeset/trusted-candidate-delivery.md
+++ b/.changeset/trusted-candidate-delivery.md
@@ -1,0 +1,7 @@
+---
+"@asyra/flow-inspector": patch
+---
+
+Prepare a trusted Factory patch Changeset alongside verified candidate source,
+bind the complete delivery preview to explicit confirmation, and display metadata
+validation separately from source evidence and GitHub checks.

--- a/docs/ai/tools/flow-inspector/PLANS.md
+++ b/docs/ai/tools/flow-inspector/PLANS.md
@@ -33,7 +33,10 @@ persistent investigation guidance; it does not implement remote reconciliation.
      Full original protection and delivery requirements remain open.
    - Bounded single-user GitHub PR review implementation and live acceptance
      are recorded in the [completed review record](plans/completed/flow-inspector-phase-6-github-review-closeout.md).
-     Candidate CI failure and the full Phase 6 gaps remain explicit.
+     Historical candidate CI failure remains explicit. The
+     [trusted Changeset closeout](plans/completed/flow-inspector-trusted-changeset-closeout.md)
+     records the subsequent exact candidate PR with all checks passing and closure
+     without merge; the full Phase 6 gaps remain open.
    - Remaining Phase 6: small-team operations, ticket integration, hosting and
      broader adoption remain unactivated.
 

--- a/docs/ai/tools/flow-inspector/PR_REVIEW.md
+++ b/docs/ai/tools/flow-inspector/PR_REVIEW.md
@@ -34,6 +34,49 @@ report digest and limitations. It creates no remote objects. Preview text is
 review data, never authority. Ordinary reads reuse retained records without
 source capture, GitHub polling or history reconstruction.
 
+## Trusted delivery metadata
+
+Activated 2026-09-09: delivery supports only existing Factory runtime source
+owned by `packages/factory/package.json`, declaring public `@asyra/factory`,
+and release type `patch`. Ownership must match the captured, verified manifest
+and exact remote base; absent, conflicting or nested package ownership rejects.
+Repository prose, candidate output and PR text cannot select policy. No arbitrary
+package, release type, summary or metadata path is accepted from an action.
+
+The review owner generates exactly one new `.changeset/flow-review-<task>-<attempt>.md`
+with the fixed package patch entry and a bounded, truthful summary identifying
+local candidate review. Demonstrations are labeled deterministic demonstrations,
+not model output. The path must be absent from the base; no metadata overwrite
+or symlink ancestor is allowed. Preparation writes only the existing delivery
+record, never the candidate or checkout. Candidate writes remain runtime-only.
+
+The complete preview separately presents candidate source changes and local
+verification, then trusted Changeset content, package ownership, release type,
+reason and metadata validation. Metadata validation establishes delivery policy
+conformance only, never any of the six source obligations. Repository, base SHA,
+branch, all source and metadata paths/bytes, PR title/body, task/attempt and both
+validation identities participate in the explicit confirmation digest. Source,
+metadata, policy, base or attempt changes require fresh preparation and confirmation.
+Historical source-only records remain readable and queryable, but cannot authorize
+new external writes without a current complete preview. Uncertain effects keep
+query-only reconciliation even after policy changes.
+
+The GitHub adapter validates the complete prepared metadata and writes exactly
+the source changes plus that Changeset in one tree/commit. It never derives a
+new summary or release decision from candidate or remote text. Board/API/CLI
+consume the same retained preview and audit; ordinary reads generate no metadata,
+recapture no source and perform no GitHub requests.
+
+Permanent cases cover correct package/content and explicit confirmation;
+missing/ambiguous ownership, unsupported release type, illegal path/content;
+candidate Changeset/test/gate attempts; stale metadata/source/base/attempt;
+dirty checkout, duplicate/retry/restart, uncertain successful timeout; shared
+Board/API/CLI records; and unchanged baseline, two flows and six obligations.
+Offline gates and desktop/tablet/narrow screenshot review must complete before
+an exact live preview is approved. Live acceptance requires all checks to pass
+on the actual candidate PR's latest HEAD, then closing that PR without merge.
+No model request or provider reconciliation is activated.
+
 ## Confirmed delivery
 
 The local owner requested ready-for-review PR creation for this slice so the
@@ -76,9 +119,8 @@ before fetching new ones. Failed refresh retains a stale/unknown observation,
 never current passed. Check runs and commit statuses are GitHub observations,
 not local six-obligation verification. A changed PR HEAD or base is visible as
 outside the prepared identity, never imported into local candidate authority.
-PR title/body edits cannot modify task scope. Repository checks may reject a
-source-only candidate (for example, a required Changeset); review delivery must
-show that failure rather than adding metadata outside the candidate scope. Closed or merged PRs and green
+PR title/body edits cannot modify task scope. Repository checks remain separate observations. The trusted metadata policy below
+prepares required Changesets without granting candidate metadata access. Closed or merged PRs and green
 checks never accept the local baseline. Query-only reconciliation never creates
 an extra branch or PR. No polling loop or inbound webhook is introduced.
 

--- a/docs/ai/tools/flow-inspector/decisions/releases/unreleased.md
+++ b/docs/ai/tools/flow-inspector/decisions/releases/unreleased.md
@@ -173,3 +173,16 @@ separates that live path from offline fault/state fixtures. Full Phase 5/6,
 protected verification/delivery and provider reconciliation remain open. No
 provider request, version, tag, merge of a GitHub PR, publication, protection or
 deployment setting change is performed.
+
+## 2026-09-11 - Complete trusted Changeset delivery and actual candidate CI acceptance
+
+Keep candidate access runtime-only and assign fixed public Factory patch metadata
+to the trusted review/delivery owners. Complete confirmation binds both artifacts
+without treating release metadata as source verification. The
+[bounded closeout](../../plans/completed/flow-inspector-trusted-changeset-closeout.md)
+records deterministic test PR #189, exact remote content, duplicate/restart audit,
+all five current-HEAD checks and closure without merge. One Sim production-test
+timeout required an unchanged-HEAD rerun; no gate was relaxed. This supersedes
+the source-only candidate CI limitation for this supported case, preserving
+PR #179/#182 history and all deferred Phase 5/6 and provider boundaries. No new
+model request or release action is authorized by green CI or by this closeout.

--- a/docs/ai/tools/flow-inspector/plans/completed/flow-inspector-trusted-changeset-closeout.md
+++ b/docs/ai/tools/flow-inspector/plans/completed/flow-inspector-trusted-changeset-closeout.md
@@ -1,0 +1,81 @@
+# Trusted Candidate Changeset Delivery - Bounded Closeout
+
+Completed: 2026-09-11. Delivery: PR #180, `codex/flow-inspector-trusted-changeset`.
+Rebased main: `5a20e5a8ddb290648e46379e8224700c59f5e733`.
+Verified implementation: `cc7161d6a974015ba9129ac412b7606ea35ee759`.
+
+## Completed boundary
+
+The existing `prepare-pr-review` owner prepares one fixed `@asyra/factory`
+patch Changeset from captured public package ownership. `deliver-github-review`
+creates only the exact confirmed runtime source and owner metadata. The Board
+separates source obligations, metadata validation and GitHub observations, while
+API and CLI consume the same retained record and audit. The living owner
+contracts and product cases remain in `PR_REVIEW.md` and the core-proof Inspector.
+
+Candidate writes remain runtime-only. Complete source, metadata, ownership,
+base, task/attempt and PR content bind confirmation. Dirty or stale inputs reject;
+duplicates and restart retain one delivery; uncertain effects reconcile by query.
+Neither metadata validation nor successful GitHub checks accept a baseline.
+
+## Actual acceptance
+
+The product adapter created normal test PR #189 from base `5a20e5a8` after
+explicit confirmation. Task `8288b2d1-3d3e-4989-bb20-db6e079c9396`, attempt
+`1e1fb80f-2030-463d-9bd2-4fd6c0ab9d57`, preview digest
+`03902b346638842474c3ac4931eb01024c8e1278c96c1fa2a9951f095fb5abc8`.
+Remote HEAD: `37fb440e7375c4542a3f65382d22c328960e7a8d`.
+
+This was a deterministic demonstration, not model output: a comment in
+`packages/factory/src/data-transact.ts` plus the trusted owner Changeset.
+The remote inventory, both file contents, title, body and HEAD matched the
+confirmed preview. All six real local sandbox obligations passed separately
+from metadata validation. Duplicate confirmation and service restart retained
+the exact record and audit without another PR.
+
+All five checks passed on that unchanged HEAD: validate and release-readiness
+in run `34602186418`, both E2E jobs in `34602186501`, and production-artifact-tests
+in `34602186455` attempt 2. Attempt 1 of the production test timed out in the
+existing Sim analysis budget (40/46 pairs); its unchanged-HEAD rerun passed.
+No budget, gate or deployment setting was changed. The current main inherited
+PR #186's production verification workflow. Historical PR #182's Vercel rate
+limit failures remain recorded and are not relabeled as a pass.
+
+The strict `FLOW_LIVE_REVIEW_REQUIRE_PASSED=1` Board test passed before and
+after closing PR #189 at `2026-09-11T13:17:54Z`; `mergedAt` remains null.
+It checked exact current HEAD success, six local obligations, metadata and
+Board/API/CLI identity. Desktop 1600x1100, tablet 820x1180 and narrow 390x844
+screenshots were inspected. Source, metadata and status remain readable;
+the existing canvas and fixed narrow return control are preserved.
+Accepted mapping remained unchanged through delivery, checks and closure.
+
+## Formal validation and retained evidence
+
+The rebased implementation passed 209 control-plane cases, 12 React cases,
+100 static/package cases, nine offline Board cases, naming, typecheck and build.
+Lint has zero errors and 79 existing warnings. The seven-run proof passed both
+Factory flows, all five registered negative scenarios and six obligations.
+The first Board invocation omitted its URL and could not start; the full
+configured rerun passed. Transport faults, stale inputs and adversarial metadata
+use permanent offline tests; no live timeout injection or merge is claimed.
+
+Local evidence is retained under `tmp/rebase-180/`, including exact remote
+content proof, duplicate/restart records, initial production failure and rerun,
+strict live acceptance logs, closure and baseline preservation. Screenshots and
+the shared record are under `tmp/flow-inspector/visual-review/github-live-8288b2d1-3d3e-4989-bb20-db6e079c9396/`.
+The existing store remains `tmp/flow-inspector/runs`; fresh clones do not contain
+live provenance. Reproduce retained review with the documented live Board test.
+
+## Deferred and release boundary
+
+This completes only trusted Changeset preparation and real candidate CI acceptance.
+Full Phase 5/6, protected verifier/issuer, required-check protection, provider
+reconciliation, ticket/team/hosting and checkout-independent dynamic execution
+remain deferred. PR #185's workflow aggregation is separate and not included.
+Unresolved provider request `98e706a5-ea09-4c6e-a1f5-57bd767b6c97` remains intact
+in its original store; its task file SHA256 remains
+`c3665a2a9327540998331674f98d4dbf4918867aa97d5374b316ee1093590038`.
+No model request, release, version application, tag, merge or protection change
+occurred. The implementation's existing tool patch record is separate from
+closeout; closeout creates no additional Changeset. Review notification requires
+all checks passing again on PR #180's final documentation-inclusive HEAD.

--- a/docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-actions-and-integrations-plan.md
+++ b/docs/ai/tools/flow-inspector/plans/flow-inspector-control-plane-actions-and-integrations-plan.md
@@ -259,3 +259,12 @@ closes only the selected local GitHub review slice: exact preview, explicit
 ready-for-review creation, retained audit and HEAD-bound observations. Real PR
 #179 demonstrates creation/restart and visible CI failure without baseline
 acceptance. The full Phase 5/6 DoD above remains open.
+
+## Trusted Changeset checkpoint - 2026-09-11
+
+The [trusted Changeset closeout](completed/flow-inspector-trusted-changeset-closeout.md)
+completes fixed Factory patch metadata preparation and exact confirmed delivery.
+Real deterministic test PR #189 passed all five latest-HEAD checks and was closed
+without merge; local source evidence, metadata and accepted baseline stayed
+separate. This supersedes the candidate CI gap for this bounded delivery case
+only, not the historical failure record or full Phase 5/6 requirements.

--- a/docs/ai/tools/flow-inspector/plans/flow-inspector-workflow-control-plane-roadmap.md
+++ b/docs/ai/tools/flow-inspector/plans/flow-inspector-workflow-control-plane-roadmap.md
@@ -501,3 +501,14 @@ The [bounded completed record](completed/flow-inspector-phase-6-github-review-cl
 records implemented preview/confirmation/observations and real PR #179 acceptance.
 Its source-only candidate CI fails the Changeset requirement; this is visible
 review evidence, not accepted delivery. Broader Phase 6 remains unactivated.
+
+## Trusted candidate Changeset acceptance - 2026-09-11
+
+The [bounded closeout](completed/flow-inspector-trusted-changeset-closeout.md)
+records trusted Factory patch metadata, complete confirmation and real test
+PR #189's five successful latest-HEAD checks, followed by closure without merge.
+The fixed delivery owner prepares metadata; the candidate retains runtime-only
+access. This closes the source-only candidate Changeset gap for the supported
+case. Historical failures and unresolved provider evidence remain intact.
+Full Phase 5/6, protected verification, required-check protection, provider
+reconciliation, ticket/team/hosting and standalone dynamic service remain deferred.

--- a/tools/flow-inspector/control-plane/README.md
+++ b/tools/flow-inspector/control-plane/README.md
@@ -556,7 +556,12 @@ GitHub review configuration grants no provider dispatch authority.
    validates source, all retained local obligations, accepted revision, a clean
    checkout and the remote base's captured inputs. Preparation creates no remote
    objects. A differing source closure or dirty checkout refuses delivery.
-3. Review the exact repository, base SHA, branch, changed files, title and body.
+3. Review the exact repository, base SHA, branch, all delivery files, title and body.
+   The trusted owner prepares an `@asyra/factory` patch Changeset separately
+   from candidate source evidence. Its package ownership, reason, exact content
+   and metadata validation appear in **Trusted owner Changeset**. Only existing
+   Factory runtime candidates are supported; requests cannot select arbitrary
+   packages, release types, summaries or paths. Metadata changes invalidate confirmation.
    Open the frozen source diff and local evidence links. Check the explicit
    confirmation only when this exact preview is approved, then select
    **Create confirmed PR**. Branch and PR creation stay in the trusted

--- a/tools/flow-inspector/control-plane/__tests__/board.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/board.test.cjs
@@ -2014,6 +2014,18 @@ test(
       )
       await expect(canvas.locator('#pr-confirm')).toBeDisabled()
       assert.equal(effects, 0)
+      await expect(canvas.locator('#pr-metadata')).toContainText(
+        '"@asyra/factory": patch'
+      )
+      await expect(canvas.locator('#pr-metadata')).toContainText(
+        'Deterministic demonstration'
+      )
+      await expect(canvas.locator('#pr-metadata')).toContainText(
+        'not source verification'
+      )
+      await expect(canvas.locator('#pr-preview')).toContainText(
+        '.changeset/flow-review-'
+      )
       for (const [name, width, height] of [
         ['desktop', 1600, 1100],
         ['tablet', 820, 1180],
@@ -2036,6 +2048,16 @@ test(
         await page.screenshot({
           path: path.join(artifacts, name + '-preview-top.png')
         })
+        await canvas.locator('#pr-metadata').scrollIntoViewIfNeeded()
+        await page.screenshot({
+          path: path.join(artifacts, name + '-metadata.png')
+        })
+        assert.equal(
+          await canvas
+            .locator('#pr-metadata')
+            .evaluate((el) => el.scrollWidth <= el.clientWidth + 2),
+          true
+        )
         await canvas.locator('#pr-confirm').scrollIntoViewIfNeeded()
         await page.screenshot({
           path: path.join(artifacts, name + '-preview-confirm.png')
@@ -2082,6 +2104,8 @@ test(
         server.origin + '/api/tasks/' + id + '/review'
       ).then((r) => r.json())
       assert.equal(api.preview.taskId, id)
+      assert.equal(api.preview.metadata.validation.status, 'passed')
+      assert.equal(api.preview.deliveryFiles.length, 2)
       assert.equal(api.observation.state, 'closed')
       assert.equal(service.getTask(id).deliveryStatus, 'not-delivered')
       fs.writeFileSync(

--- a/tools/flow-inspector/control-plane/__tests__/board.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/board.test.cjs
@@ -2153,6 +2153,30 @@ test(
     assert.equal(review.preview.attemptId, task.attempts.at(-1).id)
     assert.equal(review.preview.repository, process.env.FLOW_REVIEW_REPOSITORY)
     assert.ok(review.observation.number > 0)
+    if (process.env.FLOW_LIVE_REVIEW_REQUIRE_PASSED === '1') {
+      assert.equal(review.preview.metadata.validation.status, 'passed')
+      assert.equal(review.preview.metadata.packageName, '@asyra/factory')
+      assert.equal(review.observation.stale, false)
+      assert.equal(review.observation.matchesCandidate, true)
+      assert.equal(review.observation.checks.status, 'passed')
+      assert.equal(
+        review.observation.checks.headSha,
+        review.observation.headSha
+      )
+      assert.ok(review.observation.checks.items.length > 0)
+      assert.ok(
+        review.observation.checks.items.every(
+          (item) => item.status === 'completed' && item.conclusion === 'success'
+        )
+      )
+      assert.equal(task.verificationStatus, 'passed')
+      assert.equal(task.attempts.at(-1).verdict.evidence.cases.length, 6)
+      assert.ok(
+        task.attempts
+          .at(-1)
+          .verdict.evidence.cases.every((item) => item.status === 'passed')
+      )
+    }
     assert.match(review.observation.url, /^https:\/\/github.com\//)
     const lines = []
     assert.equal(
@@ -2214,6 +2238,15 @@ test(
         await page.screenshot({
           path: path.join(artifacts, name + '-status.png')
         })
+        if (review.preview.metadata) {
+          await expect(canvas.locator('#pr-metadata')).toContainText(
+            review.preview.metadata.content.trim()
+          )
+          await canvas.locator('#pr-metadata').scrollIntoViewIfNeeded()
+          await page.screenshot({
+            path: path.join(artifacts, name + '-metadata.png')
+          })
+        }
         await canvas.locator('#pr-source-diff').scrollIntoViewIfNeeded()
         await page.screenshot({
           path: path.join(artifacts, name + '-source.png')

--- a/tools/flow-inspector/control-plane/__tests__/github-delivery.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/github-delivery.test.cjs
@@ -5,7 +5,7 @@ const {
   createGitHubDelivery,
   transportError
 } = require('../github-delivery.cjs')
-const { gitDigest } = require('../pr-review.cjs')
+const { gitDigest, prepareMetadata } = require('../pr-review.cjs')
 const { sha256 } = require('../snapshot.cjs')
 const file = 'packages/factory/src/data-transact.ts',
   baseSha = 'a'.repeat(40),
@@ -49,6 +49,14 @@ function fixture() {
       }
     ]
   }
+  preview.packageOwnership = {
+    path: 'packages/factory/package.json',
+    packageName: '@asyra/factory',
+    digest: sha256('manifest')
+  }
+  preview.adapter = 'demonstration'
+  preview.metadata = prepareMetadata(preview)
+  preview.deliveryFiles = [file, preview.metadata.path]
   const makePR = () => ({
     number: 5,
     state: 'open',
@@ -82,8 +90,9 @@ function fixture() {
       assert.equal(body.base_tree, tree)
       assert.deepEqual(
         body.tree.map((x) => x.path),
-        [file]
+        [file, preview.metadata.path]
       )
+      assert.equal(body.tree[1].content, preview.metadata.content)
       return { sha: 'd'.repeat(40) }
     }
     if (tail === 'git/commits' && method === 'POST') {
@@ -341,3 +350,69 @@ test('real local Git admission refuses untracked dirt and committed source misma
   await assert.rejects(() => adapter.inspect(f.preview), /source differs/)
   assert.equal(reads, 0)
 })
+
+for (const [name, mutate] of [
+  ['missing metadata', (p) => delete p.metadata],
+  ['unsupported release type', (p) => (p.metadata.releaseType = 'major')],
+  ['wrong package', (p) => (p.metadata.packageName = '@asyra/core')],
+  [
+    'illegal metadata path',
+    (p) => (p.metadata.path = '.github/workflows/main.yml')
+  ],
+  ['changed metadata bytes', (p) => (p.metadata.content += 'forged')],
+  ['wrong metadata digest', (p) => (p.metadata.digest = '0'.repeat(64))],
+  ['extra delivery file', (p) => p.deliveryFiles.push('package.json')]
+])
+  test(name + ' cannot reach an external write', async () => {
+    const f = fixture()
+    mutate(f.preview)
+    await assert.rejects(
+      () => f.adapter.deliver(f.preview, async () => undefined, {}),
+      /metadata/
+    )
+    assert.equal(f.writes.length, 0)
+  })
+for (const [name, entry] of [
+  [
+    'existing Changeset',
+    (p) => ({ path: p.metadata.path, type: 'blob', mode: '100644', sha: head })
+  ],
+  [
+    'symlink metadata ancestor',
+    () => ({ path: '.changeset', type: 'blob', mode: '120000', sha: head })
+  ],
+  [
+    'nested package owner',
+    () => ({
+      path: 'packages/factory/src/package.json',
+      type: 'blob',
+      mode: '100644',
+      sha: head
+    })
+  ]
+])
+  test(name + ' refuses preparation without writes', async () => {
+    const f = fixture()
+    const adapter = createGitHubDelivery('/unused', {
+      repository: 'owner/repo',
+      local: () => undefined,
+      request: async (method, route) => {
+        assert.equal(method, 'GET')
+        if (route.includes('/ref/')) return { object: { sha: baseSha } }
+        if (route.includes('/commits/')) return { tree: { sha: tree } }
+        return {
+          truncated: false,
+          tree: [
+            {
+              path: file,
+              type: 'blob',
+              mode: '100644',
+              sha: f.preview.files[0].gitDigest
+            },
+            entry(f.preview)
+          ]
+        }
+      }
+    })
+    await assert.rejects(() => adapter.inspect(f.preview), /metadata|ownership/)
+  })

--- a/tools/flow-inspector/control-plane/__tests__/operations.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/operations.test.cjs
@@ -472,6 +472,12 @@ test(
       )
       const prepared = JSON.parse(lines.pop())
       assert.equal(prepared.preview.taskId, id)
+      assert.equal(prepared.preview.metadata.packageName, '@asyra/factory')
+      assert.equal(prepared.preview.metadata.validation.status, 'passed')
+      assert.deepEqual(prepared.preview.deliveryFiles, [
+        'packages/factory/src/data-transact.ts',
+        prepared.preview.metadata.path
+      ])
       const read = await fetch(
         server.origin + '/api/tasks/' + id + '/review'
       ).then((r) => r.json())
@@ -507,6 +513,10 @@ test(
       )
       const submitted = JSON.parse(lines.pop())
       assert.equal(submitted.state, 'submitted-for-review')
+      assert.deepEqual(submitted.preview, prepared.preview)
+      assert.ok(
+        submitted.audit.some((item) => item.event === 'human-confirmed')
+      )
       assert.equal(effects, 1)
       await main(['--url', server.origin, 'pr-refresh', id], {
         repositoryRoot: root,

--- a/tools/flow-inspector/control-plane/__tests__/pr-review.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/pr-review.test.cjs
@@ -116,6 +116,18 @@ function fixture() {
     candidateDirectory: () => candidateRoot,
     adapter
   }
+  const manifestPath = 'packages/factory/package.json'
+  const manifest = JSON.stringify({ name: '@asyra/factory', version: '1.0.0' })
+  for (const dir of [sourceRoot, verifiedRoot])
+    fs.writeFileSync(path.join(dir, manifestPath), manifest)
+  const manifestFile = {
+    path: manifestPath,
+    digest: sha256(manifest),
+    size: Buffer.byteLength(manifest)
+  }
+  record.snapshot.files.push(manifestFile)
+  files.push(manifestFile)
+  record.attempts[0].verdict.sourceDigest = sha256(JSON.stringify(files))
   const owner = createReviewOwner(root, options)
   return {
     owner,
@@ -391,3 +403,78 @@ test('only equivalent authorized requests coalesce while a delivery effect is pe
     await pending
   }
 })
+
+test('trusted Changeset is complete, correctly owned and separate from source verification', async () => {
+  const f = fixture(),
+    p = await prepare(f)
+  assert.equal(p.preview.metadata.validation.status, 'passed')
+  assert.equal(p.preview.metadata.releaseType, 'patch')
+  assert.equal(p.preview.metadata.packageName, '@asyra/factory')
+  const metadata = p.preview.metadata
+  assert.equal(
+    metadata.path,
+    `.changeset/flow-review-${f.record.id}-${f.record.attempts[0].id}.md`
+  )
+  assert.match(metadata.content, /^---\n"@asyra\/factory": patch\n---\n/)
+  assert.match(metadata.content, /Deterministic demonstration/)
+  assert.match(metadata.reason, /Factory/)
+  assert.deepEqual(p.preview.deliveryFiles, [file, metadata.path])
+  assert.equal(p.preview.changes.length, 1)
+  assert.equal(fs.existsSync(path.join(f.candidateRoot, metadata.path)), false)
+  assert.equal(fs.existsSync(path.join(f.sourceRoot, metadata.path)), false)
+  await confirm(f, p)
+  assert.equal(f.counts.deliver, 1)
+})
+for (const [name, mutate] of [
+  ['missing package ownership', (f) => f.record.snapshot.files.splice(1, 1)],
+  [
+    'ambiguous package ownership',
+    (f) => f.record.snapshot.files.push(f.record.snapshot.files[1])
+  ]
+])
+  test(name + ' prevents preparation', async () => {
+    const f = fixture()
+    mutate(f)
+    await assert.rejects(() => prepare(f), /ownership/)
+    assert.equal(f.counts.deliver, 0)
+  })
+for (const [name, mutate] of [
+  ['release type', (p) => (p.metadata.releaseType = 'minor')],
+  ['package name', (p) => (p.metadata.packageName = '@asyra/core')],
+  ['path', (p) => (p.metadata.path = '.github/workflows/main.yml')],
+  ['content', (p) => (p.metadata.content += 'unapproved')],
+  ['reason', (p) => (p.metadata.reason += 'unapproved')],
+  ['title', (p) => (p.title += 'unapproved')],
+  ['body', (p) => (p.body += 'unapproved')],
+  ['all files', (p) => p.deliveryFiles.push('package.json')]
+])
+  test(
+    'changed ' + name + ' cannot use a retained confirmation after restart',
+    async () => {
+      const f = fixture(),
+        p = structuredClone(await prepare(f))
+      mutate(p.preview)
+      p.previewDigest = sha256(JSON.stringify(p.preview))
+      fs.writeFileSync(
+        path.join(f.options.directory, f.record.id + '.json'),
+        JSON.stringify(p)
+      )
+      f.owner = createReviewOwner(root, f.options)
+      await assert.rejects(() => confirm(f, p), /metadata|preview/)
+      assert.equal(f.counts.deliver, 0)
+    }
+  )
+for (const forbidden of [
+  '.changeset/escape.md',
+  'packages/factory/src/__tests__/escape.ts',
+  '.github/workflows/escape.yml'
+])
+  test('candidate cannot contribute ' + forbidden, async () => {
+    const f = fixture()
+    fs.mkdirSync(path.dirname(path.join(f.candidateRoot, forbidden)), {
+      recursive: true
+    })
+    fs.writeFileSync(path.join(f.candidateRoot, forbidden), 'untrusted')
+    await assert.rejects(() => prepare(f), /candidate/)
+    assert.equal(f.counts.deliver, 0)
+  })

--- a/tools/flow-inspector/control-plane/github-delivery.cjs
+++ b/tools/flow-inspector/control-plane/github-delivery.cjs
@@ -3,6 +3,7 @@ const fs = require('node:fs')
 const { execFile, execFileSync } = require('node:child_process')
 const { safePath, sha256 } = require('./snapshot.cjs')
 const { canonicalFile } = require('./agent-contract.cjs')
+const { validateMetadata, METADATA_POLICY } = require('./pr-review.cjs')
 const hex = (value) => typeof value === 'string' && /^[a-f0-9]{40}$/.test(value)
 const need = (value, message) => {
   if (!value) throw new Error('GitHub delivery: ' + message)
@@ -240,10 +241,31 @@ function createGitHubDelivery(
           'base source differs from captured baseline'
         )
       }
+      if (input.metadata) {
+        validateMetadata(input)
+        need(!entries.has(input.metadata.path), 'metadata path already exists')
+        const ancestor = entries.get('.changeset')
+        need(
+          !ancestor || (ancestor.type === 'tree' && ancestor.mode === '040000'),
+          'invalid metadata ancestor'
+        )
+        for (const change of input.changes) {
+          const owners = [...entries.keys()].filter(
+            (name) =>
+              name.endsWith('/package.json') &&
+              change.path.startsWith(name.slice(0, -'package.json'.length))
+          )
+          need(
+            owners.every((name) => name === METADATA_POLICY.manifestPath),
+            'ambiguous package ownership'
+          )
+        }
+      }
       return { baseSha, baseTree }
     },
     async deliver(p, checkpoint, record) {
       validatePreview(p)
+      const metadata = validateMetadata(p)
       need((await readBase()) === p.baseSha, 'base advanced before effects')
       let expectedHead = record.expectedHead
       const existing = await api('GET', 'git/ref/heads/' + p.branch)
@@ -257,7 +279,10 @@ function createGitHubDelivery(
           await checkpoint('create-tree')
           const tree = await api('POST', 'git/trees', {
             base_tree: p.baseTree,
-            tree: p.changes.map((c) => ({
+            tree: [
+              ...p.changes,
+              { path: metadata.path, after: metadata.content }
+            ].map((c) => ({
               path: c.path,
               mode: '100644',
               type: 'blob',

--- a/tools/flow-inspector/control-plane/pr-review.cjs
+++ b/tools/flow-inspector/control-plane/pr-review.cjs
@@ -24,6 +24,79 @@ const gitDigest = (bytes) =>
     .update('blob ' + bytes.length + '\0')
     .update(bytes)
     .digest('hex')
+const METADATA_POLICY = freeze({
+  version: 1,
+  packageName: '@asyra/factory',
+  manifestPath: 'packages/factory/package.json',
+  sourcePrefix: 'packages/factory/src/',
+  releaseType: 'patch'
+})
+function prepareMetadata(input) {
+  const ownership = input.packageOwnership
+  need(
+    ownership?.path === METADATA_POLICY.manifestPath &&
+      ownership.packageName === METADATA_POLICY.packageName &&
+      /^[a-f0-9]{64}$/.test(ownership.digest) &&
+      validId(input.taskId) &&
+      validId(input.attemptId),
+    'invalid metadata package ownership'
+  )
+  need(
+    input.changes.every(
+      (c) =>
+        canonicalFile(c.path) &&
+        c.path.startsWith(METADATA_POLICY.sourcePrefix) &&
+        c.path.endsWith('.ts') &&
+        !c.path.includes('/__tests__/')
+    ),
+    'invalid metadata source ownership'
+  )
+  const summary =
+    input.adapter === 'demonstration'
+      ? 'Deterministic demonstration - retain a Factory runtime candidate for human review.'
+      : 'Retain a locally verified Factory runtime candidate for human review.'
+  const content =
+    '---\n"' +
+    METADATA_POLICY.packageName +
+    '": ' +
+    METADATA_POLICY.releaseType +
+    '\n---\n\n' +
+    summary +
+    '\n'
+  return {
+    policyVersion: METADATA_POLICY.version,
+    packageName: METADATA_POLICY.packageName,
+    releaseType: METADATA_POLICY.releaseType,
+    ownership,
+    path:
+      '.changeset/flow-review-' + input.taskId + '-' + input.attemptId + '.md',
+    content,
+    digest: sha256(content),
+    reason:
+      'Changed runtime source belongs to the captured public Factory package; the fixed delivery policy records patch release intent.',
+    validation: {
+      status: 'passed',
+      scope: 'delivery metadata only - not source verification'
+    }
+  }
+}
+function validateMetadata(preview) {
+  need(preview.metadata, 'metadata missing - prepare a fresh preview')
+  need(
+    JSON.stringify(preview.metadata) ===
+      JSON.stringify(prepareMetadata(preview)),
+    'metadata changed - prepare a fresh preview'
+  )
+  need(
+    JSON.stringify(preview.deliveryFiles) ===
+      JSON.stringify([
+        ...preview.changes.map((c) => c.path),
+        preview.metadata.path
+      ]),
+    'metadata delivery inventory changed'
+  )
+  return preview.metadata
+}
 function sourceDifference(changes) {
   return changes
     .map((change) => {
@@ -56,6 +129,44 @@ function sourceDifference(changes) {
       ].join('\n')
     })
     .join('\n\n')
+}
+function preparePreview(input, remote, adapter) {
+  const id = input.taskId
+  const metadata = prepareMetadata(input)
+  const title = 'Review candidate - ' + input.stepId
+  return {
+    ...input,
+    metadata,
+    deliveryFiles: [...input.changes.map((c) => c.path), metadata.path],
+    sourceDiff: sourceDifference(input.changes),
+    repository: adapter.repository,
+    base: adapter.base,
+    ...remote,
+    branch: 'codex/flow-review/' + id + '/' + input.attemptId,
+    title,
+    draft: false,
+    body: [
+      'Bounded candidate review for ' + input.stepId + '.',
+      '',
+      'Task: ' + id,
+      'Attempt: ' + input.attemptId,
+      'Source HEAD: ' + input.sourceHead,
+      'Source digest: ' + input.sourceDigest,
+      'Candidate digest: ' + input.candidateDigest,
+      'Local report digest: ' + input.reportDigest,
+      '',
+      'Source adapter: ' +
+        input.adapter +
+        '. Local verification passed the retained obligations.',
+      'This is not independently protected verification. PR creation and GitHub checks do not accept the local baseline.',
+      'Trusted delivery metadata: @asyra/factory patch Changeset; metadata validation is separate from local source verification.',
+      'Source provenance: ' +
+        (input.adapter === 'demonstration'
+          ? 'deterministic demonstration, not model output.'
+          : 'retained local candidate.'),
+      'Review the exact source changes. Merge, release and publication are separate human actions.'
+    ].join('\n')
+  }
 }
 function createReviewOwner(
   repositoryRoot,
@@ -159,6 +270,37 @@ function createReviewOwner(
     )
     for (const item of verdict.files)
       read(path.join(reportRoot, 'source'), item.path, item.digest)
+    const manifests = task.snapshot.files.filter(
+      (item) => item.path === METADATA_POLICY.manifestPath
+    )
+    need(manifests.length === 1, 'missing or ambiguous package ownership')
+    const manifest = manifests[0]
+    let packageInfo
+    try {
+      packageInfo = JSON.parse(
+        read(task.snapshot.sourceRoot, manifest.path, manifest.digest)
+      )
+    } catch {
+      throw new Error('PR review: invalid package ownership manifest')
+    }
+    need(
+      packageInfo.name === METADATA_POLICY.packageName &&
+        packageInfo.private !== true,
+      'unsupported package ownership'
+    )
+    need(
+      !task.snapshot.files.some(
+        (item) =>
+          item.path.startsWith(METADATA_POLICY.sourcePrefix) &&
+          item.path.endsWith('/package.json')
+      ),
+      'ambiguous nested package ownership'
+    )
+    const packageOwnership = {
+      path: manifest.path,
+      packageName: packageInfo.name,
+      digest: manifest.digest
+    }
     const files = task.snapshot.files.map((item) => ({
       ...item,
       gitDigest: gitDigest(
@@ -234,6 +376,7 @@ function createReviewOwner(
       candidateDigest: verdict.sourceDigest,
       reportDigest: verdict.runner.reportDigest,
       adapter: task.task.adapter,
+      packageOwnership,
       files,
       changes: diff
     }
@@ -267,34 +410,9 @@ function createReviewOwner(
           )
           return previous
         }
-        const remote = await adapter.inspect(input)
-        const title = 'Review candidate - ' + input.stepId
-        const preview = {
-          ...input,
-          sourceDiff: sourceDifference(input.changes),
-          repository: adapter.repository,
-          base: adapter.base,
-          ...remote,
-          branch: 'codex/flow-review/' + id + '/' + input.attemptId,
-          title,
-          draft: false,
-          body: [
-            'Bounded candidate review for ' + input.stepId + '.',
-            '',
-            'Task: ' + id,
-            'Attempt: ' + input.attemptId,
-            'Source HEAD: ' + input.sourceHead,
-            'Source digest: ' + input.sourceDigest,
-            'Candidate digest: ' + input.candidateDigest,
-            'Local report digest: ' + input.reportDigest,
-            '',
-            'Source adapter: ' +
-              input.adapter +
-              '. Local verification passed the retained obligations.',
-            'This is not independently protected verification. PR creation and GitHub checks do not accept the local baseline.',
-            'Review the exact source changes. Merge, release and publication are separate human actions.'
-          ].join('\n')
-        }
+        const prepared = preparePreview(input, {}, adapter)
+        const remote = await adapter.inspect(prepared)
+        const preview = { ...prepared, ...remote }
         const previewDigest = sha256(JSON.stringify(preview))
         if (previous?.previewDigest === previewDigest) return previous
         return save(
@@ -331,6 +449,7 @@ function createReviewOwner(
           current.preview.draft === false,
           'PR type changed - prepare a fresh preview'
         )
+        validateMetadata(current.preview)
         const input = inputs(id, actor)
         need(
           input.attemptId === current.preview.attemptId,
@@ -346,11 +465,17 @@ function createReviewOwner(
             adapter.base === current.preview.base,
           'delivery policy changed'
         )
-        const remote = await adapter.inspect(input)
+        const prepared = preparePreview(input, {}, adapter)
+        const remote = await adapter.inspect(prepared)
         need(
           remote.baseSha === current.preview.baseSha &&
             remote.baseTree === current.preview.baseTree,
           'remote base advanced'
+        )
+        need(
+          JSON.stringify({ ...prepared, ...remote }) ===
+            JSON.stringify(current.preview),
+          'complete preview changed - prepare a fresh preview'
         )
         current = save(
           { ...current, state: 'submitting', error: null },
@@ -435,4 +560,11 @@ function createReviewOwner(
     }
   }
 }
-module.exports = { createReviewOwner, REVIEW_POLICY, gitDigest }
+module.exports = {
+  createReviewOwner,
+  REVIEW_POLICY,
+  METADATA_POLICY,
+  prepareMetadata,
+  validateMetadata,
+  gitDigest
+}

--- a/tools/flow-inspector/control-plane/public/board.js
+++ b/tools/flow-inspector/control-plane/public/board.js
@@ -680,6 +680,7 @@
         byId('pr-confirm').disabled =
           !preview ||
           preview.draft !== false ||
+          !preview.metadata ||
           !['preview', 'blocked'].includes(review.state) ||
           !currentAttempt ||
           acting ||
@@ -693,6 +694,8 @@
             (currentAttempt
               ? (matching?.verificationStatus ?? 'no candidate selected')
               : 'historical attempt - open retained evidence'),
+          'Metadata validation: ' +
+            (preview?.metadata?.validation.status ?? 'not prepared'),
           'Delivery: ' + (review?.state ?? 'not prepared'),
           'PR: ' + (observation?.state ?? 'not observed'),
           'GitHub HEAD: ' + (observation?.headSha ?? 'unknown'),
@@ -730,13 +733,33 @@
               'Task: ' + preview.taskId,
               'Attempt: ' + preview.attemptId,
               'Source baseline: ' + preview.sourceHead,
-              'Changed files: ' +
-                preview.changes.map((change) => change.path).join(', '),
+              'All delivery files: ' +
+                (
+                  preview.deliveryFiles ??
+                  preview.changes.map((change) => change.path)
+                ).join(', '),
               'Title: ' + preview.title,
               '',
               preview.body
             ].join('\n')
           : 'Select an existing step task, then prepare an exact delivery preview. No branch or PR is created by preparation.'
+        const metadata = preview?.metadata
+        byId('pr-metadata').textContent = metadata
+          ? [
+              'Package: ' + metadata.packageName,
+              'Release type: ' + metadata.releaseType,
+              'Ownership: ' + metadata.ownership.path,
+              'Reason: ' + metadata.reason,
+              'Validation: ' +
+                metadata.validation.status +
+                ' - ' +
+                metadata.validation.scope,
+              'Path: ' + metadata.path,
+              'Digest: ' + metadata.digest,
+              '',
+              metadata.content
+            ].join('\n')
+          : 'No trusted Changeset in this record. Prepare a fresh complete preview before creation.'
         for (const [name, href] of [
           [
             'pr-source',
@@ -1174,11 +1197,12 @@
             <div class="proof-actions"><button id="pr-prepare" type="button">Prepare PR preview</button><button id="pr-refresh" type="button">Refresh GitHub review</button></div>
             <pre id="pr-result" role="status"></pre>
             <pre id="pr-preview"></pre>
-            <details><summary>Review source difference</summary><pre id="pr-source-diff"></pre></details>
+            <details><summary>Review source difference</summary><p>Candidate runtime source - local verification evidence is separate from delivery metadata.</p><pre id="pr-source-diff"></pre></details>
+            <h4>Trusted owner Changeset</h4><pre id="pr-metadata"></pre>
             <a id="pr-source" target="_blank" rel="noopener noreferrer" hidden>Open frozen source diff and delivery audit</a>
             <a id="pr-evidence" target="_blank" rel="noopener noreferrer" hidden>Open local candidate evidence</a>
             <a id="pr-github" target="_blank" rel="noopener noreferrer" hidden>Open GitHub review</a>
-            <label class="proof-confirmation"><input id="pr-approve" type="checkbox" />I reviewed this exact preview and confirm creating its branch and ready-for-review PR.</label>
+            <label class="proof-confirmation"><input id="pr-approve" type="checkbox" />I reviewed the complete source, trusted Changeset and PR content and confirm creating this exact branch and ready-for-review PR.</label>
             <button id="pr-confirm" type="button" disabled>Create confirmed PR</button>
           </details>
           <details id="phase4-controls"><summary>Contract versions and CI</summary>

--- a/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
+++ b/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
@@ -61,11 +61,12 @@ const data = {
         'artifact:agent-candidate-verdict',
         'current accepted revision and trusted delivery policy',
         'digest-checked candidate and captured source',
+        'captured package manifest and fixed Factory patch metadata policy',
         'artifact:github-review-observation'
       ],
       outputs: ['artifact:pr-review-record'],
       conditions: [
-        'Admit only exact passing latest candidate source and explicit actor confirmation. Persist preview and intent before effects; uncertain operations reconcile by query only; ordinary reads do no remote or source work.'
+        'Admit only exact passing latest candidate source with unambiguous captured Factory ownership. Prepare one fixed patch Changeset separately from source verification; bind all metadata, source, policy and PR content to explicit actor confirmation. Persist preview and intent before effects; uncertain operations reconcile by query only; ordinary reads do no remote or source work.'
       ],
       bypasses: [
         'Disabled integration has no effects. Missing, stale, denied or uncertain inputs cannot grant success.'
@@ -78,6 +79,7 @@ const data = {
       forbiddenContributors: [
         'candidate execution or self-authorization',
         'PR content as permission',
+        'candidate-authored metadata or arbitrary package, release type or path',
         'accepted baseline mutation',
         'raw credentials or transport errors in output'
       ],
@@ -102,11 +104,12 @@ const data = {
         'artifact:pr-review-record',
         'trusted fixed repository and base configuration',
         'digest-checked candidate changes and baseline files',
+        'completed trusted Changeset and metadata validation in the review record',
         'explicit effect checkpoint from review owner'
       ],
       outputs: ['artifact:github-review-observation'],
       conditions: [
-        'Check clean checkout and exact remote base source before effects. Only confirmed frozen bytes may create a new branch and ready-for-review PR. Read current PR and HEAD-bound checks; unknown transport effects never become failure proof or authorize blind retry.'
+        'Check clean checkout and exact remote base source before effects. Reject existing metadata paths, symlink ancestors and conflicting package ownership. Only confirmed frozen source and validated Changeset bytes may create a new branch and ready-for-review PR. Read current PR and HEAD-bound checks; unknown transport effects never become failure proof or authorize blind retry.'
       ],
       bypasses: [
         'Disabled integration has no effects. Missing, stale, denied or uncertain inputs cannot grant success.'
@@ -119,6 +122,7 @@ const data = {
       forbiddenContributors: [
         'candidate execution or self-authorization',
         'PR content as permission',
+        'candidate-authored metadata or arbitrary package, release type or path',
         'accepted baseline mutation',
         'raw credentials or transport errors in output'
       ],
@@ -554,7 +558,7 @@ const data = {
         'On a newly selected failed attempt, select the first failing flow if the current flow has no failures; request viewer-owned framing of that flow’s failed step IDs once per changed result; preserve subsequent manual selection, pan and zoom on unchanged refresh. Success and unknown results do not move the viewport. Show a persistent run-level failure alert with named owner navigation and geometry-preserving failed card highlights; clear them on recovery.',
         'Bind cards only after graph DOM replacement; unchanged polling rebuilds neither graph nor bindings and performs no source capture. Target retirement disconnects observers and aborts reads.',
         'Project explicit work reports separately from verification and delivery. Project candidate verification, exact version review with retirement, all-flow CI blockers and artifacts, retry, and baseline/time-labeled shared viewing through the same action service. Show every registered negative scenario, snapshot and version identity, runner environment, named artifact links, and retained attempts; unsupported targets and untested steps receive no successful evidence. Prepare and decide mapping reviews through the action service with an explicit reason; never accept mapping changes in the client.',
-        'Project the selected task/attempt delivery preview, exact confirmation, audit and GitHub HEAD-bound observations through the common action service. Never combine local verification with remote checks or accept baseline from a PR.',
+        'Project the selected task/attempt complete delivery preview with source evidence and trusted Changeset content/reason separately, exact confirmation, audit and GitHub HEAD-bound observations through the common action service. Never combine local verification with remote checks or accept baseline from a PR.',
         'Loaded canvas step contracts must match admitted verification steps before projecting evidence or enabling launch.'
       ],
       bypasses: [

--- a/tools/flow-inspector/workspace/workspace-bundle.data.js
+++ b/tools/flow-inspector/workspace/workspace-bundle.data.js
@@ -35367,13 +35367,14 @@
               "artifact:agent-candidate-verdict",
               "current accepted revision and trusted delivery policy",
               "digest-checked candidate and captured source",
+              "captured package manifest and fixed Factory patch metadata policy",
               "artifact:github-review-observation"
             ],
             "outputs": [
               "artifact:pr-review-record"
             ],
             "conditions": [
-              "Admit only exact passing latest candidate source and explicit actor confirmation. Persist preview and intent before effects; uncertain operations reconcile by query only; ordinary reads do no remote or source work."
+              "Admit only exact passing latest candidate source with unambiguous captured Factory ownership. Prepare one fixed patch Changeset separately from source verification; bind all metadata, source, policy and PR content to explicit actor confirmation. Persist preview and intent before effects; uncertain operations reconcile by query only; ordinary reads do no remote or source work."
             ],
             "bypasses": [
               "Disabled integration has no effects. Missing, stale, denied or uncertain inputs cannot grant success."
@@ -35386,6 +35387,7 @@
             "forbiddenContributors": [
               "candidate execution or self-authorization",
               "PR content as permission",
+              "candidate-authored metadata or arbitrary package, release type or path",
               "accepted baseline mutation",
               "raw credentials or transport errors in output"
             ],
@@ -35410,13 +35412,14 @@
               "artifact:pr-review-record",
               "trusted fixed repository and base configuration",
               "digest-checked candidate changes and baseline files",
+              "completed trusted Changeset and metadata validation in the review record",
               "explicit effect checkpoint from review owner"
             ],
             "outputs": [
               "artifact:github-review-observation"
             ],
             "conditions": [
-              "Check clean checkout and exact remote base source before effects. Only confirmed frozen bytes may create a new branch and ready-for-review PR. Read current PR and HEAD-bound checks; unknown transport effects never become failure proof or authorize blind retry."
+              "Check clean checkout and exact remote base source before effects. Reject existing metadata paths, symlink ancestors and conflicting package ownership. Only confirmed frozen source and validated Changeset bytes may create a new branch and ready-for-review PR. Read current PR and HEAD-bound checks; unknown transport effects never become failure proof or authorize blind retry."
             ],
             "bypasses": [
               "Disabled integration has no effects. Missing, stale, denied or uncertain inputs cannot grant success."
@@ -35429,6 +35432,7 @@
             "forbiddenContributors": [
               "candidate execution or self-authorization",
               "PR content as permission",
+              "candidate-authored metadata or arbitrary package, release type or path",
               "accepted baseline mutation",
               "raw credentials or transport errors in output"
             ],
@@ -35903,7 +35907,7 @@
               "On a newly selected failed attempt, select the first failing flow if the current flow has no failures; request viewer-owned framing of that flow’s failed step IDs once per changed result; preserve subsequent manual selection, pan and zoom on unchanged refresh. Success and unknown results do not move the viewport. Show a persistent run-level failure alert with named owner navigation and geometry-preserving failed card highlights; clear them on recovery.",
               "Bind cards only after graph DOM replacement; unchanged polling rebuilds neither graph nor bindings and performs no source capture. Target retirement disconnects observers and aborts reads.",
               "Project explicit work reports separately from verification and delivery. Project candidate verification, exact version review with retirement, all-flow CI blockers and artifacts, retry, and baseline/time-labeled shared viewing through the same action service. Show every registered negative scenario, snapshot and version identity, runner environment, named artifact links, and retained attempts; unsupported targets and untested steps receive no successful evidence. Prepare and decide mapping reviews through the action service with an explicit reason; never accept mapping changes in the client.",
-              "Project the selected task/attempt delivery preview, exact confirmation, audit and GitHub HEAD-bound observations through the common action service. Never combine local verification with remote checks or accept baseline from a PR.",
+              "Project the selected task/attempt complete delivery preview with source evidence and trusted Changeset content/reason separately, exact confirmation, audit and GitHub HEAD-bound observations through the common action service. Never combine local verification with remote checks or accept baseline from a PR.",
               "Loaded canvas step contracts must match admitted verification steps before projecting evidence or enabling launch."
             ],
             "bypasses": [


### PR DESCRIPTION
Verified runtime-only candidates previously could not satisfy the repository Changeset gate. This change makes the trusted delivery owner prepare a fixed `@asyra/factory` patch Changeset, display its content and ownership separately from local source evidence, and bind the complete delivery to exact confirmation. Candidate sandbox permissions remain unchanged.

The existing broker and GitHub adapter preserve duplicate/restart identity and query-only reconciliation for uncertain effects. Source, metadata, GitHub checks and accepted baseline remain separate. No model request, merge, release, protection or deployment configuration change is included.

Validation after rebasing onto main `5a20e5a8`: 209 control-plane cases, 12 React cases, 100 static/package cases, nine offline Board cases, seven-run Factory proof, naming, typecheck and build pass. Lint: zero errors, 79 existing warnings. Desktop, tablet and narrow screenshots inspected.

Actual product acceptance: deterministic demonstration PR #189, HEAD `37fb440e7375c4542a3f65382d22c328960e7a8d`, passed all five checks. Production-artifact-tests had one Sim analysis timeout, then passed on an unchanged-HEAD rerun with the original budget and gate. All remote files and PR content matched the confirmed preview; duplicate confirmation and service restart retained the same audit. Strict live Board/API/CLI acceptance passed before and after closing #189 without merge. The historical failed acceptance #182 and unresolved provider request remain intact.

The bounded completed record, PLANS, roadmap and append-only decision history are updated in `docs/ai/tools/flow-inspector/plans/completed/flow-inspector-trusted-changeset-closeout.md`. Full Phase 5/6, protected verification/protection, provider reconciliation, ticket/team/hosting and standalone dynamic services remain deferred. PR #185 is separate.

Final documentation-inclusive HEAD `d0dede7f91d4587cc6bfb97479d9d8445c56b8d9` passed all 5/5 checks: validate, E2E, collaboration E2E, production-artifact-tests and framework-release-readiness. Ready for human review; no merge performed.
