### PR TITLE
Close FieldScope plans and exempt documentation-only PRs from Changeset checks

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -13,8 +13,9 @@ Changeset release entries target fixed-allowlist Framework packages under
 `packages/*`, or the independently versioned public tool `@asyra/flow-inspector`. Root `asyra`, private apps, `create-app/*` CLI packages, and
 generated templates use their own manual version owners and must not be listed
 in Changeset frontmatter. Use an empty Changeset only when no versioned package is affected. Records
-capture future release intent; applying versions and publication are separate actions. Pull requests must include a pending Changeset record before
-completion. A release pull request remains valid after `changeset version`
+capture future release intent; applying versions and publication are separate actions. Pure Markdown documentation pull requests are exempt from the pending
+Changeset requirement. All other pull requests must include a pending Changeset
+record before completion. A release pull request remains valid after `changeset version`
 consumes those records only when the generated Framework package version and
 changelog changes are committed together. See
 `docs/ai/framework/rules/release-version-topology.md`.

--- a/.changeset/docs-only-pr-check.md
+++ b/.changeset/docs-only-pr-check.md
@@ -1,0 +1,4 @@
+---
+---
+
+Exempt pure Markdown documentation pull requests from the Changeset requirement while preserving checks for mixed and executable changes.

--- a/docs/ai/apps/fieldscope/PLANS.md
+++ b/docs/ai/apps/fieldscope/PLANS.md
@@ -10,6 +10,8 @@ None.
 
 - [Water and crop population](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md) - DONE 2026-09-11. PR #174 merged with all five checks passing; delivered water/crops, responsive scene updates, immediate editing/history, camera gestures and bilingual UI. See the [closeout decision](/docs/ai/apps/fieldscope/decisions/releases/unreleased.md).
 
+- [Documentation and CI follow-up](/docs/ai/apps/fieldscope/plans/completed/documentation-and-ci/plan.md) - DONE 2026-09-12 (Asia/Taipei). PR #190 archives prior stages and fixes the documentation-only Changeset gate; its implementation head passed all five checks. PR review and merge remain pending.
+
 ## Completed follow-up stages in PR #174
 
 These are completed stages of the archived water/crop plan, not separate active plans or additional release records.

--- a/docs/ai/apps/fieldscope/PLANS.md
+++ b/docs/ai/apps/fieldscope/PLANS.md
@@ -6,6 +6,24 @@ None.
 
 ## Completed
 
+- [Greenhouse workspace baseline](/docs/ai/apps/fieldscope/plans/completed/greenhouse-workspace/plan.md) - DONE 2026-09-09 (Asia/Taipei), retrospective closeout recorded 2026-09-11. PR #170 delivered the initial private 0.1.0 modeling workspace; its original baseline decision is retained.
+
 - [Water and crop population](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md) - DONE 2026-09-11. PR #174 merged with all five checks passing; delivered water/crops, responsive scene updates, immediate editing/history, camera gestures and bilingual UI. See the [closeout decision](/docs/ai/apps/fieldscope/decisions/releases/unreleased.md).
 
