### PR TITLE
[TEST ONLY - DO NOT MERGE] Verify final Flow CI detects Design Delete fault

### DIFF
--- a/.changeset/final-flow-ci-results.md
+++ b/.changeset/final-flow-ci-results.md
@@ -1,0 +1,5 @@
+---
+"@asyra/flow-inspector": patch
+---
+
+Aggregate completed Factory and Design CI jobs with exact Delete case outcomes and execution identity, preserving failures and missing evidence.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,12 @@
 name: E2E Tests
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call:
+    outputs:
+      design-evidence:
+        value: ${{ jobs.e2e-tests.outputs.evidence }}
+      collaboration-evidence:
+        value: ${{ jobs.collaboration-e2e-tests.outputs.evidence }}
   workflow_dispatch:
     inputs:
       run_balanced_ai_correctness:
@@ -22,6 +26,15 @@ concurrency:
 
 jobs:
   e2e-tests:
+    outputs:
+      evidence: ${{ steps.flow-results.outputs.evidence }}
+    env:
+      FLOW_RESULT_REPOSITORY: ${{ github.repository }}
+      FLOW_RESULT_BASE: ${{ github.event.pull_request.base.sha || github.sha }}
+      FLOW_RESULT_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+      FLOW_RESULT_INTEGRATION: ${{ github.sha }}
+      FLOW_RESULT_RUN: ${{ github.run_id }}
+      FLOW_RESULT_ATTEMPT: ${{ github.run_attempt }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -62,10 +75,25 @@ jobs:
 
       - name: Run E2E Tests
         env:
+          FLOW_CI_REPORT: ${{ github.workspace }}/tmp/flow-ci/design.json
           RUN_BALANCED_AI_CORRECTNESS: ${{ steps.balanced_ai_scope.outputs.run_balanced_ai_correctness }}
         run: bash scripts/run-e2e.sh
 
+      - name: Collect Design flow results
+        id: flow-results
+        if: ${{ always() }}
+        run: node tools/flow-inspector/control-plane/workflow-results.cjs collect design tmp/flow-ci/design.json
+
   collaboration-e2e-tests:
+    outputs:
+      evidence: ${{ steps.flow-results.outputs.evidence }}
+    env:
+      FLOW_RESULT_REPOSITORY: ${{ github.repository }}
+      FLOW_RESULT_BASE: ${{ github.event.pull_request.base.sha || github.sha }}
+      FLOW_RESULT_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+      FLOW_RESULT_INTEGRATION: ${{ github.sha }}
+      FLOW_RESULT_RUN: ${{ github.run_id }}
+      FLOW_RESULT_ATTEMPT: ${{ github.run_attempt }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -93,4 +121,11 @@ jobs:
         run: yarn react:build
 
       - name: Run Collaboration E2E Tests
-        run: yarn workspace @asyra/asyra-design test:e2e:collaboration
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: ${{ github.workspace }}/tmp/flow-ci/collaboration.json
+        run: yarn workspace @asyra/asyra-design test:e2e:collaboration --reporter=line,json
+
+      - name: Collect collaboration flow results
+        id: flow-results
+        if: ${{ always() }}
+        run: node tools/flow-inspector/control-plane/workflow-results.cjs collect collaboration tmp/flow-ci/collaboration.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,11 +103,12 @@ jobs:
         run: yarn release:records
 
   design-e2e:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/e2e.yml
 
   flow-ci:
     needs: [validate, design-e2e]
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
           FLOW_CI_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
           FLOW_CI_EMIT_EVIDENCE: '1'
         run: |
-          node --test --test-concurrency=1 tools/flow-inspector/control-plane/__tests__/{contracts,snapshot,runner,evidence,store,service,server,mapping,cli,evolution,ci-context,ci-evidence,operations,agent-contract,agent-provider,agent-transport,agent-task,agent-verifier,pr-review,github-delivery}.test.cjs
+          node --test --test-concurrency=1 tools/flow-inspector/control-plane/__tests__/{contracts,snapshot,runner,evidence,store,service,server,mapping,cli,evolution,ci-context,ci-evidence,operations,agent-contract,agent-provider,agent-transport,agent-task,agent-verifier,pr-review,github-delivery,workflow-results}.test.cjs
           node tools/flow-inspector/control-plane/cli.cjs prove
           node tools/flow-inspector/control-plane/cli.cjs ci-trial
 
@@ -101,3 +101,30 @@ jobs:
 
       - name: Verify release records
         run: yarn release:records
+
+  design-e2e:
+    uses: ./.github/workflows/e2e.yml
+
+  flow-ci:
+    needs: [validate, design-e2e]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      FLOW_RESULT_REPOSITORY: ${{ github.repository }}
+      FLOW_RESULT_BASE: ${{ github.event.pull_request.base.sha || github.sha }}
+      FLOW_RESULT_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+      FLOW_RESULT_INTEGRATION: ${{ github.sha }}
+      FLOW_RESULT_RUN: ${{ github.run_id }}
+      FLOW_RESULT_ATTEMPT: ${{ github.run_attempt }}
+      FLOW_VALIDATE_RESULT: ${{ needs.validate.result }}
+      FLOW_E2E_RESULT: ${{ needs.design-e2e.result }}
+      FLOW_DESIGN_EVIDENCE: ${{ needs.design-e2e.outputs.design-evidence }}
+      FLOW_COLLABORATION_EVIDENCE: ${{ needs.design-e2e.outputs.collaboration-evidence }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Aggregate completed flow results
+        run: node tools/flow-inspector/control-plane/workflow-results.cjs aggregate

--- a/apps/asyra-design/src/features/delete-element/index.ts
+++ b/apps/asyra-design/src/features/delete-element/index.ts
@@ -19,7 +19,7 @@ export const deleteElementFeature = defineFeature(
       }
 
       const selectedIds = selectionApis.getSelectedIds()
-      if (selectedIds.length !== 1) {
+      if (selectedIds.length !== 2) {
         return null
       }
 

--- a/docs/ai/tools/flow-inspector/CORE_PROOF.md
+++ b/docs/ai/tools/flow-inspector/CORE_PROOF.md
@@ -355,3 +355,41 @@ GitHub repository and one candidate review. The trusted delivery adapter uses
 explicit preview confirmation; external observations do not admit CI evidence,
 accept a local baseline or alter any of the six obligations. Earlier phase
 exclusions above describe their original activation, not this later grant.
+
+## Final workflow aggregation
+
+The `flow-ci` GitHub job waits for `validate` and the reusable Design E2E
+workflow, and runs even when a dependency fails. It consumes their completed
+results; it does not analyze runtime source or execute a second test suite.
+The existing Factory proof remains an independent producer. A successful
+Factory job does not establish Design conformance.
+
+The bounded Design mapping contains the existing single-element Delete case
+and two collaboration Delete cases (connected windows and nested Group removal).
+The workflow collects exact Playwright file, title, project, expected status,
+and every attempt outcome. Missing, duplicate, skipped, interrupted, unexpected,
+flaky, malformed or report-error results cannot pass. A known failed assertion
+remains failed even when another required case was not reached by fail-fast.
+Other Design flows remain outside this mapping, not implicitly verified.
+
+Each producer envelope binds repository, base, PR HEAD, actual integration SHA,
+run id and run attempt, plus the raw report SHA-256. The collector emits bounded
+job outputs and a readable job summary after tests, including failed tests.
+The final job validates identity and the exact fixed case inventory before
+projecting pass, fail or unverified. Dependency failure also blocks the final
+check even when the selected cases passed. Missing output after infrastructure
+failure or cancellation remains unverified. No secret, raw stdout, screenshot,
+trace, or arbitrary report text enters the bounded output.
+
+This is observational CI integration, not a protected issuer. Workflow and
+report bytes remain repository-controlled; digest integrity is not authenticity.
+It grants neither accepted conformance nor delivery authorization and makes no
+required-check protection claim. Existing Board PR observations can display
+the final GitHub check and its summary link; this does not add Design badges
+to the local Factory proof or alter accepted history.
+
+Formal cases cover outcome classification, exact identity, malformed and missing
+reports, inventory weakening, dependency failures and workflow ordering. Live
+acceptance uses the same Delete runtime mutation as PR 183, then removes it and
+requires a new successful final check on the corrected HEAD. Test PRs close
+without merging; production changes are delivered separately.

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -93,7 +93,15 @@ test('GitHub Actions use least privilege and immutable action revisions', () => 
     const workflow = readText(workflowPath)
     assert.match(workflow, /^permissions:\n {2}contents: read$/m, workflowPath)
     for (const line of workflow.match(/^\s*-?\s*uses:\s*\S+$/gm) ?? []) {
-      assert.match(line, /@[0-9a-f]{40}(?:\s+#.*)?$/u, line)
+      if (line.trim() === 'uses: ./.github/workflows/e2e.yml') {
+        assert.equal(workflowPath, '.github/workflows/main.yml')
+        assert.match(
+          readText('.github/workflows/e2e.yml'),
+          /^ {2}workflow_call:/m
+        )
+      } else {
+        assert.match(line, /@[0-9a-f]{40}(?:\s+#.*)?$/u, line)
+      }
     }
   }
 
@@ -109,7 +117,15 @@ test('PR workflows skip Draft jobs and run when the PR becomes ready', () => {
     '.github/workflows/e2e.yml'
   ]) {
     const workflow = readText(workflowPath)
-    const events = workflow.match(/pull_request:\n\s+types: \[([^\]]+)\]/)[1]
+    const eventOwner =
+      workflowPath === '.github/workflows/e2e.yml'
+        ? readText('.github/workflows/main.yml')
+        : workflow
+    if (workflowPath === '.github/workflows/e2e.yml') {
+      assert.match(workflow, /^ {2}workflow_call:/m)
+      assert.doesNotMatch(workflow, /^ {2}pull_request:/m)
+    }
+    const events = eventOwner.match(/pull_request:\n\s+types: \[([^\]]+)\]/)[1]
     for (const event of [
       'opened',
       'synchronize',
@@ -120,11 +136,18 @@ test('PR workflows skip Draft jobs and run when the PR becomes ready', () => {
     }
     const jobs = workflow.split('\njobs:\n')[1].split(/(?=^ {2}[\w-]+:\n)/m)
     for (const job of jobs.filter((block) => block.trim())) {
-      assert.match(
-        job,
-        /^ {4}if: github.event_name != 'pull_request' \|\| github.event.pull_request.draft == false$/m,
-        `${workflowPath}: ${job.split('\n')[0]}`
-      )
+      if (job.startsWith('  flow-ci:')) {
+        assert.match(
+          job,
+          /^ {4}if: \$\{\{ always\(\) && \(github.event_name != 'pull_request' \|\| github.event.pull_request.draft == false\) \}\}$/m
+        )
+      } else {
+        assert.match(
+          job,
+          /^ {4}if: github.event_name != 'pull_request' \|\| github.event.pull_request.draft == false$/m,
+          `${workflowPath}: ${job.split('\n')[0]}`
+        )
+      }
     }
   }
 })

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -110,7 +110,11 @@ if [ "${CI:-}" = "true" ]; then
   E2E_RENDER_PERFORMANCE_BROWSER=chromium \
     yarn workspace @asyra/asyra-design playwright test --config playwright.config.ts e2e/render-delta-performance.spec.ts --workers=1
   echo "Step 11: Running functional Playwright tests..."
-  E2E_SKIP_PERFORMANCE=true yarn test:e2e
+  if [ -n "${FLOW_CI_REPORT:-}" ]; then
+    E2E_SKIP_PERFORMANCE=true PLAYWRIGHT_JSON_OUTPUT_NAME="$FLOW_CI_REPORT" yarn test:e2e --reporter=line,json
+  else
+    E2E_SKIP_PERFORMANCE=true yarn test:e2e
+  fi
 else
   echo "Step 10: Running Playwright tests..."
   yarn test:e2e

--- a/tools/flow-inspector/control-plane/__tests__/board.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/board.test.cjs
@@ -656,7 +656,32 @@ test(
         canvas.locator('.proof-badge[data-status="passed"]')
       ).toHaveCount(3)
       await page.goto(server.origin + '/core-proof')
-      await expect(canvas.locator('.step-card')).toHaveCount(13)
+      await expect(canvas.locator('.step-card')).toHaveCount(14)
+      await expect(
+        canvas.locator('[data-step-id="aggregate-workflow-results"]')
+      ).toContainText('Aggregate completed workflow results')
+      for (const viewport of [
+        { width: 1600, height: 1100 },
+        { width: 820, height: 1180 },
+        { width: 390, height: 844 }
+      ]) {
+        await page.setViewportSize(viewport)
+        await page.goto(server.origin + '/core-proof')
+        await canvas
+          .locator('[data-step-id="aggregate-workflow-results"]')
+          .click()
+        await expect(canvas.locator('.detail-heading')).toContainText(
+          'Aggregate completed workflow results'
+        )
+        await page.screenshot({
+          path: path.join(
+            artifacts,
+            'workflow-owner-' + viewport.width + '.png'
+          ),
+          fullPage: true
+        })
+      }
+      await page.setViewportSize({ width: 1600, height: 1100 })
       await expect(canvas.locator('.proof-badge')).toHaveCount(0)
       await expect(canvas.locator('#run-all')).toHaveCount(0)
       await expect(canvas.locator('#proof-unavailable')).toContainText(

--- a/tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs
@@ -1,0 +1,191 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { test } = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const { collect, aggregate } = require('../workflow-results.cjs')
+const identity = {
+  repository: 'karote00/asyra',
+  base: 'a'.repeat(40),
+  head: 'b'.repeat(40),
+  integration: 'c'.repeat(40),
+  run: '123',
+  attempt: '1'
+}
+const names = [
+  ['delete-element.spec.ts', 'Delete key removes the single selected element'],
+  [
+    'collaboration.spec.ts',
+    'two real Asyra Design windows converge while connected and catch up through reconnect bootstrap'
+  ],
+  [
+    'collaboration.spec.ts',
+    'remote undo restores an exact nested Group with and without local tombstones'
+  ]
+]
+function report(indices) {
+  return {
+    errors: [],
+    suites: [
+      {
+        suites: [
+          {
+            specs: indices.map((i) => ({
+              file: names[i][0],
+              title: names[i][1],
+              tests: [
+                {
+                  projectName: 'chromium',
+                  expectedStatus: 'passed',
+                  results: [{ status: 'passed' }]
+                }
+              ]
+            }))
+          }
+        ]
+      }
+    ]
+  }
+}
+function envelopes() {
+  return [
+    collect(report([0]), 'design', identity),
+    collect(report([1, 2]), 'collaboration', identity)
+  ]
+}
+function assess(
+  records = envelopes(),
+  jobs = { validate: 'success', e2e: 'success' }
+) {
+  return aggregate(records, identity, jobs)
+}
+test('all exact Design cases pass only after successful dependencies', () => {
+  const r = assess()
+  assert.equal(r.status, 'passed')
+  assert.equal(r.cases.length, 3)
+})
+test('a Delete assertion failure survives missing downstream observations and failed jobs', () => {
+  const r = report([0])
+  r.suites[0].suites[0].specs[0].tests[0].results[0].status = 'failed'
+  const result = assess(
+    [collect(r, 'design', identity), collect(null, 'collaboration', identity)],
+    { validate: 'success', e2e: 'failure' }
+  )
+  assert.equal(result.status, 'failed')
+  assert.equal(result.cases[0].status, 'failed')
+  assert.equal(result.cases[1].status, 'unverified')
+})
+for (const status of ['skipped', 'interrupted', 'unknown'])
+  test(status + ' cannot pass', () => {
+    const r = report([0])
+    r.suites[0].suites[0].specs[0].tests[0].results[0].status = status
+    assert.notEqual(
+      assess([collect(r, 'design', identity), envelopes()[1]]).status,
+      'passed'
+    )
+  })
+test('failed retry followed by pass remains failed', () => {
+  const r = report([0])
+  r.suites[0].suites[0].specs[0].tests[0].results = [
+    { status: 'failed' },
+    { status: 'passed' }
+  ]
+  assert.equal(collect(r, 'design', identity).cases[0].status, 'failed')
+})
+for (const variant of [
+  'missing',
+  'duplicate',
+  'wrong-project',
+  'expected-failure',
+  'errors'
+])
+  test(variant + ' report is unverified', () => {
+    const r = report([0])
+    const specs = r.suites[0].suites[0].specs
+    if (variant === 'missing') specs.length = 0
+    if (variant === 'duplicate') specs.push(structuredClone(specs[0]))
+    if (variant === 'wrong-project') specs[0].tests[0].projectName = 'firefox'
+    if (variant === 'expected-failure')
+      specs[0].tests[0].expectedStatus = 'failed'
+    if (variant === 'errors')
+      r.errors.push({ message: 'do not expose report text' })
+    assert.equal(collect(r, 'design', identity).cases[0].status, 'unverified')
+  })
+for (const key of Object.keys(identity))
+  test('mismatched ' + key + ' cannot pass', () => {
+    const e = envelopes()
+    e[0].identity[key] += 'x'
+    assert.equal(assess(e).status, 'unverified')
+  })
+test('malformed envelope, removed or duplicated cases cannot weaken inventory', () => {
+  for (const records of [[], [null], [{ producer: 'design' }]])
+    assert.notEqual(assess(records).status, 'passed')
+  const e = envelopes()
+  e[0].cases = []
+  assert.equal(assess(e).status, 'unverified')
+  const d = envelopes()
+  d.push(d[0])
+  assert.equal(assess(d).status, 'unverified')
+  const changed = envelopes()
+  changed[0].cases[0].status = 'passed'
+  changed[0].cases[0].observations[0].results = ['failed']
+  assert.notEqual(assess(changed).status, 'passed')
+})
+test('dependency failure or cancellation blocks green even if selected cases passed', () => {
+  for (const outcome of ['failure', 'cancelled', 'skipped', ''])
+    assert.notEqual(
+      assess(envelopes(), { validate: outcome, e2e: 'success' }).status,
+      'passed'
+    )
+})
+test('bounded output contains no raw report messages or stdout', () => {
+  const r = report([0])
+  r.secret = 'SENSITIVE_VALUE'
+  r.errors = [{ message: 'SENSITIVE_VALUE' }]
+  assert.ok(
+    !JSON.stringify(collect(r, 'design', identity)).includes('SENSITIVE_VALUE')
+  )
+})
+test('workflow waits on reusable producers and always collects after failed tests', () => {
+  const root = path.resolve(__dirname, '../../../..')
+  const main = fs.readFileSync(
+    path.join(root, '.github/workflows/main.yml'),
+    'utf8'
+  )
+  const e2e = fs.readFileSync(
+    path.join(root, '.github/workflows/e2e.yml'),
+    'utf8'
+  )
+  assert.match(
+    main,
+    /flow-ci:\s*\n\s*needs: \[validate, design-e2e\]\s*\n\s*if: \$\{\{ always\(\) \}\}/
+  )
+  assert.match(main, /uses: \.\/.github\/workflows\/e2e.yml/)
+  assert.match(e2e, /workflow_call:/)
+  assert.doesNotMatch(e2e.split('permissions:')[0], /pull_request:/)
+  assert.equal((e2e.match(/if: \$\{\{ always\(\) \}\}/g) || []).length, 2)
+  assert.match(e2e, /workflow-results.cjs collect design/)
+  assert.match(e2e, /workflow-results.cjs collect collaboration/)
+})
+
+test('CLI retains missing reports as unverified and exits nonzero on incomplete aggregation', () => {
+  const { spawnSync } = require('node:child_process')
+  const root = path.resolve(__dirname, '../../../..')
+  const parent = path.join(root, 'tmp/flow-ci-tests')
+  fs.mkdirSync(parent, { recursive: true })
+  const directory = fs.mkdtempSync(path.join(parent, 'results-'))
+  try {
+    const output = path.join(directory, 'output')
+    const summary = path.join(directory, 'summary')
+    const env = { ...process.env, GITHUB_OUTPUT: output, GITHUB_STEP_SUMMARY: summary, ...Object.fromEntries(Object.entries(identity).map(([k, v]) => ['FLOW_RESULT_' + k.toUpperCase(), v])) }
+    const cli = path.join(root, 'tools/flow-inspector/control-plane/workflow-results.cjs')
+    const collected = spawnSync(process.execPath, [cli, 'collect', 'design', path.join(directory, 'missing.json')], { env, encoding: 'utf8' })
+    assert.equal(collected.status, 0)
+    const evidence = JSON.parse(fs.readFileSync(output, 'utf8').trim().slice('evidence='.length))
+    assert.equal(evidence.cases[0].status, 'unverified')
+    const result = spawnSync(process.execPath, [cli, 'aggregate'], { env: { ...env, FLOW_DESIGN_EVIDENCE: JSON.stringify(evidence), FLOW_COLLABORATION_EVIDENCE: 'invalid', FLOW_VALIDATE_RESULT: 'success', FLOW_E2E_RESULT: 'failure' }, encoding: 'utf8' })
+    assert.equal(result.status, 1)
+    assert.equal(JSON.parse(result.stdout).status, 'unverified')
+    assert.match(fs.readFileSync(summary, 'utf8'), /design.delete \| unverified/)
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+})

--- a/tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs
@@ -177,15 +177,55 @@ test('CLI retains missing reports as unverified and exits nonzero on incomplete 
   try {
     const output = path.join(directory, 'output')
     const summary = path.join(directory, 'summary')
-    const env = { ...process.env, GITHUB_OUTPUT: output, GITHUB_STEP_SUMMARY: summary, ...Object.fromEntries(Object.entries(identity).map(([k, v]) => ['FLOW_RESULT_' + k.toUpperCase(), v])) }
-    const cli = path.join(root, 'tools/flow-inspector/control-plane/workflow-results.cjs')
-    const collected = spawnSync(process.execPath, [cli, 'collect', 'design', path.join(directory, 'missing.json')], { env, encoding: 'utf8' })
+    const env = {
+      ...process.env,
+      GITHUB_OUTPUT: output,
+      GITHUB_STEP_SUMMARY: summary,
+      ...Object.fromEntries(
+        Object.entries(identity).map(([k, v]) => [
+          'FLOW_RESULT_' + k.toUpperCase(),
+          v
+        ])
+      )
+    }
+    const cli = path.join(
+      root,
+      'tools/flow-inspector/control-plane/workflow-results.cjs'
+    )
+    const collected = spawnSync(
+      process.execPath,
+      [cli, 'collect', 'design', path.join(directory, 'missing.json')],
+      { env, encoding: 'utf8' }
+    )
     assert.equal(collected.status, 0)
-    const evidence = JSON.parse(fs.readFileSync(output, 'utf8').trim().slice('evidence='.length))
+    const evidence = JSON.parse(
+      fs.readFileSync(output, 'utf8').trim().slice('evidence='.length)
+    )
     assert.equal(evidence.cases[0].status, 'unverified')
-    const result = spawnSync(process.execPath, [cli, 'aggregate'], { env: { ...env, FLOW_DESIGN_EVIDENCE: JSON.stringify(evidence), FLOW_COLLABORATION_EVIDENCE: 'invalid', FLOW_VALIDATE_RESULT: 'success', FLOW_E2E_RESULT: 'failure' }, encoding: 'utf8' })
+    assert.equal(
+      evidence.identity.integration,
+      spawnSync('git', ['rev-parse', 'HEAD'], {
+        cwd: root,
+        encoding: 'utf8'
+      }).stdout.trim()
+    )
+    const result = spawnSync(process.execPath, [cli, 'aggregate'], {
+      env: {
+        ...env,
+        FLOW_DESIGN_EVIDENCE: JSON.stringify(evidence),
+        FLOW_COLLABORATION_EVIDENCE: 'invalid',
+        FLOW_VALIDATE_RESULT: 'success',
+        FLOW_E2E_RESULT: 'failure'
+      },
+      encoding: 'utf8'
+    })
     assert.equal(result.status, 1)
     assert.equal(JSON.parse(result.stdout).status, 'unverified')
-    assert.match(fs.readFileSync(summary, 'utf8'), /design.delete \| unverified/)
-  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+    assert.match(
+      fs.readFileSync(summary, 'utf8'),
+      /design.delete \| unverified/
+    )
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
 })

--- a/tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs
+++ b/tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs
@@ -158,7 +158,7 @@ test('workflow waits on reusable producers and always collects after failed test
   )
   assert.match(
     main,
-    /flow-ci:\s*\n\s*needs: \[validate, design-e2e\]\s*\n\s*if: \$\{\{ always\(\) \}\}/
+    /flow-ci:\s*\n\s*needs: \[validate, design-e2e\]\s*\n\s*if: \$\{\{ always\(\) && \(github.event_name != 'pull_request' \|\| github.event.pull_request.draft == false\) \}\}/
   )
   assert.match(main, /uses: \.\/.github\/workflows\/e2e.yml/)
   assert.match(e2e, /workflow_call:/)

--- a/tools/flow-inspector/control-plane/workflow-results.cjs
+++ b/tools/flow-inspector/control-plane/workflow-results.cjs
@@ -1,0 +1,237 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('node:fs')
+const { createHash } = require('node:crypto')
+const inventory = Object.freeze(
+  [
+    {
+      id: 'design.delete',
+      producer: 'design',
+      file: 'delete-element.spec.ts',
+      title: 'Delete key removes the single selected element'
+    },
+    {
+      id: 'design.collaboration-delete',
+      producer: 'collaboration',
+      file: 'collaboration.spec.ts',
+      title:
+        'two real Asyra Design windows converge while connected and catch up through reconnect bootstrap'
+    },
+    {
+      id: 'design.group-delete',
+      producer: 'collaboration',
+      file: 'collaboration.spec.ts',
+      title:
+        'remote undo restores an exact nested Group with and without local tombstones'
+    }
+  ].map(Object.freeze)
+)
+const identityKeys = [
+  'repository',
+  'base',
+  'head',
+  'integration',
+  'run',
+  'attempt'
+]
+const hash = (value) => createHash('sha256').update(value).digest('hex')
+function classify(observations, reportValid) {
+  if (
+    observations.some((o) =>
+      o.results?.some((s) => ['failed', 'timedOut'].includes(s))
+    )
+  )
+    return 'failed'
+  if (!reportValid || observations.length !== 1) return 'unverified'
+  const o = observations[0]
+  return o.project === 'chromium' &&
+    o.expected === 'passed' &&
+    o.results.length === 1 &&
+    o.results[0] === 'passed'
+    ? 'passed'
+    : 'unverified'
+}
+function collect(report, producer, identity) {
+  if (!['design', 'collaboration'].includes(producer))
+    throw new Error('Unknown workflow producer')
+  const specs = []
+  function walk(suites) {
+    if (!Array.isArray(suites)) return
+    for (const suite of suites) {
+      if (!suite || typeof suite !== 'object') continue
+      if (Array.isArray(suite.specs)) specs.push(...suite.specs)
+      walk(suite.suites)
+    }
+  }
+  walk(report?.suites)
+  const reportValid = Boolean(
+    report &&
+    Array.isArray(report.suites) &&
+    Array.isArray(report.errors) &&
+    report.errors.length === 0
+  )
+  const cases = inventory
+    .filter((c) => c.producer === producer)
+    .map((c) => {
+      const observations = specs
+        .filter(
+          (s) =>
+            s &&
+            [c.file, 'e2e/' + c.file].includes(s.file) &&
+            s.title === c.title
+        )
+        .flatMap((s) => (Array.isArray(s.tests) ? s.tests : []))
+        .map((t) => ({
+          project: t.projectName === 'chromium' ? 'chromium' : 'unknown',
+          expected: t.expectedStatus === 'passed' ? 'passed' : 'unknown',
+          results: Array.isArray(t.results)
+            ? t.results
+                .map((r) =>
+                  [
+                    'passed',
+                    'failed',
+                    'timedOut',
+                    'skipped',
+                    'interrupted'
+                  ].includes(r?.status)
+                    ? r.status
+                    : 'unknown'
+                )
+                .slice(0, 20)
+            : []
+        }))
+        .slice(0, 20)
+      return {
+        id: c.id,
+        status: classify(observations, reportValid),
+        observations
+      }
+    })
+  return {
+    version: 1,
+    producer,
+    identity: Object.fromEntries(identityKeys.map((k) => [k, identity[k]])),
+    reportDigest: hash(JSON.stringify(report ?? null)),
+    reportValid,
+    cases
+  }
+}
+function aggregate(envelopes, identity, jobs) {
+  const blockers = []
+  const validIdentity =
+    identityKeys.every(
+      (k) => typeof identity[k] === 'string' && identity[k].length > 0
+    ) &&
+    ['base', 'head', 'integration'].every((k) =>
+      /^[a-f0-9]{40}$/.test(identity[k])
+    )
+  if (!validIdentity)
+    blockers.push('Expected execution identity is unavailable')
+  const cases = inventory.map((c) => {
+    const records = Array.isArray(envelopes)
+      ? envelopes.filter((e) => e?.producer === c.producer)
+      : []
+    const e = records.length === 1 ? records[0] : null
+    const expectedIds = inventory
+      .filter((i) => i.producer === c.producer)
+      .map((i) => i.id)
+    const admitted =
+      validIdentity &&
+      e?.version === 1 &&
+      typeof e.reportValid === 'boolean' &&
+      /^[a-f0-9]{64}$/.test(e.reportDigest ?? '') &&
+      identityKeys.every((k) => e.identity?.[k] === identity[k]) &&
+      Array.isArray(e.cases) &&
+      JSON.stringify(e.cases.map((o) => o?.id)) === JSON.stringify(expectedIds)
+    const observed = admitted ? e.cases.find((o) => o.id === c.id) : null
+    let status = 'unverified'
+    if (
+      observed &&
+      Array.isArray(observed.observations) &&
+      observed.observations.every((o) => o && Array.isArray(o.results))
+    )
+      status = classify(observed.observations, e.reportValid)
+    if (!admitted)
+      blockers.push(c.id + ': missing or invalid producer evidence')
+    return {
+      id: c.id,
+      owner: 'apps/asyra-design/src/features/delete-element/index.ts',
+      file: 'apps/asyra-design/e2e/' + c.file,
+      title: c.title,
+      status
+    }
+  })
+  for (const name of ['validate', 'e2e'])
+    if (jobs[name] !== 'success')
+      blockers.push(name + ': prerequisite did not succeed')
+  let status = 'passed'
+  if (cases.some((c) => c.status === 'failed')) status = 'failed'
+  else if (blockers.length || cases.some((c) => c.status !== 'passed'))
+    status = 'unverified'
+  return {
+    version: 1,
+    identity,
+    status,
+    cases,
+    blockers,
+    acceptedBaselineChanged: false,
+    protectedEvidence: false
+  }
+}
+function runtimeIdentity() {
+  return Object.fromEntries(
+    identityKeys.map((k) => [
+      k,
+      process.env['FLOW_RESULT_' + k.toUpperCase()] ?? ''
+    ])
+  )
+}
+function summary(result) {
+  return [
+    '## Flow CI - ' + result.status,
+    '',
+    'Observational results; no accepted baseline or protected delivery authorization.',
+    '',
+    '| Case | Result |',
+    '| --- | --- |',
+    ...result.cases.map((c) => '| ' + c.id + ' | ' + c.status + ' |'),
+    '',
+    ...result.blockers.map((b) => '- ' + b),
+    ''
+  ].join('\n')
+}
+if (require.main === module) {
+  const [command, producer, reportPath] = process.argv.slice(2)
+  if (command === 'collect') {
+    let report = null
+    try {
+      if (fs.statSync(reportPath).size <= 32 * 1024 * 1024)
+        report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+    } catch {
+      /* Missing producer output remains unverified. */
+    }
+    const envelope = collect(report, producer, runtimeIdentity())
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      'evidence=' + JSON.stringify(envelope) + '\n'
+    )
+  } else if (command === 'aggregate') {
+    const envelopes = [
+      'FLOW_DESIGN_EVIDENCE',
+      'FLOW_COLLABORATION_EVIDENCE'
+    ].map((k) => {
+      try {
+        return JSON.parse(process.env[k] ?? '')
+      } catch {
+        return null
+      }
+    })
+    const result = aggregate(envelopes, runtimeIdentity(), {
+      validate: process.env.FLOW_VALIDATE_RESULT,
+      e2e: process.env.FLOW_E2E_RESULT
+    })
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary(result))
+    console.log(JSON.stringify(result, null, 2))
+    process.exitCode = result.status === 'passed' ? 0 : 1
+  } else throw new Error('Expected collect or aggregate')
+}
+module.exports = { collect, aggregate }

--- a/tools/flow-inspector/control-plane/workflow-results.cjs
+++ b/tools/flow-inspector/control-plane/workflow-results.cjs
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require('node:fs')
+const { execFileSync } = require('node:child_process')
 const { createHash } = require('node:crypto')
 const inventory = Object.freeze(
   [
@@ -209,7 +210,11 @@ if (require.main === module) {
     } catch {
       /* Missing producer output remains unverified. */
     }
-    const envelope = collect(report, producer, runtimeIdentity())
+    const identity = runtimeIdentity()
+    identity.integration = execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8'
+    }).trim()
+    const envelope = collect(report, producer, identity)
     fs.appendFileSync(
       process.env.GITHUB_OUTPUT,
       'evidence=' + JSON.stringify(envelope) + '\n'

--- a/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
+++ b/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
@@ -60,7 +60,7 @@ const data = {
       allowedContributors: ['GitHub Actions job dependencies and outputs', 'existing Playwright JSON reporter'],
       forbiddenContributors: ['runtime source analysis', 'candidate-selected case inventory', 'accepted baseline mutation', 'provider success substituted for assertions'],
       cacheDimensions: [],
-      implementationBoundary: ['tools/flow-inspector/control-plane/workflow-results.cjs', 'tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs', 'tools/flow-inspector/control-plane/__tests__/board.test.cjs', '.github/workflows/main.yml', '.github/workflows/e2e.yml', 'scripts/run-e2e.sh'],
+      implementationBoundary: ['tools/flow-inspector/control-plane/workflow-results.cjs', 'tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs', 'tools/flow-inspector/control-plane/__tests__/board.test.cjs', '.github/workflows/main.yml', '.github/workflows/e2e.yml', 'scripts/run-e2e.sh', 'scripts/__tests__/workspace-automation.test.mjs'],
       specRefs: ['#final-workflow-aggregation'], failureOwnerStepId: 'aggregate-workflow-results'
     },
     {

--- a/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
+++ b/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
@@ -60,7 +60,7 @@ const data = {
       allowedContributors: ['GitHub Actions job dependencies and outputs', 'existing Playwright JSON reporter'],
       forbiddenContributors: ['runtime source analysis', 'candidate-selected case inventory', 'accepted baseline mutation', 'provider success substituted for assertions'],
       cacheDimensions: [],
-      implementationBoundary: ['tools/flow-inspector/control-plane/workflow-results.cjs', 'tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs', '.github/workflows/main.yml', '.github/workflows/e2e.yml', 'scripts/run-e2e.sh'],
+      implementationBoundary: ['tools/flow-inspector/control-plane/workflow-results.cjs', 'tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs', 'tools/flow-inspector/control-plane/__tests__/board.test.cjs', '.github/workflows/main.yml', '.github/workflows/e2e.yml', 'scripts/run-e2e.sh'],
       specRefs: ['#final-workflow-aggregation'], failureOwnerStepId: 'aggregate-workflow-results'
     },
     {

--- a/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
+++ b/tools/flow-inspector/inspectors/flow-inspector-core-proof-flow-inspector.data.cjs
@@ -50,6 +50,20 @@ const data = {
   ],
   steps: [
     {
+      id: 'aggregate-workflow-results', order: 15, laneId: 'proof',
+      title: 'Aggregate completed workflow results',
+      ownerPackage: 'tools/flow-inspector/control-plane', purpose: 'Observational CI aggregation',
+      inputs: ['completed validate and Design E2E job results', 'fixed Design Delete case inventory', 'Playwright raw case reports', 'GitHub repository, base, head, integration, run and attempt identity'],
+      outputs: ['artifact:workflow-result-summary'],
+      conditions: ['Wait for all declared producer jobs even on failure. Validate exact case inventory, all attempt outcomes and matching execution identity. Preserve confirmed failures; missing or invalid evidence is unverified. Job success is not case evidence or accepted conformance.'],
+      bypasses: ['No skipped, missing, mismatched or failed evidence becomes a pass.'],
+      allowedContributors: ['GitHub Actions job dependencies and outputs', 'existing Playwright JSON reporter'],
+      forbiddenContributors: ['runtime source analysis', 'candidate-selected case inventory', 'accepted baseline mutation', 'provider success substituted for assertions'],
+      cacheDimensions: [],
+      implementationBoundary: ['tools/flow-inspector/control-plane/workflow-results.cjs', 'tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs', '.github/workflows/main.yml', '.github/workflows/e2e.yml', 'scripts/run-e2e.sh'],
+      specRefs: ['#final-workflow-aggregation'], failureOwnerStepId: 'aggregate-workflow-results'
+    },
+    {
       id: 'prepare-pr-review',
       order: 12,
       laneId: 'interaction',
@@ -583,6 +597,7 @@ const data = {
     }
   ],
   routes: [
+    { id: 'aggregate-workflow-results-terminal', from: 'aggregate-workflow-results', kind: 'terminal', predicate: 'Declared producer jobs have settled and their evidence has been assessed.', producedArtifacts: ['artifact:workflow-result-summary'] },
     {
       id: 'execute-agent-task-to-prepare-pr-review',
       from: 'execute-agent-task',
@@ -762,6 +777,7 @@ const data = {
     }
   ],
   artifacts: [
+    { id: 'artifact:workflow-result-summary', title: 'Workflow result summary', ownerStepId: 'aggregate-workflow-results', channel: 'github-check', consumerStepIds: [], terminal: true },
     {
       id: 'artifact:pr-review-record',
       title: 'Candidate PR review',

--- a/tools/flow-inspector/workspace/workspace-bundle.data.js
+++ b/tools/flow-inspector/workspace/workspace-bundle.data.js
@@ -35394,7 +35394,8 @@
               "tools/flow-inspector/control-plane/__tests__/board.test.cjs",
               ".github/workflows/main.yml",
               ".github/workflows/e2e.yml",
-              "scripts/run-e2e.sh"
+              "scripts/run-e2e.sh",
+              "scripts/__tests__/workspace-automation.test.mjs"
             ],
             "specRefs": [
               "#final-workflow-aggregation"

--- a/tools/flow-inspector/workspace/workspace-bundle.data.js
+++ b/tools/flow-inspector/workspace/workspace-bundle.data.js
@@ -35356,6 +35356,51 @@
         ],
         "steps": [
           {
+            "id": "aggregate-workflow-results",
+            "order": 15,
+            "laneId": "proof",
+            "title": "Aggregate completed workflow results",
+            "ownerPackage": "tools/flow-inspector/control-plane",
+            "purpose": "Observational CI aggregation",
+            "inputs": [
+              "completed validate and Design E2E job results",
+              "fixed Design Delete case inventory",
+              "Playwright raw case reports",
+              "GitHub repository, base, head, integration, run and attempt identity"
+            ],
+            "outputs": [
+              "artifact:workflow-result-summary"
+            ],
+            "conditions": [
+              "Wait for all declared producer jobs even on failure. Validate exact case inventory, all attempt outcomes and matching execution identity. Preserve confirmed failures; missing or invalid evidence is unverified. Job success is not case evidence or accepted conformance."
+            ],
+            "bypasses": [
+              "No skipped, missing, mismatched or failed evidence becomes a pass."
+            ],
+            "allowedContributors": [
+              "GitHub Actions job dependencies and outputs",
+              "existing Playwright JSON reporter"
+            ],
+            "forbiddenContributors": [
+              "runtime source analysis",
+              "candidate-selected case inventory",
+              "accepted baseline mutation",
+              "provider success substituted for assertions"
+            ],
+            "cacheDimensions": [],
+            "implementationBoundary": [
+              "tools/flow-inspector/control-plane/workflow-results.cjs",
+              "tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs",
+              ".github/workflows/main.yml",
+              ".github/workflows/e2e.yml",
+              "scripts/run-e2e.sh"
+            ],
+            "specRefs": [
+              "#final-workflow-aggregation"
+            ],
+            "failureOwnerStepId": "aggregate-workflow-results"
+          },
+          {
             "id": "prepare-pr-review",
             "order": 12,
             "laneId": "interaction",
@@ -35933,6 +35978,15 @@
         ],
         "routes": [
           {
+            "id": "aggregate-workflow-results-terminal",
+            "from": "aggregate-workflow-results",
+            "kind": "terminal",
+            "predicate": "Declared producer jobs have settled and their evidence has been assessed.",
+            "producedArtifacts": [
+              "artifact:workflow-result-summary"
+            ]
+          },
+          {
             "id": "execute-agent-task-to-prepare-pr-review",
             "from": "execute-agent-task",
             "to": "prepare-pr-review",
@@ -36153,6 +36207,14 @@
           }
         ],
         "artifacts": [
+          {
+            "id": "artifact:workflow-result-summary",
+            "title": "Workflow result summary",
+            "ownerStepId": "aggregate-workflow-results",
+            "channel": "github-check",
+            "consumerStepIds": [],
+            "terminal": true
+          },
           {
             "id": "artifact:pr-review-record",
             "title": "Candidate PR review",

--- a/tools/flow-inspector/workspace/workspace-bundle.data.js
+++ b/tools/flow-inspector/workspace/workspace-bundle.data.js
@@ -35391,6 +35391,7 @@
             "implementationBoundary": [
               "tools/flow-inspector/control-plane/workflow-results.cjs",
               "tools/flow-inspector/control-plane/__tests__/workflow-results.test.cjs",
+              "tools/flow-inspector/control-plane/__tests__/board.test.cjs",
               ".github/workflows/main.yml",
               ".github/workflows/e2e.yml",
               "scripts/run-e2e.sh"


### PR DESCRIPTION
Test-only verification requested by the repository owner. **Do not merge. Closed after obtaining real CI evidence.**

Exact tested HEAD: `fa33fba5517b894f295658065081345b36aa85f6`.

Relative to delivery PR 185, the only source difference is the deliberate Delete guard fault (`selectedIds.length !== 1` becomes `!== 2`). Formal behavioral assertions, workflow aggregation and metadata are identical.

Actual GitHub run: https://github.com/karote00/asyra/actions/runs/34354774205

- `validate`, including the original Factory proof: SUCCESS.
- Design E2E: FAILURE at the existing single-element Delete assertion.
- Collaboration E2E: FAILURE at the two existing Delete scenarios.
- Final `flow-ci`: FAILURE, explicitly reporting `design.delete`, `design.collaboration-delete`, and `design.group-delete` as failed.
- Every producer completed before the final job started at 2026-09-09T13:12:36Z. Run id, attempt, repository, base, PR HEAD and actual integration SHA matched; missing output was not substituted with provider status.

Final aggregation log: https://github.com/karote00/asyra/actions/runs/34354774205/job/102479458603

This demonstrates actual failure propagation after producer completion, rather than merely leaving the independent Factory proof green. No model request, accepted-baseline update, merge, release, protection change or deployment configuration change was performed. Normal implementation is delivered in PR 185.
