### PR TITLE
ci: release affected apps manually behind production verification

### DIFF
--- a/.changeset/manual-app-release.md
+++ b/.changeset/manual-app-release.md
@@ -1,0 +1,5 @@
+---
+---
+
+Separate manual App deployments from PR validation, verify production artifacts,
+and require explicit production approval with per-App accumulated change detection.

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -87,6 +87,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_BYPASS_SIM: ${{ secrets.VERCEL_BYPASS_SIM }}
+          VERCEL_BYPASS_DESIGN: ${{ secrets.VERCEL_BYPASS_DESIGN }}
+          VERCEL_BYPASS_FRAMEWORK: ${{ secrets.VERCEL_BYPASS_FRAMEWORK }}
           VERCEL_TEAM_ID: ${{ vars.VERCEL_TEAM_ID }}
           FORCE_APP: ${{ inputs.force_app }}
           RELEASE_REASON: ${{ inputs.reason }}

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -1,0 +1,94 @@
+name: Manual App Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_app:
+        description: Optional App to rebuild for an out-of-Git configuration change
+        type: choice
+        default: ''
+        options: ['', 'asyra-sim', 'asyra-design', 'asyra-framework']
+      reason:
+        description: Required reason when forcing an App release
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: manual-app-production
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    if: github.repository_id == '893098287' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: read
+    outputs:
+      plan: ${{ steps.plan.outputs.plan }}
+      has_changes: ${{ steps.plan.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '24'
+      - name: Plan accumulated App changes
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE_APP: ${{ inputs.force_app }}
+          RELEASE_REASON: ${{ inputs.reason }}
+        run: node scripts/app-release.mjs plan
+
+  ci:
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    uses: ./.github/workflows/main.yml
+
+  e2e:
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    uses: ./.github/workflows/e2e.yml
+    with:
+      run_balanced_ai_correctness: true
+
+  production-artifacts:
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    uses: ./.github/workflows/production-artifacts.yml
+
+  publish:
+    needs: [plan, ci, e2e, production-artifacts]
+    if: github.repository_id == '893098287' && github.ref == 'refs/heads/main' && needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    environment: app-production
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '24'
+      # No dependency install, PR artifact download or build in this privileged job.
+      - name: Stage, verify and promote the admitted App versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TEAM_ID: ${{ vars.VERCEL_TEAM_ID }}
+          FORCE_APP: ${{ inputs.force_app }}
+          RELEASE_REASON: ${{ inputs.reason }}
+          RELEASE_PLAN: ${{ needs.plan.outputs.plan }}
+        run: node scripts/app-release.mjs publish

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,11 @@
 name: E2E Tests
 
 on:
+  workflow_call:
+    inputs:
+      run_balanced_ai_correctness:
+        type: boolean
+        default: false
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
@@ -31,6 +36,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Yarn
         run: corepack enable && yarn set version 4.3.1
@@ -73,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Yarn
         run: corepack enable && yarn set version 4.3.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   push:
     branches:
       - main
@@ -19,6 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Yarn
         run: corepack enable && yarn set version 4.3.1
@@ -77,6 +79,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Yarn
         run: corepack enable && yarn set version 4.3.1

--- a/.github/workflows/production-artifacts.yml
+++ b/.github/workflows/production-artifacts.yml
@@ -26,9 +26,9 @@ jobs:
       - run: yarn install --immutable
       - name: Install the existing Playwright browser
         run: yarn workspace @asyra/asyra-design playwright install --with-deps chromium
-      - name: Check Design application types
-        run: yarn workspace @asyra/asyra-design typecheck
       - name: Build production artifacts
         run: yarn react:build
+      - name: Check Design application types
+        run: yarn workspace @asyra/asyra-design typecheck
       - name: Test production artifacts without dev servers
         run: yarn test:production-artifacts

--- a/.github/workflows/production-artifacts.yml
+++ b/.github/workflows/production-artifacts.yml
@@ -1,0 +1,34 @@
+name: Production Artifacts
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  production-artifact-tests:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Setup Yarn
+        run: corepack enable && yarn set version 4.3.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: '24'
+          cache: yarn
+      - run: yarn install --immutable
+      - name: Install the existing Playwright browser
+        run: yarn workspace @asyra/asyra-design playwright install --with-deps chromium
+      - name: Check Design application types
+        run: yarn workspace @asyra/asyra-design typecheck
+      - name: Build production artifacts
+        run: yarn react:build
+      - name: Test production artifacts without dev servers
+        run: yarn test:production-artifacts

--- a/.github/workflows/production-artifacts.yml
+++ b/.github/workflows/production-artifacts.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install the existing Playwright browser
         run: yarn workspace @asyra/asyra-design playwright install --with-deps chromium
       - name: Build production artifacts
-        run: yarn react:build
+        run: yarn build:production-artifacts
       - name: Check Design application types
         run: yarn workspace @asyra/asyra-design typecheck
       - name: Test production artifacts without dev servers

--- a/apps/asyra-design/vercel.json
+++ b/apps/asyra-design/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "cd ../.. && corepack yarn install --immutable",
+  "buildCommand": "cd ../.. && corepack yarn gen:turbo:check && corepack yarn turbo run react:build --filter=@asyra/asyra-design --concurrency=2",
+  "outputDirectory": "dist/frontend",
+  "git": {
+    "deploymentEnabled": false
+  }
+}

--- a/apps/asyra-framework-site/vercel.json
+++ b/apps/asyra-framework-site/vercel.json
@@ -2,10 +2,9 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd ../.. && corepack yarn install --immutable",
-  "buildCommand": "cd ../.. && corepack yarn turbo run build:asyra-framework-site --filter=@asyra/asyra-framework-site",
+  "buildCommand": "cd ../.. && corepack yarn gen:turbo:check && corepack yarn turbo run build:asyra-framework-site --filter=@asyra/asyra-framework-site",
   "outputDirectory": "dist",
-  "ignoreCommand": "node scripts/vercel-ignore-build.mjs",
   "git": {
-    "deploymentEnabled": true
+    "deploymentEnabled": false
   }
 }