-PR #170 established the [0.1.0 baseline](/docs/ai/apps/fieldscope/decisions/0.1.0.md). Its documentation was backfilled after merge; it is not an unexecuted plan.
+## Completed follow-up stages in PR #174
+
+These are completed stages of the archived water/crop plan, not separate active plans or additional release records.
+
+| Completed work | Record |
+| --- | --- |
+| Water volume, cultivar population and occlusion | [Completion summary](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#completion-and-final-decision) |
+| Cucumber development stages and surface detail | [Cucumber appearance](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#cucumber-appearance-follow-up) |
+| Cucumber/tomato leaf textures | [Leaf surfaces](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#leaf-surface-correction) |
+| Vertical maturity and delayed-harvest limit | [Maturity distribution](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#vertical-maturity-distribution), [farm-wide cap](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#farm-wide-delayed-harvest-cap) |
+| Compact immediate editor and references | [Immediate property editing](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#compact-immediate-property-editing) |
+| Continuous clips and editable crossbeam/clearance | [Tube sections](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#continuous-tube-sections), [crossbeam and clearance](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#editable-crossbeam-and-side-clearance) |
+| Geometry reuse and fine-grained updates | [Work ownership](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#configuration-update-work-ownership), [dependency-scoped updates](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#dependency-scoped-scene-updates) |
+| Focused-input Undo/Redo | [History regression](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#soil-history-interaction-regression) |
+| First-person and mobile navigation | [Camera specification](/docs/ai/apps/fieldscope/specs/camera.md), [touch gestures](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#mobile-camera-gestures) |
+| Traditional Chinese/English UI | [Bilingual interface](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#bilingual-interface) |
+| CI dependency-test isolation | [CI validation](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#ci-projection-test-isolation) |

--- a/docs/ai/apps/fieldscope/PLANS.md
+++ b/docs/ai/apps/fieldscope/PLANS.md
@@ -1,5 +1,11 @@
 # Plans
 
-- [Water and crop population](plans/water-and-crops/plan.md): correct the soil trough and filled water volume; add researched cultivar variants and deterministic dense planting.
+## Active
 
-PR #170 established the [0.1.0 baseline](decisions/0.1.0.md). Its documentation was backfilled after merge; it is not an unexecuted plan.
+None.
+
+## Completed
+
+- [Water and crop population](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md) - DONE 2026-09-11. PR #174 merged with all five checks passing; delivered water/crops, responsive scene updates, immediate editing/history, camera gestures and bilingual UI. See the [closeout decision](/docs/ai/apps/fieldscope/decisions/releases/unreleased.md).
+
+PR #170 established the [0.1.0 baseline](/docs/ai/apps/fieldscope/decisions/0.1.0.md). Its documentation was backfilled after merge; it is not an unexecuted plan.

--- a/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
+++ b/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
@@ -17,3 +17,19 @@ Context: the user requested closing earlier completed FieldScope work that lacke
 Decision: add the [retrospective baseline closeout](/docs/ai/apps/fieldscope/plans/completed/greenhouse-workspace/plan.md), recording the actual merge time and the historical validation evidence. Retain the original baseline decision unchanged. Add explicit links to the completed PR #174 stages in [the plan index](/docs/ai/apps/fieldscope/PLANS.md); those stages remain part of the existing archived plan rather than being presented as newly invented plans.
 
 Consequences: both merged implementation batches and their completed follow-up stages are discoverable. The earlier statement that baseline documentation was backfilled remains true; this entry supplies the missing closeout record. No implementation, deployment, version change or release action is introduced.
+
+## 2026-09-12 - Close documentation and CI follow-up
+
+Context: the user requested closeout for the current stage and every earlier
+FieldScope stage. PR #170 and all completed PR #174 follow-ups already have
+archived records and index entries. PR #190 remains open, and its implementation
+head `333b1fba9b816b061a671c8ebc6c6e62788fe34f` passed all five CI checks.
+
+Decision: accept the [documentation and CI follow-up](/docs/ai/apps/fieldscope/plans/completed/documentation-and-ci/plan.md)
+as DONE and add it to the completed index. Preserve earlier records without
+inventing separate implementation plans for their already completed sub-stages.
+
+Consequences: no active FieldScope plan remains through this stage. The existing
+PR still requires review and merge; archived status does not claim main contains
+these changes. Closeout adds documentation only and creates no Changeset, version,
+tag, publication or deployment.

--- a/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
+++ b/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
@@ -1,0 +1,11 @@
+# Unreleased decisions
+
+## 2026-09-11 - Water and crop population plan closeout
+
+Context: PR #174 merged on 2026-09-11 as `59c8c1d36ffb4cc95683616d931ca4407607ed8c`. Its final head `5918a2526ef2943170d581781450fe3f41797635` passed all five CI jobs. Local validation passed 172 unit tests and the build; the completed visual review passed 31 browser cases and the expanded bilingual layout checks.
+
+Decision: accept the implementation as DONE and archive the [plan](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md) and its [Inspector flow](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/inspector-flow.md). This supersedes the plan's interim status that PR validation remained outstanding; historical execution notes are retained unchanged apart from relocated links.
+
+Consequences: water/crop geometry, natural cultivar variation, performance ownership, immediate editing/history, camera gestures and bilingual presentation are maintained through the current app specifications and formal tests. No active implementation task remains in this plan. Robot behavior, harvesting physics and load/clearance validation were not delivered by this plan.
+
+Release boundary: documentation closeout only. FieldScope remains private at version 0.1.0. No Changeset, version bump, tag, package publication or deployment is created or required.

--- a/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
+++ b/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
@@ -9,3 +9,11 @@ Decision: accept the implementation as DONE and archive the [plan](/docs/ai/apps
 Consequences: water/crop geometry, natural cultivar variation, performance ownership, immediate editing/history, camera gestures and bilingual presentation are maintained through the current app specifications and formal tests. No active implementation task remains in this plan. Robot behavior, harvesting physics and load/clearance validation were not delivered by this plan.
 
 Release boundary: documentation closeout only. FieldScope remains private at version 0.1.0. No Changeset, version bump, tag, package publication or deployment is created or required.
+
+## 2026-09-11 - Backfill earlier FieldScope closeout records
+
+Context: the user requested closing earlier completed FieldScope work that lacked records. Repository and merged-PR history identify PR #170 (initial workspace) and PR #174 (subsequent crop/workbench work). The initial 0.1.0 decision existed, but its completed-plan record was missing.
+
+Decision: add the [retrospective baseline closeout](/docs/ai/apps/fieldscope/plans/completed/greenhouse-workspace/plan.md), recording the actual merge time and the historical validation evidence. Retain the original baseline decision unchanged. Add explicit links to the completed PR #174 stages in [the plan index](/docs/ai/apps/fieldscope/PLANS.md); those stages remain part of the existing archived plan rather than being presented as newly invented plans.
+
+Consequences: both merged implementation batches and their completed follow-up stages are discoverable. The earlier statement that baseline documentation was backfilled remains true; this entry supplies the missing closeout record. No implementation, deployment, version change or release action is introduced.

--- a/docs/ai/apps/fieldscope/plans/completed/documentation-and-ci/plan.md
+++ b/docs/ai/apps/fieldscope/plans/completed/documentation-and-ci/plan.md
@@ -1,0 +1,44 @@
+# Documentation and CI follow-up - Closeout
+
+Status: DONE
+Completed: 2026-09-12 (Asia/Taipei)
+
+## Outcome and final decision
+
+The completed FieldScope baseline and water/crop stages are archived and indexed.
+PR #190 also corrects the repository Changeset gate so pure Markdown documentation
+changes do not require a release record. Accept this implementation stage as DONE.
+PR #190 remains open for review; completion does not imply it has merged into main.
+
+## Delivered scope
+
+- Retrospective closeout of PR #170 and archival of PR #174, retaining original
+  decisions, implementation history and actual validation evidence.
+- Links to completed crop, surface, maturity, editing, geometry, performance,
+  history, desktop/touch navigation and bilingual stages in the app plan index.
+- Documentation-only Changeset exemption, including deleted Markdown and both
+  rename paths. Mixed code/configuration changes and executable MDX retain the
+  ordinary gate. Moving a record out of `.changeset/` does not count as pending.
+
+The CI behavior is owned by `scripts/changeset-pr-check.js` and
+[release version topology](/docs/ai/framework/rules/release-version-topology.md).
+This record does not introduce another app-owned CI implementation.
+
+## Exit evidence
+
+Implementation head `333b1fba9b816b061a671c8ebc6c6e62788fe34f` in PR #190 passed
+all five checks: `validate`, `e2e-tests`, `collaboration-e2e-tests`,
+`production-artifact-tests` and `framework-release-readiness`. No check was skipped.
+The production-artifact job passed on rerun after a Sim analysis timeout; that
+unrelated runtime was not modified. The CI fix passed 17 focused Changeset tests,
+ESLint and the naming gate, with failing regression evidence captured before fixes.
+
+The baseline and crop plan records retain their own historical evidence. These
+results describe the completed implementation head, not a claim that a subsequent
+documentation commit has already passed CI.
+
+## Release boundary
+
+The CI code fix already carried its own empty Changeset. This documentation
+closeout creates no additional record, version bump, tag, publication or deployment.
+FieldScope remains private at 0.1.0. PR review and merge remain separate actions.

--- a/docs/ai/apps/fieldscope/plans/completed/greenhouse-workspace/plan.md
+++ b/docs/ai/apps/fieldscope/plans/completed/greenhouse-workspace/plan.md
@@ -1,0 +1,30 @@
+# Greenhouse workspace baseline - Retrospective closeout
+
+Status: DONE
+Implementation completed: 2026-09-09 (Asia/Taipei)
+Closeout recorded: 2026-09-11
+
+## Context and final decision
+
+PR #170 merged at `2026-09-08T17:54:10Z` as `716c0da956db167aa665551dfea0a5ba0468cb30`, from reviewed head `aab20833475bb538e1994226a5579f398293955d`. This record backfills the missing closeout for already merged work. It is not a reconstructed pre-implementation plan or a new implementation request. The original [0.1.0 baseline decision](/docs/ai/apps/fieldscope/decisions/0.1.0.md) remains unchanged.
+
+Decision: accept the initial private FieldScope 0.1.0 workspace as completed. Canonical record: [baseline closeout](/docs/ai/apps/fieldscope/plans/completed/greenhouse-workspace/plan.md).
+
+## Delivered scope
+
+- Four connected, dimension-driven greenhouses with circular arches, steel framing, exterior plastic film and end openings.
+- Typed soil/drain strips, rounded channels, connecting passages and outer waterproof barriers.
+- Growing poles, crossed-pipe spring clips, longitudinal climbing nets and cable ties.
+- Editable dimensions, strip order, pole placement and net limits using Asyra Core configuration transactions and Undo/Redo.
+- Collapsible layer/editor panels, camera flight, pan, look, dolly, optical zoom, fit and 100% reset.
+- Private version 0.1.0 and a Vercel-compatible workspace build configuration following asyra-design.
+
+## Exit evidence
+
+The final PR head passed `validate`, `framework-release-readiness`, standard E2E and collaboration E2E. Attached Vercel checks also succeeded. The merged PR's validation record reports 56 FieldScope unit/integration tests, 10 browser tests in two batches, the filtered deployment build's 17 tasks, app lint/naming and repository script checks. These are historical results, not tests rerun for this documentation closeout. A dedicated FieldScope Vercel project was not deployed by PR #170.
+
+## Subsequent work and boundaries
+
+The baseline initially used an Apply action and had no crop population. The completed [water and crop population plan](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md) subsequently corrected water ownership, added cultivars, replaced Apply with immediate editing, and refined performance, first-person/touch navigation and bilingual UI. Those later outcomes belong to PR #174, not this baseline. Current behavior is governed by the app specifications.
+
+Robot hardware connections, harvesting simulation, collision/plant-damage physics and configuration persistence were outside this baseline. This retrospective closeout creates no remaining implementation task, version change, Changeset, tag, publication or deployment.

--- a/docs/ai/apps/fieldscope/plans/completed/water-and-crops/inspector-flow.md
+++ b/docs/ai/apps/fieldscope/plans/completed/water-and-crops/inspector-flow.md
@@ -1,6 +1,8 @@
 # Water and crop architecture flow
 
-This flow maps the [product specification](../../specs/water-and-crops.md); it is not an execution log.
+Archived with the completed plan on 2026-09-11. Current behavior remains governed by the app specifications.
+
+This flow maps the [product specification](/docs/ai/apps/fieldscope/specs/water-and-crops.md); it is not an execution log.
 
 ## W - Water domain and projection
 

--- a/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md
+++ b/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md
@@ -1,6 +1,23 @@
 # Water and crop population plan
 
-Status: implementation complete; PR validation is the remaining integration gate.
+Status: DONE
+Completed: 2026-09-11
+
+## Completion and final decision
+
+Accepted and merged through PR #174 on 2026-09-11 at merge commit `59c8c1d36ffb4cc95683616d931ca4407607ed8c`. The final reviewed branch head was `5918a2526ef2943170d581781450fe3f41797635`.
+
+Outcome: closed soil troughs with filled water volumes; forty reusable cultivar variants and deterministic planting; realistic fruit development, occlusion and leaf surfaces; dependency-scoped scene updates; immediate configuration editing with Undo/Redo; first-person desktop/touch navigation; and a Traditional Chinese/English interface. PR #170 baseline documentation was also backfilled.
+
+Exit criteria: all 172 app unit tests and the production build passed after the final rebase. The completed UI/rendering review passed 31 browser cases, plus expanded bilingual layout checks at 360/390/768/1440px. At the final PR head, `validate`, `e2e-tests`, `collaboration-e2e-tests`, `production-artifact-tests` and `framework-release-readiness` all succeeded; none were skipped. The merged PR is the final integration acceptance.
+
+Canonical record: [completed plan](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md). Ongoing behavior is defined by [water and crop specification](/docs/ai/apps/fieldscope/specs/water-and-crops.md), [configuration specification](/docs/ai/apps/fieldscope/specs/configuration.md), [camera specification](/docs/ai/apps/fieldscope/specs/camera.md) and [architecture](/docs/ai/apps/fieldscope/ARCHITECTURE.md).
+
+Release boundary: this closeout is documentation-only. FieldScope remains private at 0.1.0; no release, version change, Changeset, tag or deployment is part of closeout. Robot control, harvesting simulation and collision/load validation remain outside the delivered scope.
+
+## Historical execution notes
+
+The following notes preserve the implementation sequence, including superseded approaches and gates that subsequently passed. They are not open tasks; the completion decision and current specifications above take precedence.
 
 The user additionally requested Blender-assisted review and natural, near-realistic plants. Review the exact domain meshes in Blender and refine leaf curvature, shoot tips, fruit attachment and materials before app visual closure. The optional `apps/fieldscope/scripts/export-crop-review.mjs` exports the current models inside the app artifacts directory for this purpose.
 
@@ -12,7 +29,7 @@ Discovery is limited to the current FieldScope owners/tests, Asyra Design docume
 
 ## Sequence
 
-1. Document the baseline and freeze the [product specification](../../specs/water-and-crops.md) and [Inspector flow](inspector-flow.md).
+1. Document the baseline and freeze the [product specification](/docs/ai/apps/fieldscope/specs/water-and-crops.md) and [Inspector flow](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/inspector-flow.md).
 2. Water owner: prove the old curved-water behavior fails the flat-water/soil tests; correct the shared profile and both consumers.
 3. Crop domain owner: implement and prove reusable variants, deterministic row placement and invalid-layout handling.
 4. Rendering owner: admit and render instance transforms, include transformed bounds, and prove reuse/disposal. Compose crop layers from completed domain products.

--- a/docs/ai/framework/rules/release-version-topology.md
+++ b/docs/ai/framework/rules/release-version-topology.md
@@ -28,6 +28,11 @@ app templates.
   template inherits that app version through the official generator; the
   template is never edited, versioned, or selected in Changesets independently.
 
+Pure Markdown documentation PRs require no Changeset. This exemption checks
+all changed paths, including deletions and both rename paths: every path must
+end in `.md` and be outside `.changeset/`. Mixed changes and executable
+documentation such as `.mdx` retain the ordinary requirement.
+
 An empty Changeset may record a non-documentation PR that changes no versioned
 Framework package or public tool. Empty records satisfy closeout without assigning a release version to
 root, private, CLI, or generated-template owners.

--- a/docs/ai/workflows/package-release-validation.md
+++ b/docs/ai/workflows/package-release-validation.md
@@ -207,8 +207,11 @@ authorizes the corresponding remote operation.
 Changesets version only fixed-allowlist Framework packages under `packages/*`.
 Root `asyra`, private apps, `create-app/*` CLI packages, and generated templates
 must never appear as Changeset release entries. A non-Framework code PR may use
-an empty Changeset as its closeout record. Every pull request must carry that
-pending record before completion. CI accepts a release pull request after
+an empty Changeset as its closeout record. Pure Markdown documentation pull requests do not require a Changeset.
+All changed paths, including deleted files and both sides of a rename, must
+end in `.md` and be outside `.changeset/` to qualify. Executable documentation
+(such as `.mdx`), scripts, configuration, and mixed changes retain the pending
+record requirement before completion. CI accepts a release pull request after
 `changeset version` consumes its pending records only when at least one
 allowlisted Framework package has both its generated manifest version and
 changelog committed; deleting a Changeset alone never satisfies the gate.

--- a/scripts/__tests__/changeset-pr-check.test.mjs
+++ b/scripts/__tests__/changeset-pr-check.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { evaluateChangesetPrDiff } from '../changeset-pr-check.js'
+import {
+  evaluateChangesetPrDiff,
+  parseNameStatus
+} from '../changeset-pr-check.js'
 
 test('accepts a pull request with a pending changeset record', () => {
   const result = evaluateChangesetPrDiff([
@@ -32,7 +35,7 @@ test('accepts a release pull request with materialized versions and changelogs',
 
 test('rejects ordinary pull requests without a changeset record', () => {
   const result = evaluateChangesetPrDiff([
-    { status: 'M', path: 'docs/README.md' }
+    { status: 'M', path: 'scripts/example.js' }
   ])
 
   assert.equal(result.valid, false)
@@ -55,4 +58,67 @@ test('deleted changesets do not satisfy the pending-record rule by themselves', 
 
   assert.equal(result.valid, false)
   assert.equal(result.mode, 'missing')
+})
+
+for (const status of ['A', 'M', 'D']) {
+  test(`accepts documentation-only ${status} changes without a changeset`, () => {
+    assert.deepEqual(
+      evaluateChangesetPrDiff([
+        { status, path: 'docs/ai/apps/fieldscope/PLANS.md' },
+        { status, path: 'apps/fieldscope/README.md' }
+      ]),
+      { valid: true, mode: 'documentation-only', packages: [] }
+    )
+  })
+}
+
+test('accepts documentation moves but checks both paths of code moves', () => {
+  assert.equal(
+    evaluateChangesetPrDiff(
+      parseNameStatus('R100\tdocs/plan.md\tdocs/completed/plan.md\n')
+    ).valid,
+    true
+  )
+  for (const output of [
+    'R100\tscripts/tool.js\tdocs/tool.md\n',
+    'R100\tdocs/tool.md\tscripts/tool.js\n'
+  ]) {
+    assert.equal(evaluateChangesetPrDiff(parseNameStatus(output)).valid, false)
+  }
+})
+
+test('does not exempt empty diffs, changeset metadata, executable docs, or mixed changes', () => {
+  assert.equal(evaluateChangesetPrDiff([]).valid, false)
+  for (const path of [
+    'scripts/tool.js',
+    'docs/example.js',
+    'docs/page.mdx',
+    'package.json',
+    '.github/workflows/ci.yml',
+    '.changeset/README.md',
+    '.changeset/deleted-record.md'
+  ]) {
+    for (const status of ['M', 'D']) {
+      if (path === '.changeset/deleted-record.md' && status === 'M') continue
+      assert.equal(
+        evaluateChangesetPrDiff([
+          { status: 'M', path: 'docs/README.md' },
+          { status, path }
+        ]).valid,
+        false,
+        `${status} ${path}`
+      )
+    }
+  }
+})
+
+test('moving a changeset out of its directory does not count as a pending record', () => {
+  assert.equal(
+    evaluateChangesetPrDiff(
+      parseNameStatus(
+        'R100\t.changeset/old.md\tdocs/old.md\nM\tscripts/tool.js\n'
+      )
+    ).valid,
+    false
+  )
 })

--- a/scripts/changeset-pr-check.js
+++ b/scripts/changeset-pr-check.js
@@ -26,12 +26,32 @@ export const parseNameStatus = (output) =>
   output
     .split('\n')
     .filter(Boolean)
-    .map((line) => {
+    .flatMap((line) => {
       const [status, ...paths] = line.split('\t')
-      return { status: status[0], path: paths.at(-1) }
+      if (status.startsWith('R')) {
+        return [
+          { status: 'D', path: paths[0] },
+          { status: 'A', path: paths[1] }
+        ]
+      }
+      return paths.map((changedPath) => ({
+        status: status[0],
+        path: changedPath
+      }))
     })
 
 export const evaluateChangesetPrDiff = (changes) => {
+  const isDocumentationOnly =
+    changes.length > 0 &&
+    changes.every(
+      ({ path: changedPath }) =>
+        changedPath.endsWith('.md') && !changedPath.startsWith('.changeset/')
+    )
+
+  if (isDocumentationOnly) {
+    return { valid: true, mode: 'documentation-only', packages: [] }
+  }
+
   const hasPendingChangeset = changes.some(
     ({ status, path: changedPath }) =>
       status !== 'D' &&
@@ -82,7 +102,7 @@ export const runChangesetPrCheck = ({ baseSha, headSha }) => {
 
   if (!result.valid) {
     throw new Error(
-      'PR requires a pending .changeset/*.md record. Release PRs are accepted only after Changesets materializes both package versions and changelogs.'
+      'Non-documentation PR requires a pending .changeset/*.md record. Release PRs are accepted only after Changesets materializes both package versions and changelogs.'
     )
   }
 


### PR DESCRIPTION
Close the completed FieldScope work that was not included when PR #174 merged. The latest main contains the implementation but still lists the water/crop plan as active and lacks the retrospective baseline closeout.

- Archive the water/crop plan and Inspector flow with the final merge and CI evidence.
- Backfill the PR #170 greenhouse workspace closeout and index the completed PR #174 follow-up stages.
- Append dated decision history while preserving the original baseline decision and historical implementation notes.

The Changeset gate previously rejected even pure documentation PRs. Exempt changes where every path is Markdown outside `.changeset/`, checking deletions and both rename paths. Mixed code/configuration changes and executable MDX still require a record. Update the release rules and include an empty Changeset for this CI code fix; no versions are changed.

Validation: 17 focused Changeset tests pass, including new regressions reproduced before the fix; ESLint and the naming gate pass. The updated checker accepts the original documentation-only closeout diff and the current mixed PR with its pending record. All 33 closeout document links and section anchors resolve, and whitespace checks pass. Application behavior, dependencies, tags, publication and deployment are unchanged.