--- a/apps/asyra-sim/src/init/__tests__/vercel-deployment.test.ts
+++ b/apps/asyra-sim/src/init/__tests__/vercel-deployment.test.ts
@@ -14,10 +14,10 @@ it('builds the Sim dependency graph and serves only its static output', () => {
     'cd ../.. && corepack yarn install --immutable'
   )
   expect(config.buildCommand).toBe(
-    'cd ../.. && corepack yarn turbo run react:build --filter=@asyra/asyra-sim --concurrency=2'
+    'cd ../.. && corepack yarn gen:turbo:check && corepack yarn turbo run react:build --filter=@asyra/asyra-sim --concurrency=2'
   )
   expect(config.outputDirectory).toBe('dist')
-  expect(config.git.deploymentEnabled).toBe(true)
+  expect(config.git.deploymentEnabled).toBe(false)
   // An absent script/Worker must remain a 404, never an HTML app fallback.
   expect(config.rewrites).toBeUndefined()
   expect(config.functions).toBeUndefined()

--- a/apps/asyra-sim/vercel.json
+++ b/apps/asyra-sim/vercel.json
@@ -2,18 +2,27 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
   "installCommand": "cd ../.. && corepack yarn install --immutable",
-  "buildCommand": "cd ../.. && corepack yarn turbo run react:build --filter=@asyra/asyra-sim --concurrency=2",
+  "buildCommand": "cd ../.. && corepack yarn gen:turbo:check && corepack yarn turbo run react:build --filter=@asyra/asyra-sim --concurrency=2",
   "outputDirectory": "dist",
   "git": {
-    "deploymentEnabled": true
+    "deploymentEnabled": false
   },
   "headers": [
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy", "value": "no-referrer" },
-        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Cross-Origin-Resource-Policy",
+          "value": "same-origin"
+        },
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; worker-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"

--- a/docs/ai/workflows/README.md
+++ b/docs/ai/workflows/README.md
@@ -22,6 +22,7 @@ Repository automation contracts:
 
 - workspace build, generated-template, and release validation:
   `package-release-validation.md`
+- manual App deployment and recovery: `manual-app-release.md`
 
 ## Authoring Rule
 

--- a/docs/ai/workflows/manual-app-release.md
+++ b/docs/ai/workflows/manual-app-release.md
@@ -1,0 +1,150 @@
+# Manual App Release
+
+## Operator flow
+
+1. Merge reviewed changes through the protected PR flow. Merging does not deploy.
+2. Open Actions, select **Manual App Release**, choose **main**, and run it.
+   The dispatch commit is frozen for every job; a later main push cannot change
+   the candidate. Arbitrary branches, fork repositories and older SHA inputs
+   are deliberately unsupported. Trigger a new run to choose a newer candidate.
+3. Read the plan job summary and its changed-input list. Each App compares its
+   own last successful online SHA with the candidate, including accumulated
+   commits and the union of old/new transitive workspace dependencies.
+4. The existing CI, packed clean-consumer readiness, ordinary/collaboration E2E
+   and production-artifact tests run against that exact dispatch commit. The
+   release enables the existing balanced AI correctness gate. No production
+   credential is passed to these jobs.
+5. If any verifier fails, do not approve or deploy. If nothing is affected, the
+   workflow ends without requesting a deployment.
+6. Review and approve the **app-production** environment only after the plan
+   and all verifiers are successful. Its approved reviewer is the repository
+   owner; self-approval is allowed for this single-maintainer repository.
+7. The privileged job re-reads the online records, checks live Vercel project
+   identity/configuration, enforces the budget, then releases Apps sequentially.
+   It creates one staged Production deployment per affected App, verifies the
+   exact built SHA and HTTP/script delivery, promotes it, and checks the stable
+   production domain. No automatic mutation retry or automatic rollback occurs.
+
+For a deployment setting or environment-variable change outside Git, choose
+the specific `force_app` and provide a single-line reason of 8-200 characters.
+This intentionally bypasses deployment deduplication and consumes quota.
+Ordinary retries must inspect previous results before starting another run.
+
+## Setup and cutover
+
+The default branch must contain the reviewed workflows before the manual entry
+can run. Do not dispatch the publication workflow merely to test this PR.
+
+- Keep the Vercel GitHub App authorization for this public repository, but
+  disconnect the Git repository inside **each** hosted Vercel project.
+  Deployment creation uses the API Git source with both ref and SHA fixed to
+  the candidate; `skipGitConnectDuringLink` prevents intentional reconnection.
+- In each project's Production environment, disable **Auto-assign Custom
+  Production Domains**. The release refuses to proceed if this is enabled,
+  if a Git connection remains, or if the project root is unexpected.
+- In GitHub Environment **app-production**, allow only the branch `main`,
+  require owner approval, set `VERCEL_TEAM_ID`, and store a team-scoped
+  `VERCEL_TOKEN` secret. Do not store it as an unrestricted repository secret.
+  Keep token expiry/rotation under the account owner's control. Never paste it
+  into PRs, logs, source, workflow inputs or chat.
+- Require the five PR checks listed in `package-release-validation.md`.
+  Preserve existing PR, force-push and deletion protection. Do not require
+  obsolete Vercel Preview status contexts.
+- A staged URL protected by Vercel authentication returns a smoke failure.
+  Do not disable protection to turn the check green. Add a separately reviewed,
+  host-scoped automation-bypass mechanism if that project needs one.
+
+## App ownership and online versions
+
+`scripts/app-release-plan.mjs` owns the three public project identities and
+their roots. It reads committed manifests, traversing runtime, development,
+peer and optional workspace dependencies. Old dependency edges are included
+so deleting a dependency cannot hide an affected deployment.
+
+App/owned dependency source and assets trigger release. Public documentation
+also triggers the website. Tests, internal AI documents and unrelated
+workspaces do not. Unknown root inputs, including lockfiles and shared build
+scripts, conservatively affect all Apps. The graph and diff are constructed
+once per distinct commit per planning invocation, with no cross-run cache.
+
+The canonical deployment records are GitHub Deployments named
+`app-production - <project>`. Each record links the candidate SHA, Vercel ID,
+previous production ID and Actions run. Only a successful final smoke receives
+a success status. Initial setup reads the existing Vercel-created Production
+environment's successful record; its legacy environment name is retained as
+an immutable external compatibility identity. Before any publication, the live
+Vercel production target must match that baseline. Missing records, failed
+post-promotion checks, manual rollbacks or other drift require reconciliation;
+the workflow does not silently choose a new baseline.
+
+For reconciliation, inspect the live Vercel production target, its source SHA,
+stable domain and smoke results. An owner may then create a corrected GitHub
+Deployment record with that actual SHA, deployment ID, a success status and a
+reason linking the recovery evidence. Never mark a failed candidate successful
+to unblock the next run. Package versions are not website version identities.
+
+## Evidence and limits
+
+`yarn test:production-artifacts` consumes an existing successful production
+build. It never rebuilds or starts Vite middleware. It verifies Sim analysis
+and local persistence, Design local editing/history, and Next production
+routes/client search. It checks browser exceptions and rejects dev-source
+requests. Next runs as an explicitly owned child process and is cleaned up.
+The suite supplements, rather than replaces, the larger diagnostic E2E suites.
+
+Vercel still builds the exact source separately. This is source-identity
+verification, not a claim that the CI and Vercel output bytes are identical.
+Production HTTP smoke checks HTML and delivered scripts, not every browser
+interaction, backend API or external dependency. Design's local editing proof
+does not claim hosted AI or collaboration backends exist. Their formal service
+E2E remains separate. Do not add dev middleware to make production tests pass.
+
+Hobby's deployment rate limit is owner-wide, including all projects. Before a
+batch, the workflow counts retained deployments from the last 24 hours and
+requires room for the batch plus six repair deployments under the 100 limit.
+It also caps this workflow's deployments at twelve per 24 hours. Failed and
+canceled entries count conservatively. Deleted deployments and in-flight
+external requests may be absent, so this is a safety budget, not an exact
+provider rate-limit meter. Provider 429/error responses stop the workflow;
+never delete entries to reclaim budget or repeatedly retry a limited request.
+Build CPU/time, transfer, Functions and storage remain separate usage measures.
+
+## Failure and recovery
+
+- Before promotion: leave the current domain untouched. Inspect the recorded
+  deployment ID. A timeout may have completed remotely; never blindly retry.
+- After promotion: the run fails and records the previous deployment ID.
+  Inspect the App and use Vercel Instant Rollback to its immediately previous
+  eligible Production deployment when data/API compatibility permits it.
+  Hobby does not promise arbitrary historical rollback. Verify the stable
+  domain and reconcile the deployment record before the next release.
+- A partially completed multi-App batch retains each App's actual state;
+  there is no cross-project atomic switch. Do not continue a dependent App
+  after a failure. Check compatible App/backend versions before approving.
+- Storage migrations, worker/CSP changes, rendering performance, toolchain,
+  production configuration and external services need their owner-specific
+  gates and a data-compatible recovery plan before approval. HTTP smoke alone
+  is insufficient for those changes.
+
+## Security boundary
+
+PR jobs use read-only tokens. Release triggers are manual and upstream-main
+only, with a fixed dispatch SHA, global non-canceling concurrency and a
+protected Environment. The privileged job installs no packages, builds no
+App code and downloads no PR artifacts. First-party Actions are SHA-pinned;
+checkout does not retain Git credentials. Inputs travel through environment
+variables and are validated, never interpolated as shell programs. API clients
+use fixed origins, reject redirects, bound timeouts and redact provider error
+bodies. Production secrets are scoped to the single publication step.
+
+The workflow, controller scripts and their dependency-free imports are trusted
+release code and must be reviewed accordingly. Environment reviewers must
+inspect their diff before approval; secret storage alone is not a security
+boundary against a malicious change merged into trusted release code.
+
+References:
+
+- <a href="https://vercel.com/docs/rest-api/deployments/create-a-new-deployment" target="_blank" rel="noopener noreferrer">Vercel deployment API</a>
+- <a href="https://vercel.com/docs/deployments/promoting-a-deployment" target="_blank" rel="noopener noreferrer">Staged production promotion</a>
+- <a href="https://vercel.com/docs/instant-rollback" target="_blank" rel="noopener noreferrer">Instant Rollback</a>
+- <a href="https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments" target="_blank" rel="noopener noreferrer">GitHub deployment environments</a>

--- a/docs/ai/workflows/manual-app-release.md
+++ b/docs/ai/workflows/manual-app-release.md
@@ -89,8 +89,10 @@ to unblock the next run. Package versions are not website version identities.
 
 ## Evidence and limits
 
-`yarn test:production-artifacts` consumes an existing successful production
-build. It never rebuilds or starts Vite middleware. It verifies Sim analysis
+`yarn build:production-artifacts` executes the App builds and the website's
+explicit `build:asyra-framework-site` task in one Turbo graph. Root
+`react:build` alone does not include that website task.
+`yarn test:production-artifacts` then consumes those production builds. It never rebuilds or starts Vite middleware. It verifies Sim analysis
 and local persistence, Design local editing/history, and Next production
 routes/client search. It checks browser exceptions and rejects dev-source
 requests. Next runs as an explicitly owned child process and is cleaned up.

--- a/docs/ai/workflows/manual-app-release.md
+++ b/docs/ai/workflows/manual-app-release.md
@@ -50,9 +50,13 @@ can run. Do not dispatch the publication workflow merely to test this PR.
 - Require the five PR checks listed in `package-release-validation.md`.
   Preserve existing PR, force-push and deletion protection. Do not require
   obsolete Vercel Preview status contexts.
-- A staged URL protected by Vercel authentication returns a smoke failure.
-  Do not disable protection to turn the check green. Add a separately reviewed,
-  host-scoped automation-bypass mechanism if that project needs one.
+- Keep Vercel Authentication enabled. For each protected project, the owner
+  creates a Protection Bypass for Automation secret in Vercel and stores it in
+  the same GitHub Environment as `VERCEL_BYPASS_SIM`, `VERCEL_BYPASS_DESIGN`
+  or `VERCEL_BYPASS_FRAMEWORK`. The controller checks for a missing secret
+  before creating deployments. It sends the secret only in an HTTP header to
+  the exact staged origin, refuses redirects and never sends it to external
+  assets or the stable production smoke. It never places secrets in URLs.
 
 ## App ownership and online versions
 
@@ -143,6 +147,8 @@ inspect their diff before approval; secret storage alone is not a security
 boundary against a malicious change merged into trusted release code.
 
 References:
+
+- <a href="https://vercel.com/docs/deployment-protection/methods-to-bypass-deployment-protection/protection-bypass-automation" target="_blank" rel="noopener noreferrer">Automation bypass for protected deployments</a>
 
 - <a href="https://vercel.com/docs/rest-api/deployments/create-a-new-deployment" target="_blank" rel="noopener noreferrer">Vercel deployment API</a>
 - <a href="https://vercel.com/docs/deployments/promoting-a-deployment" target="_blank" rel="noopener noreferrer">Staged production promotion</a>

--- a/docs/ai/workflows/package-release-validation.md
+++ b/docs/ai/workflows/package-release-validation.md
@@ -4,40 +4,18 @@ This workflow owns the repository automation contract between workspace
 manifests, Turbo, generated app templates, CI, and the explicit release
 command.
 
-## PR Checks and Vercel Deployment Status
+## PR Checks and App Deployment
 
-The PR checks list combines GitHub Actions CI with statuses reported by the
-Vercel Git integration. Vercel deployments can run alongside CI; a successful
-Vercel check does not mean the test jobs passed or the PR was merged.
+PR validation is independent of hosting. Ready PRs require `validate`,
+`framework-release-readiness`, `e2e-tests`, `collaboration-e2e-tests`, and
+`production-artifact-tests`. Draft jobs remain deferred until ready for review.
+Vercel statuses from older Git-integrated deployments are historical evidence,
+not merge prerequisites or proof that CI passed.
 
-| Check | Meaning |
-| --- | --- |
-| `Vercel – asyra-framework` | Deployment status for the Framework website. On a feature-branch PR, this is a Preview deployment. |
-| `Vercel – asyra-design` | Deployment status for Asyra Design. On a feature-branch PR, this is a Preview deployment. |
-| `Vercel Preview Comments` | Updates the PR preview comment; it is not a third deployment. |
-
-Pushing a feature/PR branch can create or update Preview deployments. Merging
-the reviewed PR into the configured Production branch, `main`, can trigger
-the automatic Production deployment. The Git integration reacts to branch
-updates, so direct pushes to `main` must not be used to bypass PR review.
-
-Vercel's generic `Deployment has completed` message does not distinguish
-Preview from Production. Open the check's deployment details and verify
-**Environment**, **Source branch/commit**, and **Domains**. A completed Preview
-deployment does not update the Production site.
-
-The Framework website enables Git deployments in
-`apps/asyra-framework-site/vercel.json` and filters build inputs through
-`scripts/vercel-ignore-build.mjs` within that app. This behavior was enabled
-by PR #129 on August 28, 2026. As of September 5, 2026, the Asyra Design
-provider setting for skipping unaffected projects is disabled, so a
-website-only PR can also create a Design Preview. This is an observed provider
-setting, not an instruction to change deployment behavior.
-
-References:
-
-- <a href="https://github.com/karote00/asyra/pull/129" target="_blank" rel="noopener noreferrer">PR #129: Framework website Git deployment configuration</a>
-- <a href="https://vercel.com/docs/git/vercel-for-github" target="_blank" rel="noopener noreferrer">Vercel for GitHub</a>
+The three hosted Apps use the explicit [manual App release workflow](manual-app-release.md).
+Their Git connections are removed during cutover, and repository configurations
+also disable automatic Git deployment. A push, PR or merge does not request an
+App deployment. Package registry publication remains a separate workflow.
 
 ## Workspace Build Graph
 

--- a/docs/public/generated/source-map.json
+++ b/docs/public/generated/source-map.json
@@ -604,7 +604,7 @@
         },
         {
           "path": "package.json",
-          "sha256": "efe36a23abf1075c0880ca135f11b4dc809fd2d27a3fd304109b3585c32a9e72"
+          "sha256": "373430e3223bc848cbd61d3455a01a5da0a9030584966ea5df5baf9cd614eddf"
         }
       ]
     },

--- a/docs/public/generated/source-map.json
+++ b/docs/public/generated/source-map.json
@@ -604,7 +604,7 @@
         },
         {
           "path": "package.json",
-          "sha256": "34d80b862a5f4cb36eb726d683a5a5a0e45261680deb665157a835b3342f3f6b"
+          "sha256": "efe36a23abf1075c0880ca135f11b4dc809fd2d27a3fd304109b3585c32a9e72"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "release:full": "node scripts/release-full.js",
     "release:full:asyra-design": "node scripts/release-full.js --prod=asyra-design",
     "dev:description": "Run in watch mode: all packages including design-system, asyra-design app",
+    "build:production-artifacts": "yarn gen:turbo:check && turbo run react:build build:asyra-framework-site --concurrency=2",
     "test:production-artifacts": "node --test --test-concurrency=1 scripts/__tests__/production-artifacts.browser.test.mjs"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rebuild:design-system": "yarn workspace @asyra/design-system rebuild:design-system",
     "react:build": "yarn gen:turbo:check && turbo run react:build",
     "test": "turbo run test",
-    "test:scripts": "node --test scripts/__tests__/deps-validate.test.mjs scripts/__tests__/workspace-automation.test.mjs scripts/__tests__/release-automation.test.mjs scripts/__tests__/release-records.test.mjs scripts/__tests__/changeset-all-patch.test.mjs scripts/__tests__/changeset-pr-check.test.mjs scripts/__tests__/test-file-placement.test.mjs scripts/__tests__/brand-neutral-code.test.mjs scripts/__tests__/display-name-separators.test.mjs scripts/__tests__/create-app-cli.test.mjs scripts/docs/__tests__/public-documentation-inputs.test.mjs scripts/docs/__tests__/public-content-contract.test.mjs scripts/docs/__tests__/public-package-reference.test.mjs scripts/docs/__tests__/public-documentation.test.mjs scripts/docs/__tests__/public-documentation-validation.test.mjs scripts/docs/__tests__/public-readme-inputs.test.mjs scripts/docs/__tests__/public-package-readmes.test.mjs scripts/docs/__tests__/public-readme-validation.test.mjs",
+    "test:scripts": "node --test scripts/__tests__/deps-validate.test.mjs scripts/__tests__/workspace-automation.test.mjs scripts/__tests__/release-automation.test.mjs scripts/__tests__/release-records.test.mjs scripts/__tests__/changeset-all-patch.test.mjs scripts/__tests__/changeset-pr-check.test.mjs scripts/__tests__/test-file-placement.test.mjs scripts/__tests__/brand-neutral-code.test.mjs scripts/__tests__/display-name-separators.test.mjs scripts/__tests__/create-app-cli.test.mjs scripts/docs/__tests__/public-documentation-inputs.test.mjs scripts/docs/__tests__/public-content-contract.test.mjs scripts/docs/__tests__/public-package-reference.test.mjs scripts/docs/__tests__/public-documentation.test.mjs scripts/docs/__tests__/public-documentation-validation.test.mjs scripts/docs/__tests__/public-readme-inputs.test.mjs scripts/docs/__tests__/public-package-readmes.test.mjs scripts/docs/__tests__/public-readme-validation.test.mjs scripts/__tests__/app-release-plan.test.mjs scripts/__tests__/app-release-service.test.mjs scripts/__tests__/app-release-workflow.test.mjs",
     "test:local": "yarn test:scripts && turbo run test:local",
     "test:ci": "yarn test:scripts && turbo run test:ci",
     "test:e2e": "yarn workspace @asyra/asyra-design test:e2e",
@@ -75,7 +75,8 @@
     "release:create-app": "node scripts/release-create-app.js",
     "release:full": "node scripts/release-full.js",
     "release:full:asyra-design": "node scripts/release-full.js --prod=asyra-design",
-    "dev:description": "Run in watch mode: all packages including design-system, asyra-design app"
+    "dev:description": "Run in watch mode: all packages including design-system, asyra-design app",
+    "test:production-artifacts": "node --test --test-concurrency=1 scripts/__tests__/production-artifacts.browser.test.mjs"
   },
   "workspaces": [
     "apps/*",

--- a/scripts/__tests__/app-release-plan.test.mjs
+++ b/scripts/__tests__/app-release-plan.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  RELEASE_APPS,
+  assertBudget,
+  createReleasePlan,
+  requireCommit
+} from '../app-release-plan.mjs'
+
+const old = 'a'.repeat(40)
+const sha = 'b'.repeat(40)
+const shared = {
+  name: '@asyra/shared',
+  root: 'packages/shared',
+  dependencies: {}
+}
+const snapshot = RELEASE_APPS.map((app) => ({
+  name: app.id,
+  root: app.root,
+  dependencies: { '@asyra/shared': '*' }
+})).concat(shared)
+const baselines = Object.fromEntries(
+  RELEASE_APPS.map((app) => [app.id, { sha: old }])
+)
+const plan = (files, extra = {}) =>
+  createReleasePlan({
+    sha,
+    baselines,
+    snapshot: () => snapshot,
+    diff: () => files,
+    ancestor: () => '',
+    ...extra
+  })
+
+test('accumulated changes release only the owning App', () => {
+  assert.deepEqual(
+    plan(['apps/asyra-sim/src/example.ts'])
+      .apps.filter((a) => a.release)
+      .map((a) => a.id),
+    ['asyra-sim']
+  )
+})
+test('transitive and removed dependencies affect their consumers', () => {
+  const before = snapshot
+    .map((s) =>
+      s.name === '@asyra/shared' ? { ...s, dependencies: { leaf: '*' } } : s
+    )
+    .concat({ name: 'leaf', root: 'packages/leaf' })
+  const result = plan(['packages/leaf/deleted.ts'], {
+    snapshot: (ref) => (ref === old ? before : snapshot)
+  })
+  assert.ok(result.apps.every((app) => app.release))
+})
+test('shared inputs, public content, tests and unrelated workspaces have distinct scope', () => {
+  assert.ok(plan(['yarn.lock']).apps.every((a) => a.release))
+  assert.deepEqual(
+    plan(['docs/public/start.md'])
+      .apps.filter((a) => a.release)
+      .map((a) => a.id),
+    ['asyra-framework']
+  )
+  assert.ok(
+    plan([
+      'docs/ai/plan.md',
+      'apps/asyra-sim/e2e/test.spec.ts',
+      'packages/unused/index.ts'
+    ]).apps.every((a) => !a.release)
+  )
+})
+test('each distinct commit snapshot and accumulated diff is produced once per invocation', () => {
+  let reads = 0
+  let diffs = 0
+  const options = {
+    snapshot: () => {
+      reads++
+      return snapshot
+    },
+    diff: () => {
+      diffs++
+      return ['packages/shared/index.ts']
+    }
+  }
+  assert.ok(plan([], options).apps.every((a) => a.release))
+  assert.equal(reads, 2)
+  assert.equal(diffs, 1)
+  plan([], options)
+  assert.equal(reads, 4)
+  assert.equal(diffs, 2)
+})
+test('each App uses its own online baseline', () => {
+  const ref = 'c'.repeat(40)
+  const result = plan([], {
+    baselines: { ...baselines, 'asyra-sim': { sha: ref } },
+    diff: (base) => (base === ref ? ['apps/asyra-sim/src/index.ts'] : [])
+  })
+  assert.equal(result.apps[0].release, true)
+  assert.equal(result.apps[1].release, false)
+})
+test('fail closed on missing baselines, rollback, malformed SHA or force input', () => {
+  assert.throws(() => plan([], { baselines: {} }))
+  assert.throws(() =>
+    plan([], {
+      ancestor: () => {
+        throw new Error('Not an ancestor')
+      }
+    })
+  )
+  assert.throws(() => requireCommit('main; curl attacker'))
+  assert.throws(() => plan([], { forceApp: 'other' }))
+  assert.throws(() => plan([], { forceApp: 'asyra-sim' }))
+  assert.equal(
+    plan([], {
+      forceApp: 'asyra-sim',
+      reason: 'Production configuration changed'
+    }).apps[0].release,
+    true
+  )
+})
+test('reserve includes all owner deployments and managed retries', () => {
+  assertBudget({ total: 91, managed: 9, requested: 3 })
+  assert.throws(() => assertBudget({ total: 92, managed: 0, requested: 3 }))
+  assert.throws(() => assertBudget({ total: 10, managed: 10, requested: 3 }))
+  assert.throws(() => assertBudget({ total: NaN, managed: 0, requested: 1 }))
+})

--- a/scripts/__tests__/app-release-service.test.mjs
+++ b/scripts/__tests__/app-release-service.test.mjs
@@ -1,4 +1,4 @@
-/* global Response */
+/* global Response, URL */
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
@@ -179,6 +179,58 @@ test('deployed smoke rejects protected pages and HTML fallback masquerading as J
           : '<html>fallback</html>',
         { headers: { 'content-type': 'text/html' } }
       )
+    })
+  )
+})
+
+test('protected staged deployment without automation secret fails before deployment creation', async () => {
+  const { options, mutations } = harness()
+  const original = options.vercel
+  options.vercel = async (...args) => {
+    const result = await original(...args)
+    return {
+      ...result,
+      ssoProtection: { deploymentType: 'prod_deployment_urls_and_all_previews' }
+    }
+  }
+  await assert.rejects(publishPlan(options), /automation bypass secret/)
+  assert.equal(mutations.length, 0)
+})
+
+test('automation bypass stays in headers on the exact staged origin and never follows external assets', async () => {
+  const requests = []
+  const fetcher = async (url, options) => {
+    requests.push({ url: String(url), options })
+    return new Response(
+      requests.length === 1
+        ? '<html><script src="/app.js"></script><script src="https://external.example/script.js"></script></html>'
+        : 'app()',
+      {
+        headers: {
+          'content-type':
+            requests.length === 1 ? 'text/html' : 'application/javascript'
+        }
+      }
+    )
+  }
+  await smokeOrigin('https://new.vercel.app', app, fetcher, {
+    bypassSecret: 'test-only',
+    bypassOrigin: 'https://new.vercel.app'
+  })
+  assert.equal(requests.length, 2)
+  for (const request of requests) {
+    assert.equal(new URL(request.url).origin, 'https://new.vercel.app')
+    assert.equal(
+      request.options.headers['x-vercel-protection-bypass'],
+      'test-only'
+    )
+    assert.equal(request.options.redirect, 'error')
+    assert.ok(!request.url.includes('test-only'))
+  }
+  await assert.rejects(
+    smokeOrigin('https://other.vercel.app', app, fetcher, {
+      bypassSecret: 'test-only',
+      bypassOrigin: 'https://new.vercel.app'
     })
   )
 })

--- a/scripts/__tests__/app-release-service.test.mjs
+++ b/scripts/__tests__/app-release-service.test.mjs
@@ -1,0 +1,184 @@
+/* global Response */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  createApi,
+  deploymentUsage,
+  publishPlan,
+  readBaselines,
+  smokeOrigin,
+  verifyProject,
+  waitForDeployment
+} from '../app-release-service.mjs'
+
+const sha = 'b'.repeat(40)
+const app = {
+  id: 'asyra-sim',
+  root: 'apps/asyra-sim',
+  host: 'asyra-sim.vercel.app',
+  baseline: { sha: 'a'.repeat(40), deploymentId: 'old' },
+  release: true
+}
+const project = {
+  name: app.id,
+  rootDirectory: app.root,
+  autoAssignCustomDomains: false,
+  targets: {
+    production: { id: 'old', meta: { githubCommitSha: app.baseline.sha } }
+  }
+}
+
+test('project admission rejects Git connections, automatic aliases and online drift', () => {
+  assert.equal(verifyProject(project, app), 'old')
+  for (const changed of [
+    { link: {} },
+    { autoAssignCustomDomains: true },
+    { rootDirectory: 'other' },
+    { targets: { production: { id: 'old', meta: { githubCommitSha: sha } } } }
+  ])
+    assert.throws(() => verifyProject({ ...project, ...changed }, app))
+})
+test('HTTP client never retries mutations or leaks response bodies and rejects redirects', async () => {
+  let calls = 0
+  const api = createApi(
+    'https://api.vercel.com',
+    'secret',
+    {},
+    async (_, options) => {
+      calls++
+      assert.equal(options.redirect, 'error')
+      return new Response('sensitive response', { status: 429 })
+    }
+  )
+  await assert.rejects(api('/v13/deployments', 'POST', {}), /429/)
+  assert.equal(calls, 1)
+  await assert.rejects(api('//attacker.example'), /relative/)
+})
+test('usage includes failures and canceled deployments across the owner', async () => {
+  let calls = 0
+  const result = await deploymentUsage(async (url) => {
+    calls++
+    assert.match(url, /since=/)
+    if (calls === 1)
+      return {
+        deployments: [
+          { state: 'CANCELED' },
+          { meta: { releaseOwner: 'manual-app-release' } }
+        ],
+        pagination: { next: 2 }
+      }
+    assert.match(url, /until=2/)
+    return { deployments: [{ state: 'ERROR' }] }
+  })
+  assert.deepEqual(result, { total: 3, managed: 1 })
+})
+test('baseline ignores incomplete releases and reads legacy successes during bootstrap', async () => {
+  const result = await readBaselines(async (url) => {
+    if (url.includes('/statuses')) return [{ state: 'success' }]
+    if (decodeURIComponent(url).includes('app-production')) return []
+    return [{ id: 1, sha, payload: {} }]
+  }, 'owner/project')
+  assert.equal(result['asyra-sim'].sha, sha)
+})
+test('a ready deployment must contain the exact source SHA and stay unaliased', async () => {
+  const ready = {
+    readyState: 'READY',
+    meta: { githubCommitSha: sha },
+    target: 'production',
+    aliasAssigned: false,
+    url: 'app-123.vercel.app'
+  }
+  assert.equal(
+    (await waitForDeployment(async () => ready, 'new', sha)).url,
+    ready.url
+  )
+  await assert.rejects(
+    waitForDeployment(
+      async () => ({ ...ready, aliasAssigned: true }),
+      'new',
+      sha
+    )
+  )
+  await assert.rejects(
+    waitForDeployment(async () => ({ ...ready, meta: {} }), 'new', sha)
+  )
+  await assert.rejects(
+    waitForDeployment(async () => ({ readyState: 'ERROR' }), 'new', sha)
+  )
+})
+
+function harness(failSmoke = false) {
+  const mutations = []
+  let promoted = false
+  return {
+    mutations,
+    options: {
+      plan: { sha, reason: '', apps: [app] },
+      repository: 'owner/project',
+      runUrl: 'https://github.com/karote00/asyra/actions/runs/1',
+      usage: async () => ({ total: 0, managed: 0 }),
+      wait: async () => ({ url: 'new.vercel.app' }),
+      smoke: async () => {
+        if (failSmoke) throw new Error('Smoke failed')
+      },
+      github: async (url, method, body) => {
+        mutations.push({ url, method, body })
+        return { id: 1 }
+      },
+      vercel: async (url, method = 'GET', body) => {
+        if (method === 'GET')
+          return promoted
+            ? { ...project, targets: { production: { id: 'new' } } }
+            : project
+        mutations.push({ url, method, body })
+        if (url.includes('/promote/')) promoted = true
+        return { id: 'new' }
+      }
+    }
+  }
+}
+test('one selected App creates exactly one deployment from the admitted SHA', async () => {
+  const { options, mutations } = harness()
+  await publishPlan(options)
+  const create = mutations.filter((m) => m.url === '/v13/deployments')
+  assert.equal(create.length, 1)
+  assert.equal(create[0].body.gitSource.ref, sha)
+  assert.equal(create[0].body.gitSource.sha, sha)
+  assert.equal(create[0].body.projectSettings.skipGitConnectDuringLink, true)
+  assert.equal(mutations.at(-1).body.state, 'success')
+})
+test('failed staged smoke records failure and never promotes or retries', async () => {
+  const { options, mutations } = harness(true)
+  await assert.rejects(publishPlan(options), /before promotion/)
+  assert.equal(mutations.filter((m) => m.url.includes('/promote/')).length, 0)
+  assert.equal(mutations.filter((m) => m.url === '/v13/deployments').length, 1)
+  assert.equal(mutations.at(-1).body.state, 'failure')
+})
+test('budget and baseline rejection happen before any mutation', async () => {
+  const { options, mutations } = harness()
+  options.usage = async () => ({ total: 99, managed: 0 })
+  await assert.rejects(publishPlan(options))
+  assert.equal(mutations.length, 0)
+})
+test('deployed smoke rejects protected pages and HTML fallback masquerading as JavaScript', async () => {
+  await assert.rejects(
+    smokeOrigin(
+      'https://new.vercel.app',
+      app,
+      async () => new Response('', { status: 401 })
+    )
+  )
+  let calls = 0
+  await assert.rejects(
+    smokeOrigin('https://new.vercel.app', app, async () => {
+      calls++
+      return new Response(
+        calls === 1
+          ? '<html><script src="/app.js"></script></html>'
+          : '<html>fallback</html>',
+        { headers: { 'content-type': 'text/html' } }
+      )
+    })
+  )
+})

--- a/scripts/__tests__/app-release-workflow.test.mjs
+++ b/scripts/__tests__/app-release-workflow.test.mjs
@@ -1,0 +1,62 @@
+/* global URL */
+
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const read = (file) =>
+  readFileSync(new URL(`../../${file}`, import.meta.url), 'utf8')
+
+test('release controller is manual, upstream-main-only and waits for every verifier', () => {
+  const workflow = read('.github/workflows/app-release.yml')
+  assert.match(workflow, /on:\n {2}workflow_dispatch:/)
+  assert.doesNotMatch(
+    workflow,
+    /pull_request_target:|workflow_run:|repository_dispatch:|schedule:|secrets: inherit/
+  )
+  assert.match(workflow, /needs: \[plan, ci, e2e, production-artifacts\]/)
+  assert.match(workflow, /environment: app-production/)
+  assert.match(workflow, /cancel-in-progress: false/)
+  assert.match(workflow, /run_balanced_ai_correctness: true/)
+  const publish = workflow.split('\n  publish:\n')[1]
+  assert.match(
+    publish,
+    /github.repository_id == '893098287' && github.ref == 'refs\/heads\/main'/
+  )
+  assert.match(publish, /ref: \$\{\{ github.sha \}\}/)
+  assert.match(publish, /persist-credentials: false/)
+  assert.doesNotMatch(
+    publish,
+    /run:.*(?:yarn|npm|npx|curl)|download-artifact|cache:/
+  )
+  assert.doesNotMatch(workflow, /run:.*\$\{\{ inputs\./)
+  for (const line of workflow.match(/^\s*-?\s*uses: actions\/.+$/gm))
+    assert.match(line, /@[a-f0-9]{40}$/)
+})
+test('all App configs prevent Git auto-deployment before any build is created', () => {
+  for (const file of [
+    'vercel.json',
+    'apps/asyra-sim/vercel.json',
+    'apps/asyra-design/vercel.json',
+    'apps/asyra-framework-site/vercel.json'
+  ]) {
+    const config = JSON.parse(read(file))
+    assert.equal(config.git.deploymentEnabled, false, file)
+    assert.equal(
+      config.ignoreCommand,
+      undefined,
+      'Manual release must not compare only HEAD^'
+    )
+  }
+})
+test('production proof is included in PR CI and never starts Vite dev or preview middleware', () => {
+  const workflow = read('.github/workflows/production-artifacts.yml')
+  assert.match(workflow, /pull_request:/)
+  assert.match(workflow, /workflow_call:/)
+  assert.match(workflow, /run: yarn react:build/)
+  assert.match(workflow, /run: yarn test:production-artifacts/)
+  assert.doesNotMatch(
+    read('scripts/production-artifact-server.mjs'),
+    /import .*vite/
+  )
+})

--- a/scripts/__tests__/app-release-workflow.test.mjs
+++ b/scripts/__tests__/app-release-workflow.test.mjs
@@ -53,10 +53,17 @@ test('production proof is included in PR CI and never starts Vite dev or preview
   const workflow = read('.github/workflows/production-artifacts.yml')
   assert.match(workflow, /pull_request:/)
   assert.match(workflow, /workflow_call:/)
-  assert.match(workflow, /run: yarn react:build/)
+  assert.match(workflow, /run: yarn build:production-artifacts/)
+  const build = JSON.parse(read('package.json')).scripts[
+    'build:production-artifacts'
+  ]
+  assert.match(
+    build,
+    /gen:turbo:check.*turbo run react:build build:asyra-framework-site --concurrency=2/
+  )
   assert.match(workflow, /run: yarn test:production-artifacts/)
   assert.ok(
-    workflow.indexOf('run: yarn react:build') <
+    workflow.indexOf('run: yarn build:production-artifacts') <
       workflow.indexOf('run: yarn workspace @asyra/asyra-design typecheck'),
     'Build workspace declarations before checking application consumers'
   )

--- a/scripts/__tests__/app-release-workflow.test.mjs
+++ b/scripts/__tests__/app-release-workflow.test.mjs
@@ -55,6 +55,11 @@ test('production proof is included in PR CI and never starts Vite dev or preview
   assert.match(workflow, /workflow_call:/)
   assert.match(workflow, /run: yarn react:build/)
   assert.match(workflow, /run: yarn test:production-artifacts/)
+  assert.ok(
+    workflow.indexOf('run: yarn react:build') <
+      workflow.indexOf('run: yarn workspace @asyra/asyra-design typecheck'),
+    'Build workspace declarations before checking application consumers'
+  )
   assert.doesNotMatch(
     read('scripts/production-artifact-server.mjs'),
     /import .*vite/

--- a/scripts/__tests__/production-artifacts.browser.test.mjs
+++ b/scripts/__tests__/production-artifacts.browser.test.mjs
@@ -205,7 +205,7 @@ test(
     await expect(
       page.getByRole('heading', { level: 1, name: 'Asyra Framework' })
     ).toBeVisible()
-    await page.getByRole('button', { name: 'Search 41 guides' }).click()
+    await page.getByRole('button', { name: /^Search \d+ guides$/ }).click()
     await page.getByRole('searchbox', { name: 'Search' }).fill('transaction')
     await expect(page.locator('.search-results a')).not.toHaveCount(0)
     const response = await page.goto(`${url}/atlas`)

--- a/scripts/__tests__/production-artifacts.browser.test.mjs
+++ b/scripts/__tests__/production-artifacts.browser.test.mjs
@@ -1,0 +1,217 @@
+/* global URL, fetch, navigator */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { spawn } from 'node:child_process'
+import { mkdir, readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { serveArtifact } from '../production-artifact-server.mjs'
+
+const require = createRequire(
+  new URL('../../apps/asyra-design/package.json', import.meta.url)
+)
+const { chromium, expect } = require('@playwright/test')
+const root = path.resolve(import.meta.dirname, '../..')
+const temporary = path.join(root, 'tmp/production-artifacts')
+await mkdir(temporary, { recursive: true })
+process.env.TMPDIR = temporary
+process.env.TMP = temporary
+process.env.TEMP = temporary
+
+async function browserPage(t, url, closeServer) {
+  let browser
+  t.after(async () => {
+    try {
+      await browser?.close()
+    } finally {
+      await closeServer()
+    }
+  })
+  browser = await chromium.launch({
+    ...(process.env.CI ? {} : { channel: 'chrome' }),
+    args: ['--use-angle=swiftshader', '--enable-unsafe-swiftshader']
+  })
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 1000 }
+  })
+  const errors = []
+  const sourceRequests = []
+  page.on('pageerror', (error) => errors.push(error.message))
+  page.on('request', (request) => {
+    if (/\/(?:@vite|src)\//.test(new URL(request.url()).pathname))
+      sourceRequests.push(request.url())
+  })
+  t.after(() => {
+    assert.deepEqual(errors, [])
+    assert.deepEqual(sourceRequests, [])
+  })
+  await page.goto(url)
+  return page
+}
+
+test(
+  'Sim production artifact loads Workers, completes an analysis and retains its project',
+  { timeout: 180_000 },
+  async (t) => {
+    const config = JSON.parse(
+      await readFile(path.join(root, 'apps/asyra-sim/vercel.json'), 'utf8')
+    )
+    const headers = Object.fromEntries(
+      config.headers[0].headers.map(({ key, value }) => [key, value])
+    )
+    const server = await serveArtifact(
+      path.join(root, 'apps/asyra-sim/dist'),
+      headers
+    )
+    const page = await browserPage(t, server.url, server.close)
+    await expect(page.getByRole('status')).toHaveText('Local runtime ready')
+    await expect(
+      page.getByTestId('workcell-canvas').locator('canvas')
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Projects', exact: true }).click()
+    await page
+      .getByLabel('Project name', { exact: true })
+      .fill('Production artifact project')
+    await page.getByLabel('Project name', { exact: true }).press('Enter')
+    await expect(page.getByTestId('persistence-status')).toHaveText(
+      'Saved locally - Production artifact project'
+    )
+    await page
+      .getByRole('button', { name: 'Close projects', exact: true })
+      .click()
+    await page.getByRole('button', { name: 'Experiments', exact: true }).click()
+    await page
+      .getByLabel('Experiment', { exact: true })
+      .selectOption({ label: 'Tool and table collision - r1' })
+    await page.getByLabel('Start time (s)').fill('3.8')
+    await page.getByLabel('Start time (s)').press('Enter')
+    await page.getByLabel('End time (s)').fill('4.2')
+    await page.getByLabel('End time (s)').press('Enter')
+    await page
+      .getByRole('button', { name: 'Run analysis', exact: true })
+      .click()
+    await page
+      .getByRole('button', { name: 'View results', exact: true })
+      .click({ timeout: 90_000 })
+    await expect(page.getByTestId('analysis-result')).toContainText(
+      'Issue found'
+    )
+    await page.reload()
+    await expect(page.getByTestId('persistence-status')).toHaveText(
+      'Saved locally - Production artifact project'
+    )
+    assert.equal((await fetch(`${server.url}/missing-worker.js`)).status, 404)
+  }
+)
+
+test(
+  'Design production artifact supports local editing and history without dev middleware',
+  { timeout: 90_000 },
+  async (t) => {
+    const server = await serveArtifact(
+      path.join(root, 'apps/asyra-design/dist/frontend')
+    )
+    const page = await browserPage(
+      t,
+      `${server.url}/?fileId=production-artifact`,
+      server.close
+    )
+    await expect(page.getByTestId('toolbar')).toBeVisible()
+    const canvas = page.locator('canvas').first()
+    await expect(canvas).toBeVisible()
+    const items = page
+      .getByTestId('contents-panel')
+      .locator('[data-testid^="element-item-"]')
+    await expect(items).toHaveCount(0)
+    await page.getByTestId('tool-rectangle').click()
+    await expect(page.getByTestId('tool-rectangle')).toHaveAttribute(
+      'data-active',
+      'true'
+    )
+    const box = await canvas.boundingBox()
+    await page.mouse.click(box.x + box.width * 0.3, box.y + box.height * 0.3)
+    await expect(items).toHaveCount(1)
+    const modifier = await page.evaluate(() =>
+      /mac/i.test(navigator.platform) ? 'Meta' : 'Control'
+    )
+    await page.keyboard.press(`${modifier}+z`)
+    await expect(items).toHaveCount(0)
+    await page.keyboard.press(`${modifier}+Shift+z`)
+    await expect(items).toHaveCount(1)
+    assert.equal((await fetch(`${server.url}/api/ai/action-batch`)).status, 404)
+  }
+)
+
+test(
+  'Website production server supports deep routes and client search',
+  { timeout: 120_000 },
+  async (t) => {
+    const cwd = path.join(root, 'apps/asyra-framework-site')
+    const siteRequire = createRequire(path.join(cwd, 'package.json'))
+    const child = spawn(
+      process.execPath,
+      [
+        siteRequire.resolve('next/dist/bin/next'),
+        'start',
+        '--hostname',
+        '127.0.0.1',
+        '--port',
+        '3038'
+      ],
+      {
+        cwd,
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, NODE_ENV: 'production' }
+      }
+    )
+    let output = ''
+    for (const stream of [child.stdout, child.stderr])
+      stream.on('data', (chunk) => {
+        output = (output + chunk).slice(-4000)
+      })
+    t.diagnostic(`Owned Next production server PID ${child.pid}`)
+    const closeServer = async () => {
+      if (child.exitCode !== null) return
+      const stopped = new Promise((resolve) => child.once('exit', resolve))
+      process.kill(-child.pid, 'SIGTERM')
+      const timer = setTimeout(() => {
+        try {
+          process.kill(-child.pid, 'SIGKILL')
+        } catch {
+          /* already stopped */
+        }
+      }, 5000)
+      await stopped
+      clearTimeout(timer)
+    }
+    let browserOwnsCleanup = false
+    t.after(async () => {
+      if (!browserOwnsCleanup) await closeServer()
+    })
+    const url = 'http://127.0.0.1:3038'
+    for (let attempt = 0; attempt < 60; attempt++) {
+      assert.equal(child.exitCode, null, output)
+      try {
+        if (output.includes('Ready in') && (await fetch(url)).ok) break
+      } catch {
+        /* wait for owned server */
+      }
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+    browserOwnsCleanup = true
+    const page = await browserPage(t, `${url}/docs`, closeServer)
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Asyra Framework' })
+    ).toBeVisible()
+    await page.getByRole('button', { name: 'Search 41 guides' }).click()
+    await page.getByRole('searchbox', { name: 'Search' }).fill('transaction')
+    await expect(page.locator('.search-results a')).not.toHaveCount(0)
+    const response = await page.goto(`${url}/atlas`)
+    assert.equal(response.status(), 200)
+    assert.ok(response.headers()['content-security-policy'])
+    await expect(page.locator('h1')).toBeVisible()
+    assert.equal((await fetch(`${url}/missing-release-route`)).status, 404)
+  }
+)

--- a/scripts/__tests__/workspace-automation.test.mjs
+++ b/scripts/__tests__/workspace-automation.test.mjs
@@ -340,15 +340,15 @@ test('CI, E2E, and release validation own their bounded integration gates', () =
   assert.match(releaseValidation, /yarn release:app:check --prod=\$\{appName\}/)
 })
 
-test('Framework site Git deployments follow artifact inputs instead of release versions', () => {
+test('Framework site deployments are independent of PR CI and Git pushes', () => {
   const siteVercel = readJSON('apps/asyra-framework-site/vercel.json')
   const ignoreBuild = readText(
     'apps/asyra-framework-site/scripts/vercel-ignore-build.mjs'
   )
   const ci = readText('.github/workflows/main.yml')
 
-  assert.equal(siteVercel.git.deploymentEnabled, true)
-  assert.equal(siteVercel.ignoreCommand, 'node scripts/vercel-ignore-build.mjs')
+  assert.equal(siteVercel.git.deploymentEnabled, false)
+  assert.equal(siteVercel.ignoreCommand, undefined)
   assert.match(ignoreBuild, /apps\/asyra-framework-site/)
   assert.match(ignoreBuild, /docs\/public/)
   assert.match(ignoreBuild, /packages/)

--- a/scripts/app-release-plan.mjs
+++ b/scripts/app-release-plan.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+
+// Public project identities are deliberately separate from release-state schema.
+export const RELEASE_APPS = Object.freeze([
+  { id: 'asyra-sim', root: 'apps/asyra-sim', host: 'asyra-sim.vercel.app' },
+  {
+    id: 'asyra-design',
+    root: 'apps/asyra-design',
+    host: 'asyra-design.vercel.app'
+  },
+  {
+    id: 'asyra-framework',
+    root: 'apps/asyra-framework-site',
+    host: 'asyra-framework.vercel.app'
+  }
+])
+export const RELEASE_SCHEMA = 1
+export const RELEASE_RESERVE = 6
+export const RELEASE_DAILY_LIMIT = 12
+
+export function requireCommit(sha) {
+  assert.match(sha, /^[a-f0-9]{40}$/, 'Expected a full Git commit SHA')
+  return sha
+}
+
+export function git(args, cwd = process.cwd()) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 8 * 1024 * 1024
+  }).trimEnd()
+}
+
+export function readSnapshot(sha, cwd) {
+  requireCommit(sha)
+  const paths = git(['ls-tree', '-r', '--name-only', sha], cwd).split('\n')
+  return paths
+    .filter((file) =>
+      /^(apps|packages|tools|create-app)\/[^/]+\/package.json$/.test(file)
+    )
+    .map((file) => ({
+      root: file.slice(0, -'/package.json'.length),
+      ...JSON.parse(git(['show', `${sha}:${file}`], cwd))
+    }))
+}
+
+export function dependencyRoots(snapshot, appRoot) {
+  const byName = new Map(snapshot.map((entry) => [entry.name, entry]))
+  const app = snapshot.find((entry) => entry.root === appRoot)
+  assert.ok(app, `Missing workspace ${appRoot}`)
+  const roots = new Set()
+  function visit(entry) {
+    if (roots.has(entry.root)) return
+    roots.add(entry.root)
+    for (const name of Object.keys({
+      ...entry.dependencies,
+      ...entry.devDependencies,
+      ...entry.peerDependencies,
+      ...entry.optionalDependencies
+    })) {
+      if (byName.has(name)) visit(byName.get(name))
+    }
+  }
+  visit(app)
+  return roots
+}
+
+export function affectsApp(file, app, roots) {
+  if (app.id === 'asyra-framework' && file.startsWith('docs/public/'))
+    return true
+  if (/^(docs\/ai\/|\.changeset\/|\.github\/)/.test(file)) return false
+  if (
+    /(^|\/)(__tests__|e2e|test-results)\//.test(file) ||
+    /\.(test|spec)\.[^.]+$/.test(file)
+  )
+    return false
+  for (const root of roots) {
+    if (file.startsWith(`${root}/`)) {
+      // Website MD/MDX can be rendered inputs; package READMEs are not runtime.
+      return !/\.md$/.test(file) || root === 'apps/asyra-framework-site'
+    }
+  }
+  if (/^(apps|packages|tools|create-app)\//.test(file)) return false
+  if (
+    /^docs\//.test(file) ||
+    /^(README|LICENSE|AGENTS|SKILLS)(\.|$)/.test(file)
+  )
+    return false
+  // Unknown root inputs fail conservatively: lockfile, toolchain, scripts, config.
+  return true
+}
+
+export function createReleasePlan({
+  sha,
+  baselines,
+  forceApp = '',
+  reason = '',
+  cwd,
+  snapshot = readSnapshot,
+  diff = (base, head) =>
+    git(['diff', '--name-only', '--no-renames', base, head, '--'], cwd)
+      .split('\n')
+      .filter(Boolean),
+  ancestor = (base, head) =>
+    git(['merge-base', '--is-ancestor', base, head], cwd)
+}) {
+  requireCommit(sha)
+  assert.ok(
+    !forceApp || RELEASE_APPS.some((app) => app.id === forceApp),
+    'Unknown forced App'
+  )
+  assert.ok(
+    !forceApp ||
+      (reason.trim().length >= 8 &&
+        reason.length <= 200 &&
+        !/[\r\n]/.test(reason)),
+    'A forced release needs an 8-200 character single-line reason'
+  )
+  // Snapshot and diff products are owned by this invocation, once per distinct SHA.
+  const snapshots = new Map()
+  const changes = new Map()
+  const read = (ref) => {
+    if (!snapshots.has(ref)) snapshots.set(ref, snapshot(ref, cwd))
+    return snapshots.get(ref)
+  }
+  const apps = RELEASE_APPS.map((app) => {
+    const baseline = baselines[app.id]
+    assert.ok(
+      baseline,
+      `Missing online baseline for ${app.id}; reconcile before release`
+    )
+    requireCommit(baseline.sha)
+    ancestor(baseline.sha, sha)
+    const roots = new Set([
+      ...dependencyRoots(read(sha), app.root),
+      ...dependencyRoots(read(baseline.sha), app.root)
+    ])
+    if (!changes.has(baseline.sha))
+      changes.set(baseline.sha, diff(baseline.sha, sha))
+    const inputs = changes
+      .get(baseline.sha)
+      .filter((file) => affectsApp(file, app, roots))
+    return {
+      ...app,
+      baseline,
+      inputs,
+      release: inputs.length > 0 || forceApp === app.id,
+      forced: forceApp === app.id
+    }
+  })
+  return { schema: RELEASE_SCHEMA, sha, reason, apps }
+}
+
+export function assertBudget({ total, managed, requested }) {
+  assert.ok(
+    Number.isInteger(total) &&
+      Number.isInteger(managed) &&
+      total >= 0 &&
+      managed >= 0,
+    'Unknown deployment usage'
+  )
+  assert.ok(
+    total + requested + RELEASE_RESERVE <= 100,
+    'Owner daily limit would consume the repair reserve'
+  )
+  assert.ok(
+    managed + requested <= RELEASE_DAILY_LIMIT,
+    'Manual release daily budget exhausted'
+  )
+}

--- a/scripts/app-release-service.mjs
+++ b/scripts/app-release-service.mjs
@@ -1,0 +1,300 @@
+/* global fetch, URL, AbortSignal */
+
+import assert from 'node:assert/strict'
+import {
+  RELEASE_APPS,
+  assertBudget,
+  requireCommit
+} from './app-release-plan.mjs'
+
+export function createApi(origin, token, query = {}, fetcher = fetch) {
+  assert.ok(token, `Missing credential for ${origin}`)
+  return async (path, method = 'GET', body) => {
+    assert.ok(
+      path.startsWith('/') && !path.startsWith('//'),
+      'API paths must be relative'
+    )
+    const url = new URL(path, origin)
+    for (const [key, value] of Object.entries(query))
+      url.searchParams.set(key, value)
+    const response = await fetcher(url, {
+      method,
+      redirect: 'error',
+      signal: AbortSignal.timeout(30_000),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28'
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) })
+    })
+    // No automatic mutation retries: a timeout may already have created a deployment.
+    assert.ok(
+      response.ok,
+      `${origin} ${method} failed (${response.status}); inspect the provider before retrying`
+    )
+    const text = await response.text()
+    return text ? JSON.parse(text) : {}
+  }
+}
+
+export async function readBaselines(github, repository) {
+  const baselines = {}
+  for (const app of RELEASE_APPS) {
+    const environments = [
+      `app-production - ${app.id}`,
+      `Production \u2013 ${app.id}`
+    ]
+    // The second name is the immutable Vercel Git integration environment.
+    for (const environment of environments) {
+      let found
+      for (let page = 1; page <= 10 && !found; page++) {
+        const deployments = await github(
+          `/repos/${repository}/deployments?environment=${encodeURIComponent(environment)}&per_page=100&page=${page}`
+        )
+        if (!deployments.length) break
+        for (const deployment of deployments) {
+          const statuses = await github(
+            `/repos/${repository}/deployments/${deployment.id}/statuses?per_page=100`
+          )
+          if (statuses[0]?.state !== 'success') continue
+          found = {
+            sha: requireCommit(deployment.sha),
+            record: deployment.id,
+            deploymentId: deployment.payload?.deploymentId ?? null
+          }
+          break
+        }
+        if (deployments.length < 100) break
+      }
+      if (found) {
+        baselines[app.id] = found
+        break
+      }
+    }
+    assert.ok(
+      baselines[app.id],
+      `No successful online record for ${app.id}; reconcile the baseline first`
+    )
+  }
+  return baselines
+}
+
+export function verifyProject(project, app) {
+  assert.equal(project.name, app.id, 'Unexpected Vercel project')
+  assert.equal(project.rootDirectory, app.root, 'Unexpected Vercel root')
+  assert.ok(
+    !project.link,
+    'Disconnect the project Git integration before manual release'
+  )
+  assert.equal(
+    project.autoAssignCustomDomains,
+    false,
+    'Disable automatic production domain assignment before release'
+  )
+  const current = project.targets?.production
+  assert.ok(current?.id, 'Missing current production deployment')
+  assert.equal(
+    current.meta?.githubCommitSha ?? current.meta?.releaseSha,
+    app.baseline.sha,
+    'Online SHA changed after the release plan; re-plan'
+  )
+  if (app.baseline.deploymentId)
+    assert.equal(
+      current.id,
+      app.baseline.deploymentId,
+      'Online deployment changed after the release plan'
+    )
+  return current.id
+}
+
+export async function deploymentUsage(vercel, now = Date.now()) {
+  let total = 0
+  let managed = 0
+  let until = ''
+  for (let page = 0; page < 20; page++) {
+    const response = await vercel(
+      `/v6/deployments?limit=100&since=${now - 86_400_000}${until}`
+    )
+    for (const deployment of response.deployments) {
+      total++
+      if (deployment.meta?.releaseOwner === 'manual-app-release') managed++
+    }
+    if (!response.pagination?.next) return { total, managed }
+    until = `&until=${response.pagination.next}`
+  }
+  throw new Error(
+    'Deployment usage pagination exceeded its bound; refusing release'
+  )
+}
+
+export async function waitForDeployment(
+  vercel,
+  id,
+  sha,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const deployment = await vercel(`/v13/deployments/${id}`)
+    assert.ok(
+      !['ERROR', 'CANCELED'].includes(deployment.readyState),
+      `Deployment ${id} ${deployment.readyState}`
+    )
+    if (deployment.readyState === 'READY') {
+      assert.equal(
+        deployment.meta?.githubCommitSha ?? deployment.gitSource?.sha,
+        sha,
+        'Vercel built a different commit'
+      )
+      assert.equal(deployment.target, 'production')
+      assert.equal(
+        deployment.aliasAssigned,
+        false,
+        'Deployment unexpectedly received production domains'
+      )
+      assert.match(deployment.url, /^[a-z0-9-]+\.vercel\.app$/)
+      return deployment
+    }
+    await sleep(15_000)
+  }
+  throw new Error(`Deployment ${id} timed out; inspect it before retrying`)
+}
+
+export async function smokeOrigin(origin, app, fetcher = fetch) {
+  const url = new URL(origin)
+  assert.equal(url.protocol, 'https:')
+  assert.ok(
+    url.hostname === app.host || /^[a-z0-9-]+\.vercel\.app$/.test(url.hostname)
+  )
+  const paths = app.id === 'asyra-framework' ? ['/', '/docs', '/atlas'] : ['/']
+  for (const path of paths) {
+    const response = await fetcher(new URL(path, url), {
+      redirect: 'error',
+      signal: AbortSignal.timeout(30_000)
+    })
+    assert.equal(response.status, 200, `${app.id} ${path} failed smoke`)
+    assert.match(response.headers.get('content-type') ?? '', /text\/html/)
+    const html = await response.text()
+    assert.match(html, /<html/i)
+    const scripts = [...html.matchAll(/<script[^>]+src=["']([^"']+)["']/g)]
+      .map((match) => new URL(match[1], url))
+      .filter((asset) => asset.origin === url.origin)
+    assert.ok(scripts.length > 0, 'No application scripts in deployed HTML')
+    for (const asset of scripts) {
+      const result = await fetcher(asset, {
+        redirect: 'error',
+        signal: AbortSignal.timeout(30_000)
+      })
+      assert.equal(result.status, 200, 'Deployed script is unavailable')
+      assert.match(result.headers.get('content-type') ?? '', /javascript/)
+      await result.body?.cancel()
+    }
+  }
+}
+
+export async function publishPlan({
+  plan,
+  vercel,
+  github,
+  repository,
+  runUrl,
+  usage = deploymentUsage,
+  wait = waitForDeployment,
+  smoke = smokeOrigin
+}) {
+  requireCommit(plan.sha)
+  const selected = plan.apps.filter((app) => app.release)
+  // Verify every selected project before consuming any deployment quota.
+  const previous = new Map()
+  for (const app of selected)
+    previous.set(
+      app.id,
+      verifyProject(await vercel(`/v9/projects/${app.id}`), app)
+    )
+  assertBudget({ ...(await usage(vercel)), requested: selected.length })
+  for (const app of selected) {
+    assert.equal(
+      verifyProject(await vercel(`/v9/projects/${app.id}`), app),
+      previous.get(app.id)
+    )
+    const deployment = await vercel(
+      `/v13/deployments${app.forced ? '?forceNew=1' : ''}`,
+      'POST',
+      {
+        name: app.id,
+        project: app.id,
+        target: 'production',
+        gitSource: {
+          type: 'github',
+          org: repository.split('/')[0],
+          repo: repository.split('/')[1],
+          ref: plan.sha,
+          sha: plan.sha
+        },
+        projectSettings: { skipGitConnectDuringLink: true },
+        meta: {
+          releaseOwner: 'manual-app-release',
+          releaseSha: plan.sha,
+          releaseRun: runUrl
+        }
+      }
+    )
+    // Write the deployment ID immediately, before waiting, to make failures reviewable.
+    const record = await github(`/repos/${repository}/deployments`, 'POST', {
+      ref: plan.sha,
+      auto_merge: false,
+      required_contexts: [],
+      environment: `app-production - ${app.id}`,
+      production_environment: true,
+      payload: {
+        schema: 1,
+        deploymentId: deployment.id,
+        previousDeploymentId: previous.get(app.id),
+        runUrl,
+        reason: plan.reason
+      }
+    })
+    const status = (state, environmentUrl) =>
+      github(`/repos/${repository}/deployments/${record.id}/statuses`, 'POST', {
+        state,
+        auto_inactive: false,
+        log_url: runUrl,
+        ...(environmentUrl ? { environment_url: environmentUrl } : {})
+      })
+    await status('in_progress')
+    let promoted = false
+    try {
+      const ready = await wait(vercel, deployment.id, plan.sha)
+      await smoke(`https://${ready.url}`, app)
+      assert.equal(
+        verifyProject(await vercel(`/v9/projects/${app.id}`), app),
+        previous.get(app.id)
+      )
+      await vercel(`/v10/projects/${app.id}/promote/${deployment.id}`, 'POST')
+      promoted = true
+      // Promotion is asynchronous. The canonical project target must match before smoke.
+      let current
+      for (let attempt = 0; attempt < 30; attempt++) {
+        current = await vercel(`/v9/projects/${app.id}`)
+        if (current.targets?.production?.id === deployment.id) break
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+      }
+      assert.equal(
+        current.targets?.production?.id,
+        deployment.id,
+        'Production promotion did not settle'
+      )
+      await smoke(`https://${app.host}`, app)
+      await status('success', `https://${app.host}`)
+    } catch (error) {
+      await status('failure').catch(() => {
+        // Preserve the original deployment failure if GitHub reporting is unavailable.
+      })
+      // Recovery is deliberately explicit: external data compatibility cannot be inferred.
+      throw new Error(
+        `${app.id} failed ${promoted ? 'after' : 'before'} promotion. Deployment ${deployment.id}; previous ${previous.get(app.id)}. ${error.message}`
+      )
+    }
+  }
+}

--- a/scripts/app-release-service.mjs
+++ b/scripts/app-release-service.mjs
@@ -161,15 +161,32 @@ export async function waitForDeployment(
   throw new Error(`Deployment ${id} timed out; inspect it before retrying`)
 }
 
-export async function smokeOrigin(origin, app, fetcher = fetch) {
+export async function smokeOrigin(
+  origin,
+  app,
+  fetcher = fetch,
+  { bypassSecret, bypassOrigin } = {}
+) {
   const url = new URL(origin)
   assert.equal(url.protocol, 'https:')
   assert.ok(
     url.hostname === app.host || /^[a-z0-9-]+\.vercel\.app$/.test(url.hostname)
   )
+  const headers = {}
+  if (bypassSecret) {
+    assert.equal(
+      url.origin,
+      bypassOrigin,
+      'Unexpected automation bypass origin'
+    )
+    assert.equal(url.username, '')
+    assert.equal(url.password, '')
+    headers['x-vercel-protection-bypass'] = bypassSecret
+  }
   const paths = app.id === 'asyra-framework' ? ['/', '/docs', '/atlas'] : ['/']
   for (const path of paths) {
     const response = await fetcher(new URL(path, url), {
+      headers,
       redirect: 'error',
       signal: AbortSignal.timeout(30_000)
     })
@@ -183,6 +200,7 @@ export async function smokeOrigin(origin, app, fetcher = fetch) {
     assert.ok(scripts.length > 0, 'No application scripts in deployed HTML')
     for (const asset of scripts) {
       const result = await fetcher(asset, {
+        headers,
         redirect: 'error',
         signal: AbortSignal.timeout(30_000)
       })
@@ -201,17 +219,21 @@ export async function publishPlan({
   runUrl,
   usage = deploymentUsage,
   wait = waitForDeployment,
-  smoke = smokeOrigin
+  smoke = smokeOrigin,
+  bypassSecrets = {}
 }) {
   requireCommit(plan.sha)
   const selected = plan.apps.filter((app) => app.release)
   // Verify every selected project before consuming any deployment quota.
   const previous = new Map()
-  for (const app of selected)
-    previous.set(
-      app.id,
-      verifyProject(await vercel(`/v9/projects/${app.id}`), app)
+  for (const app of selected) {
+    const project = await vercel(`/v9/projects/${app.id}`)
+    previous.set(app.id, verifyProject(project, app))
+    assert.ok(
+      !project.ssoProtection || bypassSecrets[app.id],
+      `${app.id} needs an automation bypass secret before creating a deployment`
     )
+  }
   assertBudget({ ...(await usage(vercel)), requested: selected.length })
   for (const app of selected) {
     assert.equal(
@@ -266,7 +288,10 @@ export async function publishPlan({
     let promoted = false
     try {
       const ready = await wait(vercel, deployment.id, plan.sha)
-      await smoke(`https://${ready.url}`, app)
+      await smoke(`https://${ready.url}`, app, undefined, {
+        bypassOrigin: `https://${ready.url}`,
+        bypassSecret: bypassSecrets[app.id]
+      })
       assert.equal(
         verifyProject(await vercel(`/v9/projects/${app.id}`), app),
         previous.get(app.id)

--- a/scripts/app-release.mjs
+++ b/scripts/app-release.mjs
@@ -70,6 +70,11 @@ if (process.argv[2] === 'plan') {
     vercel,
     github,
     repository,
+    bypassSecrets: {
+      'asyra-sim': process.env.VERCEL_BYPASS_SIM,
+      'asyra-design': process.env.VERCEL_BYPASS_DESIGN,
+      'asyra-framework': process.env.VERCEL_BYPASS_FRAMEWORK
+    },
     runUrl: `https://github.com/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`
   })
 }

--- a/scripts/app-release.mjs
+++ b/scripts/app-release.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { appendFileSync } from 'node:fs'
+import { createReleasePlan, git, requireCommit } from './app-release-plan.mjs'
+import {
+  createApi,
+  publishPlan,
+  readBaselines
+} from './app-release-service.mjs'
+
+assert.equal(
+  process.env.GITHUB_EVENT_NAME,
+  'workflow_dispatch',
+  'Release is manual only'
+)
+assert.equal(
+  process.env.GITHUB_REF,
+  'refs/heads/main',
+  'Release controller must run on main'
+)
+assert.equal(
+  process.env.GITHUB_REPOSITORY_ID,
+  '893098287',
+  'Release is restricted to the upstream repository'
+)
+const sha = requireCommit(process.env.GITHUB_SHA)
+assert.equal(
+  git(['rev-parse', 'HEAD']),
+  sha,
+  'Checkout does not match the dispatch commit'
+)
+const repository = process.env.GITHUB_REPOSITORY
+const github = createApi('https://api.github.com', process.env.GH_TOKEN)
+const baselines = await readBaselines(github, repository)
+const plan = createReleasePlan({
+  sha,
+  baselines,
+  forceApp: process.env.FORCE_APP,
+  reason: process.env.RELEASE_REASON
+})
+
+if (process.argv[2] === 'plan') {
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `plan=${JSON.stringify(plan)}\nhas_changes=${plan.apps.some((app) => app.release)}\n`
+  )
+  const rows = plan.apps
+    .map(
+      (app) =>
+        `| ${app.id} | ${app.baseline.sha} | ${app.release ? 'Release' : 'Unchanged'} | ${app.inputs.length} |`
+    )
+    .join('\n')
+  appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `Release candidate: \`${sha}\`\n\n| App | Online SHA | Decision | Changed inputs |\n| --- | --- | --- | --- |\n${rows}\n\nInspect the plan job output before approving app-production. No Vercel deployment has been created.\n`
+  )
+  console.log(JSON.stringify(plan, null, 2))
+} else {
+  assert.equal(process.argv[2], 'publish')
+  assert.deepEqual(
+    plan,
+    JSON.parse(process.env.RELEASE_PLAN),
+    'Plan changed while waiting for approval; start a new release'
+  )
+  assert.ok(process.env.VERCEL_TEAM_ID, 'Missing VERCEL_TEAM_ID')
+  const vercel = createApi('https://api.vercel.com', process.env.VERCEL_TOKEN, {
+    teamId: process.env.VERCEL_TEAM_ID
+  })
+  await publishPlan({
+    plan,
+    vercel,
+    github,
+    repository,
+    runUrl: `https://github.com/${repository}/actions/runs/${process.env.GITHUB_RUN_ID}`
+  })
+}

--- a/scripts/production-artifact-server.mjs
+++ b/scripts/production-artifact-server.mjs
@@ -1,0 +1,56 @@
+/* global URL */
+
+import { createServer } from 'node:http'
+import { readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+
+const TYPES = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.woff2': 'font/woff2',
+  '.wasm': 'application/wasm'
+}
+
+// Serve the artifact only. No Vite plugins, source modules, API mocks or HTML fallback.
+export async function serveArtifact(directory, headers = {}) {
+  const root = path.resolve(directory)
+  const server = createServer(async (request, response) => {
+    try {
+      const pathname = decodeURIComponent(
+        new URL(request.url, 'http://localhost').pathname
+      )
+      const file = path.resolve(
+        root,
+        `.${pathname === '/' ? '/index.html' : pathname}`
+      )
+      if (
+        !file.startsWith(`${root}${path.sep}`) ||
+        !(await stat(file)).isFile()
+      )
+        throw new Error('Not found')
+      response.writeHead(200, {
+        ...headers,
+        'Content-Type': TYPES[path.extname(file)] ?? 'application/octet-stream',
+        'Cache-Control': 'no-store'
+      })
+      response.end(await readFile(file))
+    } catch {
+      response.writeHead(404)
+      response.end('Not found')
+    }
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  return {
+    url: `http://127.0.0.1:${server.address().port}`,
+    close: () =>
+      new Promise((resolve) => {
+        server.closeAllConnections()
+        server.close(resolve)
+      })
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,6 @@
   "buildCommand": "turbo run react:build",
   "outputDirectory": "dist/frontend",
   "git": {
-    "deploymentEnabled": {
-      "main": true,
-      "development": false,
-      "*": false
-    }
+    "deploymentEnabled": false
   }
 }


### PR DESCRIPTION
PR pushes and merges currently trigger multiple Vercel deployments and exhaust the Hobby deployment allowance. This change retains PR CI and adds a manual, protected release workflow that freezes the main commit, validates it, and releases only Apps affected since each App's own successful production version.

- Traverse old and new workspace dependency graphs; preserve per-App SHA and Vercel deployment records, reject production drift, and bound release usage with a repair reserve.
- Keep credentials out of PR/build jobs. Require upstream main, protected Environment approval, fixed action SHAs, non-persistent checkout credentials, and successful CI/E2E/production-artifact gates before publication.
- Create staged Production deployments, verify source and HTTP/script delivery, then promote sequentially. Fail without automatic deployment retries or rollback.
- Build all three Apps in one explicit Turbo graph (root react:build previously omitted the website build); test built Sim analysis/persistence, Design editing/history and types, and the Next production site's routes/search. Document cutover, platform gaps and recovery.

Validation: explicit production build (24 tasks, including the website Next build), repository lint (0 errors), naming gate, 21 release-controller tests, 3 production browser tests, Design typecheck, and 2 Sim deployment-config tests passed locally. The repository script suite's existing placement scanner includes unrelated nested worktrees locally; the PR's clean CI checkout is the authoritative full-suite check. GitHub CI on 0c409eeaefcad4e8929328b338ff260291d7c0c7 is fully green: validate, framework-release-readiness, e2e-tests, collaboration-e2e-tests, and production-artifact-tests. The clean checkout passed the full required validation flow.

Operational cutover: the three Vercel projects have been disconnected from Git and automatic Production domain assignment disabled. The protected app-production Environment has been created with owner review and a main-only branch policy. The main ruleset now requires all five GitHub checks. No deployment, merge, new schedule, dependency installation from outside the existing lockfile, or tool upgrade was performed. VERCEL_TEAM_ID is configured. The owner must supply a team-scoped VERCEL_TOKEN and per-project VERCEL_BYPASS_SIM / VERCEL_BYPASS_DESIGN / VERCEL_BYPASS_FRAMEWORK secrets for projects using deployment protection before the first release. The bypass is sent only as a header to the exact staged origin; protection remains enabled. Source SHA is verified; CI and Vercel build bytes are not claimed identical.
