### PR TITLE
Add FieldScope harvest robot plans and feasibility foundations

### DIFF
--- a/.changeset/harvest-feasibility.md
+++ b/.changeset/harvest-feasibility.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add FieldScope harvest-robot feasibility, load, charging-energy and hazard assessment foundations with staged implementation and hardware validation plans.

--- a/apps/fieldscope/src/domain/__tests__/harvest-assessment.test.ts
+++ b/apps/fieldscope/src/domain/__tests__/harvest-assessment.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_CONFIGURATION } from '../farm-configuration'
+import * as greenhouse from '../greenhouse'
+import * as supports from '../planting-supports'
+import * as crops from '../crop-layout'
+import { assessHarvestLane, type LaneRequest } from '../harvest-assessment'
+
+function request(): LaneRequest {
+  return {
+    farm: structuredClone(DEFAULT_CONFIGURATION),
+    lane: { kind: 'strip', bay: 0, strip: 2 },
+    vehicle: { width: 0.55, length: 0.9, height: 1.2, clearance: 0.05 },
+    canopyReserve: 0.2,
+    start: 0.25,
+    end: 49.75,
+    survey: {
+      ground: 'prepared',
+      entranceWidth: 2,
+      entranceHeight: 2.5,
+      frontHeadland: 1.5,
+      rearHeadland: 1.5
+    }
+  }
+}
+afterEach(() => vi.restoreAllMocks())
+describe('M1 straight-lane feasibility', () => {
+  it('screens internal soil between existing root rows, without claiming safety', () => {
+    const result = assessHarvestLane(request())
+    expect(result.status).toBe('screened')
+    expect(result.usableWidth).toBeCloseTo(1)
+    expect(result.requiredWidth).toBeCloseTo(0.65)
+    expect(result.unresolved).toContain('physical-validation')
+  })
+  it('blocks the water channel even for a very narrow vehicle', () => {
+    const input = request()
+    input.lane = { kind: 'strip', bay: 0, strip: 1 }
+    input.vehicle.width = 0.1
+    expect(assessHarvestLane(input).blocked).toContain('water-channel')
+  })
+  it.each(['left', 'right'] as const)(
+    'accounts for center columns on shared passage %s',
+    (side) => {
+      const input = request()
+      input.lane = { kind: 'shared', boundary: 1, side }
+      const result = assessHarvestLane(input)
+      expect(result.usableWidth).toBeCloseTo(0.312)
+      expect(result.blocked).toContain('insufficient-width')
+    }
+  )
+  it('keeps unknown ground and entrance/headland measurements unverified', () => {
+    const input = request()
+    input.survey = {
+      ground: 'unknown',
+      entranceWidth: null,
+      entranceHeight: null,
+      frontHeadland: null,
+      rearHeadland: null
+    }
+    const result = assessHarvestLane(input)
+    expect(result.status).toBe('unverified')
+    expect(result.unverified).toEqual([
+      'unknown-entrance',
+      'unknown-headland',
+      'unknown-ground'
+    ])
+  })
+  it('prioritizes blocking evidence over missing evidence', () => {
+    const input = request()
+    input.survey.ground = 'soft'
+    input.survey.entranceWidth = null
+    expect(assessHarvestLane(input).status).toBe('blocked')
+  })
+  it('does not treat the plant setbacks as adequate headlands', () => {
+    const input = request()
+    input.survey.frontHeadland = 0
+    input.survey.rearHeadland = 0
+    expect(assessHarvestLane(input).blocked).toEqual([
+      'front-headland',
+      'rear-headland'
+    ])
+  })
+  it('checks entry and crossbeam heights as well as lane width', () => {
+    const input = request()
+    input.vehicle.height = 3.1
+    input.survey.entranceWidth = 0.5
+    expect(assessHarvestLane(input).blocked).toEqual([
+      'insufficient-height',
+      'entrance-width',
+      'entrance-height'
+    ])
+  })
+  it('admits exact width but rejects a larger swept width', () => {
+    const input = request()
+    input.vehicle.width = 0.9
+    expect(assessHarvestLane(input).status).toBe('screened')
+    input.vehicle.width += 0.001
+    expect(assessHarvestLane(input).blocked).toContain('insufficient-width')
+  })
+  it('reassesses geometry changes without mutation or per-plant work', () => {
+    const layout = vi.spyOn(greenhouse, 'createLayout')
+    const rows = vi.spyOn(supports, 'createPlantingRows')
+    const plants = vi.spyOn(crops, 'createCropPositions')
+    const input = request()
+    const before = structuredClone(input)
+    const first = assessHarvestLane(input)
+    expect(input).toEqual(before)
+    expect(layout).toHaveBeenCalledTimes(2)
+    expect(rows).toHaveBeenCalledTimes(1)
+    expect(plants).not.toHaveBeenCalled()
+    input.farm.length = 200
+    expect(assessHarvestLane(input).usableWidth).toBe(first.usableWidth)
+    expect(layout).toHaveBeenCalledTimes(4)
+    expect(rows).toHaveBeenCalledTimes(2)
+    input.farm.soilInset = 0.3
+    expect(assessHarvestLane(input).usableWidth).toBeCloseTo(0.7)
+    input.farm = before.farm
+    expect(assessHarvestLane(input)).toEqual(first)
+  })
+  it.each([NaN, Infinity, -1])('rejects invalid dimensions %s', (value) => {
+    const input = request()
+    input.vehicle.width = value
+    expect(() => assessHarvestLane(input)).toThrow()
+  })
+  it('rejects invalid lane, interval and incomplete survey input', () => {
+    const input = request()
+    input.lane = { kind: 'strip', bay: 4, strip: 2 }
+    expect(() => assessHarvestLane(input)).toThrow()
+    input.lane = { kind: 'strip', bay: 0, strip: 2 }
+    input.end = input.start
+    expect(() => assessHarvestLane(input)).toThrow()
+    input.end = 20
+    input.survey.frontHeadland = undefined as unknown as number
+    expect(() => assessHarvestLane(input)).toThrow()
+  })
+})

--- a/apps/fieldscope/src/domain/__tests__/harvest-energy.test.ts
+++ b/apps/fieldscope/src/domain/__tests__/harvest-energy.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { assessHarvestEnergy, type EnergyBudget } from '../harvest-energy'
+const base: EnergyBudget = {
+  nominalWh: 1000,
+  usableFraction: 0.8,
+  soc: 0.6,
+  socUncertainty: 0.05,
+  nextWorkWh: 200,
+  returnWh: 100,
+  contingencyWh: 40,
+  reserveWh: 60,
+  batteryFresh: true,
+  returnPathAdmitted: true,
+  dockAvailable: true
+}
+describe('M1 battery and charging return budget', () => {
+  it('uses derated capacity and SOC uncertainty before admitting work', () => {
+    const result = assessHarvestEnergy(base)
+    expect(result.availableWh).toBeCloseTo(440)
+    expect(result.returnRequiredWh).toBe(200)
+    expect(result.missionRequiredWh).toBe(400)
+    expect(result.minimumDispatchSoc).toBe(0.55)
+    expect(result.action).toBe('continue-screening')
+  })
+  it('returns while return reserve remains rather than draining it on a pick', () => {
+    expect(assessHarvestEnergy({ ...base, soc: 0.5 }).action).toBe(
+      'return-to-charge'
+    )
+    expect(assessHarvestEnergy({ ...base, soc: 0.2 }).action).toBe('hold')
+  })
+  it('keeps the declared reserve intact at the exact dispatch threshold', () => {
+    expect(assessHarvestEnergy({ ...base, soc: 0.55 }).action).toBe(
+      'continue-screening'
+    )
+    expect(assessHarvestEnergy({ ...base, soc: 0.549 }).action).toBe(
+      'return-to-charge'
+    )
+  })
+  it('does not hide a battery too small for the mission', () => {
+    const result = assessHarvestEnergy({ ...base, nextWorkWh: 900 })
+    expect(result.undersized).toBe(true)
+    expect(result.minimumDispatchSoc).toBeGreaterThan(1)
+  })
+  it.each([
+    { batteryFresh: false },
+    { returnPathAdmitted: false },
+    { dockAvailable: false }
+  ])('holds for missing admission %j even at full charge', (change) => {
+    expect(assessHarvestEnergy({ ...base, soc: 1, ...change }).action).toBe(
+      'hold'
+    )
+  })
+  it('handles low SOC and worsened loaded return without inventing energy', () => {
+    expect(assessHarvestEnergy({ ...base, soc: 0.01 }).availableWh).toBe(0)
+    expect(assessHarvestEnergy({ ...base, returnWh: 500 }).action).toBe('hold')
+  })
+  it.each([
+    { nominalWh: 0 },
+    { soc: 1.1 },
+    { usableFraction: -1 },
+    { reserveWh: 0 },
+    { returnWh: NaN },
+    { contingencyWh: Infinity }
+  ])('rejects invalid energy data %j', (change) => {
+    expect(() => assessHarvestEnergy({ ...base, ...change })).toThrow()
+  })
+})
+
+it('rejects finite inputs whose energy arithmetic overflows', () => {
+  expect(() =>
+    assessHarvestEnergy({
+      ...base,
+      nextWorkWh: Number.MAX_VALUE,
+      returnWh: Number.MAX_VALUE
+    })
+  ).toThrow()
+})

--- a/apps/fieldscope/src/domain/__tests__/harvest-load.test.ts
+++ b/apps/fieldscope/src/domain/__tests__/harvest-load.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { assessCrateLoad, type CrateLoad } from '../harvest-load'
+const base: CrateLoad = {
+  baseMass: 60,
+  payload: 2,
+  nextFruit: 0.2,
+  payloadLimit: 8,
+  fill: 0.3,
+  returnFill: 0.8,
+  latched: true,
+  scaleTrusted: true,
+  track: 0.42,
+  baseHeight: 0.2,
+  payloadHeight: 0.5,
+  baseOffset: 0,
+  payloadOffset: 0.1,
+  roll: 0,
+  lateralAcceleration: 0,
+  uncertainty: 0.02
+}
+describe('M1 crate and lateral reserve', () => {
+  it('computes weight and reserve without changing inventory', () => {
+    const before = { ...base }
+    const result = assessCrateLoad(base)
+    expect(result.totalMass).toBe(62)
+    expect(result.lateralReserve).toBeCloseTo(0.21 - 0.2 / 62 - 0.02)
+    expect(result.action).toBe('continue-screening')
+    expect(base).toEqual(before)
+  })
+  it('requests exchange before accepting an overweight next fruit and at exact capacity', () => {
+    expect(assessCrateLoad({ ...base, payload: 7.9 }).action).toBe('exchange')
+    expect(assessCrateLoad({ ...base, payload: 8 }).action).toBe('exchange')
+    expect(assessCrateLoad({ ...base, payload: 7.8 }).action).toBe(
+      'continue-screening'
+    )
+  })
+  it('requests exchange for spatial fill even when light', () => {
+    expect(assessCrateLoad({ ...base, fill: 0.8 }).exchange).toContain(
+      'fill-capacity'
+    )
+  })
+  it.each([
+    { latched: false },
+    { scaleTrusted: false },
+    { payload: 9 },
+    { roll: 0.8 }
+  ])('stops for current load faults %j', (change) => {
+    expect(assessCrateLoad({ ...base, ...change }).action).toBe('stop')
+  })
+  it('reduces reserve as high offset load, roll and acceleration increase', () => {
+    const empty = assessCrateLoad({ ...base, payload: 0, roll: 0.1 })
+    const full = assessCrateLoad({ ...base, payload: 8, roll: 0.1 })
+    expect(full.lateralReserve).toBeLessThan(empty.lateralReserve)
+    expect(
+      assessCrateLoad({ ...base, lateralAcceleration: -2 }).lateralReserve
+    ).toBeCloseTo(
+      assessCrateLoad({ ...base, lateralAcceleration: 2 }).lateralReserve
+    )
+  })
+  it('rejects a proposed fruit that would exhaust lateral reserve', () => {
+    const result = assessCrateLoad({
+      ...base,
+      payload: 0,
+      nextFruit: 8,
+      payloadOffset: 2
+    })
+    expect(result.lateralReserve).toBeGreaterThan(0)
+    expect(result.projectedReserve).toBeLessThan(0)
+    expect(result.action).toBe('exchange')
+  })
+  it.each([
+    { payload: -1 },
+    { baseMass: 0 },
+    { roll: Math.PI / 2 },
+    { track: NaN },
+    { fill: 1.1 },
+    { nextFruit: Infinity }
+  ])('rejects invalid physical input %j', (change) => {
+    expect(() => assessCrateLoad({ ...base, ...change })).toThrow()
+  })
+})
+
+it('rejects finite inputs whose mass moments overflow', () => {
+  expect(() =>
+    assessCrateLoad({
+      ...base,
+      baseMass: Number.MAX_VALUE,
+      baseHeight: Number.MAX_VALUE
+    })
+  ).toThrow()
+})

--- a/apps/fieldscope/src/domain/__tests__/harvest-policy.test.ts
+++ b/apps/fieldscope/src/domain/__tests__/harvest-policy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  adviseHarvestAction,
+  type HarvestObservations
+} from '../harvest-policy'
+const base: HarvestObservations = {
+  energy: 'continue-screening',
+  emergencyStop: false,
+  person: false,
+  unstable: false,
+  crateUnlatched: false,
+  sensorsFresh: true,
+  communicationFresh: true,
+  obstacle: false,
+  toolContact: false,
+  fruitAndStemVerified: true,
+  load: 'continue-screening'
+}
+describe('M1 hazard priority', () => {
+  it('protects people before instability and saving a full crate', () => {
+    expect(
+      adviseHarvestAction({
+        ...base,
+        person: true,
+        unstable: true,
+        load: 'exchange'
+      })
+    ).toEqual({
+      action: 'protect-people',
+      inhibitCutting: true,
+      stopTravel: true,
+      requireReturnAdmission: false
+    })
+  })
+  it('does not return or reach for the crate during loss of support', () => {
+    expect(
+      adviseHarvestAction({
+        ...base,
+        unstable: true,
+        energy: 'return-to-charge',
+        load: 'exchange'
+      }).action
+    ).toBe('immobilize')
+  })
+  it.each([
+    [{ sensorsFresh: false }, 'await-observation'],
+    [{ communicationFresh: false }, 'await-observation'],
+    [{ obstacle: true }, 'wait-or-replan'],
+    [{ toolContact: true }, 'hold-tool'],
+    [{ fruitAndStemVerified: false }, 'observe-or-defer'],
+    [{ energy: 'hold' }, 'await-observation']
+  ] as const)('inhibits travel and cutting for %j', (change, action) => {
+    const result = adviseHarvestAction({ ...base, ...change })
+    expect(result.action).toBe(action)
+    expect(result.stopTravel).toBe(true)
+    expect(result.inhibitCutting).toBe(true)
+  })
+  it('requests admitted return before looking for more fruit', () => {
+    const result = adviseHarvestAction({
+      ...base,
+      load: 'exchange',
+      fruitAndStemVerified: false
+    })
+    expect(result.action).toBe('return-to-dock')
+    expect(result.requireReturnAdmission).toBe(true)
+    expect(result.inhibitCutting).toBe(true)
+    expect(
+      adviseHarvestAction({ ...base, energy: 'return-to-charge' })
+        .requireReturnAdmission
+    ).toBe(true)
+  })
+  it('never lets energy policy override contact or a human stop', () => {
+    expect(
+      adviseHarvestAction({
+        ...base,
+        toolContact: true,
+        energy: 'return-to-charge'
+      }).action
+    ).toBe('hold-tool')
+    expect(
+      adviseHarvestAction({ ...base, emergencyStop: true, energy: 'hold' })
+        .action
+    ).toBe('protect-people')
+  })
+  it('does not interpret missing observations as clear', () => {
+    expect(() =>
+      adviseHarvestAction({
+        ...base,
+        sensorsFresh: undefined
+      } as unknown as HarvestObservations)
+    ).toThrow()
+  })
+})
+
+it('cannot continue when the completed load report requests a stop', () => {
+  expect(adviseHarvestAction({ ...base, load: 'stop' }).action).toBe(
+    'immobilize'
+  )
+})

--- a/apps/fieldscope/src/domain/harvest-assessment.ts
+++ b/apps/fieldscope/src/domain/harvest-assessment.ts
@@ -1,0 +1,182 @@
+import { CROP_LAYOUT } from './crop-layout'
+import {
+  configurationSite,
+  validateConfiguration,
+  type FarmConfiguration
+} from './farm-configuration'
+import { createLayout } from './greenhouse'
+import { createPlantingRows } from './planting-supports'
+
+export interface VehicleEnvelope {
+  width: number
+  length: number
+  height: number
+  clearance: number
+}
+export type PatrolLane =
+  | { kind: 'strip'; bay: number; strip: number }
+  | { kind: 'shared'; boundary: number; side: 'left' | 'right' }
+export interface LaneSurvey {
+  ground: 'prepared' | 'unknown' | 'soft'
+  entranceWidth: number | null
+  entranceHeight: number | null
+  frontHeadland: number | null
+  rearHeadland: number | null
+}
+export interface LaneRequest {
+  farm: FarmConfiguration
+  lane: PatrolLane
+  vehicle: VehicleEnvelope
+  canopyReserve: number
+  start: number
+  end: number
+  survey: LaneSurvey
+}
+export type LaneReason =
+  | 'water-channel'
+  | 'insufficient-width'
+  | 'insufficient-height'
+  | 'entrance-width'
+  | 'entrance-height'
+  | 'front-headland'
+  | 'rear-headland'
+  | 'soft-ground'
+  | 'unknown-ground'
+  | 'unknown-entrance'
+  | 'unknown-headland'
+
+/** Necessary straight-line checks only; no physical motion permission. */
+export function assessHarvestLane(request: LaneRequest) {
+  const { farm, lane, vehicle, survey, start, end, canopyReserve } = request
+  validateConfiguration(farm)
+  for (const [field, value] of Object.entries(vehicle)) {
+    if (
+      !Number.isFinite(value) ||
+      value < 0 ||
+      (field !== 'clearance' && value === 0)
+    )
+      throw new Error(`Invalid vehicle ${field}`)
+  }
+  for (const key of ['width', 'length', 'height', 'clearance'] as const)
+    if (!Number.isFinite(vehicle[key]))
+      throw new Error(`Missing vehicle ${key}`)
+  if (
+    !Number.isFinite(canopyReserve) ||
+    canopyReserve < 0 ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    start < 0 ||
+    end > farm.length ||
+    start >= end
+  )
+    throw new Error('Invalid lane interval or canopy reserve')
+  if (!['prepared', 'unknown', 'soft'].includes(survey.ground))
+    throw new Error('Invalid ground observation')
+  for (const key of [
+    'entranceWidth',
+    'entranceHeight',
+    'frontHeadland',
+    'rearHeadland'
+  ] as const) {
+    const value = survey[key]
+    if (value !== null && (!Number.isFinite(value) || value < 0))
+      throw new Error(`Invalid survey ${key}`)
+  }
+  const site = configurationSite(farm)
+  const layout = createLayout(site, farm.strips)
+  const rows = createPlantingRows(farm)
+  const blocked: LaneReason[] = []
+  const unverified: LaneReason[] = []
+  let left: number
+  let right: number
+  if (lane.kind === 'strip') {
+    if (
+      !Number.isInteger(lane.bay) ||
+      lane.bay < 0 ||
+      lane.bay >= site.bays ||
+      !Number.isInteger(lane.strip) ||
+      lane.strip < 0 ||
+      lane.strip >= farm.strips.length
+    )
+      throw new Error('Invalid strip lane')
+    const strip = layout.strips[lane.bay * farm.strips.length + lane.strip]
+    left = strip.x
+    right = strip.x + strip.width
+    if (strip.kind === 'drain') blocked.push('water-channel')
+    else {
+      for (const row of rows) {
+        if (
+          row.bay !== lane.bay ||
+          row.x < strip.x ||
+          row.x > strip.x + strip.width
+        )
+          continue
+        if (row.side === 'right')
+          left = Math.max(left, row.x + CROP_LAYOUT.rootOffset + canopyReserve)
+        else
+          right = Math.min(
+            right,
+            row.x - CROP_LAYOUT.rootOffset - canopyReserve
+          )
+      }
+    }
+  } else if (lane.kind === 'shared') {
+    if (
+      !Number.isInteger(lane.boundary) ||
+      lane.boundary < 1 ||
+      lane.boundary >= site.bays ||
+      !['left', 'right'].includes(lane.side)
+    )
+      throw new Error('Invalid shared lane')
+    const center = lane.boundary * site.width
+    left = center - site.margin
+    right = center - site.postDiameter / 2
+    if (lane.side === 'right') {
+      left = center + site.postDiameter / 2
+      right = center + site.margin
+    }
+  } else throw new Error('Unknown lane kind')
+  const usableWidth = Math.max(0, right - left)
+  const requiredWidth = vehicle.width + 2 * vehicle.clearance
+  if (usableWidth + 1e-9 < requiredWidth) blocked.push('insufficient-width')
+  if (vehicle.height > site.eave) blocked.push('insufficient-height')
+  if (survey.entranceWidth === null || survey.entranceHeight === null)
+    unverified.push('unknown-entrance')
+  if (survey.entranceWidth !== null && survey.entranceWidth < requiredWidth)
+    blocked.push('entrance-width')
+  if (survey.entranceHeight !== null && survey.entranceHeight < vehicle.height)
+    blocked.push('entrance-height')
+  if (survey.frontHeadland === null || survey.rearHeadland === null)
+    unverified.push('unknown-headland')
+  if (
+    survey.frontHeadland !== null &&
+    start - vehicle.length / 2 < -survey.frontHeadland
+  )
+    blocked.push('front-headland')
+  if (
+    survey.rearHeadland !== null &&
+    end + vehicle.length / 2 > site.length + survey.rearHeadland
+  )
+    blocked.push('rear-headland')
+  if (survey.ground === 'soft') blocked.push('soft-ground')
+  if (survey.ground === 'unknown') unverified.push('unknown-ground')
+  let status: 'blocked' | 'unverified' | 'screened' = 'screened'
+  if (unverified.length) status = 'unverified'
+  if (blocked.length) status = 'blocked'
+  return {
+    status,
+    usableWidth,
+    requiredWidth,
+    centerX: (left + right) / 2,
+    bounds: { left, right, start, end },
+    blocked,
+    unverified,
+    unresolved: [
+      'full-swept-envelope',
+      'braking',
+      'stability',
+      'dynamic-obstacles',
+      'physical-validation'
+    ] as const
+  }
+}

--- a/apps/fieldscope/src/domain/harvest-energy.ts
+++ b/apps/fieldscope/src/domain/harvest-energy.ts
@@ -1,0 +1,74 @@
+export interface EnergyBudget {
+  nominalWh: number
+  usableFraction: number
+  soc: number
+  socUncertainty: number
+  nextWorkWh: number
+  returnWh: number
+  contingencyWh: number
+  reserveWh: number
+  batteryFresh: boolean
+  returnPathAdmitted: boolean
+  dockAvailable: boolean
+}
+
+/** Conservative budget arithmetic; measured consumption remains a caller obligation. */
+export function assessHarvestEnergy(budget: EnergyBudget) {
+  for (const key of ['nominalWh', 'usableFraction', 'reserveWh'] as const)
+    if (!Number.isFinite(budget[key]) || budget[key] <= 0)
+      throw new Error(`Invalid energy ${key}`)
+  for (const key of [
+    'soc',
+    'socUncertainty',
+    'nextWorkWh',
+    'returnWh',
+    'contingencyWh'
+  ] as const)
+    if (!Number.isFinite(budget[key]) || budget[key] < 0)
+      throw new Error(`Invalid energy ${key}`)
+  for (const key of ['usableFraction', 'soc', 'socUncertainty'] as const)
+    if (budget[key] > 1) throw new Error(`Invalid energy fraction ${key}`)
+  for (const key of [
+    'batteryFresh',
+    'returnPathAdmitted',
+    'dockAvailable'
+  ] as const)
+    if (typeof budget[key] !== 'boolean')
+      throw new Error(`Invalid energy observation ${key}`)
+  const usableWh = budget.nominalWh * budget.usableFraction
+  const availableWh = usableWh * Math.max(0, budget.soc - budget.socUncertainty)
+  const returnRequiredWh =
+    budget.returnWh + budget.contingencyWh + budget.reserveWh
+  const missionRequiredWh = returnRequiredWh + budget.nextWorkWh
+  const minimumDispatchSoc =
+    missionRequiredWh / usableWh + budget.socUncertainty
+  if (
+    ![
+      usableWh,
+      availableWh,
+      returnRequiredWh,
+      missionRequiredWh,
+      minimumDispatchSoc
+    ].every(Number.isFinite)
+  )
+    throw new Error('Energy arithmetic exceeds finite range')
+  const reasons: string[] = []
+  if (!budget.batteryFresh) reasons.push('stale-battery')
+  if (!budget.returnPathAdmitted) reasons.push('return-path-unavailable')
+  if (!budget.dockAvailable) reasons.push('dock-unavailable')
+  if (availableWh < returnRequiredWh) reasons.push('insufficient-return-energy')
+  let action: 'hold' | 'return-to-charge' | 'continue-screening' =
+    'continue-screening'
+  if (availableWh < missionRequiredWh) action = 'return-to-charge'
+  if (reasons.length) action = 'hold'
+  return {
+    action,
+    reasons,
+    usableWh,
+    availableWh,
+    returnRequiredWh,
+    missionRequiredWh,
+    minimumDispatchSoc,
+    undersized: minimumDispatchSoc > 1
+  }
+}

--- a/apps/fieldscope/src/domain/harvest-load.ts
+++ b/apps/fieldscope/src/domain/harvest-load.ts
@@ -1,0 +1,101 @@
+export interface CrateLoad {
+  baseMass: number
+  payload: number
+  nextFruit: number
+  payloadLimit: number
+  fill: number
+  returnFill: number
+  latched: boolean
+  scaleTrusted: boolean
+  track: number
+  baseHeight: number
+  payloadHeight: number
+  baseOffset: number
+  payloadOffset: number
+  roll: number
+  lateralAcceleration: number
+  uncertainty: number
+}
+
+/** Stowed-pose lateral screening; no contact or dynamic stability solver. */
+export function assessCrateLoad(load: CrateLoad) {
+  for (const key of [
+    'baseMass',
+    'payloadLimit',
+    'track',
+    'returnFill'
+  ] as const)
+    if (!Number.isFinite(load[key]) || load[key] <= 0)
+      throw new Error(`Invalid load ${key}`)
+  for (const key of [
+    'payload',
+    'nextFruit',
+    'fill',
+    'baseHeight',
+    'payloadHeight',
+    'uncertainty'
+  ] as const)
+    if (!Number.isFinite(load[key]) || load[key] < 0)
+      throw new Error(`Invalid load ${key}`)
+  for (const key of [
+    'baseOffset',
+    'payloadOffset',
+    'roll',
+    'lateralAcceleration'
+  ] as const)
+    if (!Number.isFinite(load[key])) throw new Error(`Invalid load ${key}`)
+  if (
+    load.fill > 1 ||
+    load.returnFill > 1 ||
+    Math.abs(load.roll) >= Math.PI / 2 ||
+    typeof load.latched !== 'boolean' ||
+    typeof load.scaleTrusted !== 'boolean'
+  )
+    throw new Error('Invalid crate observation')
+  const reserve = (payload: number) => {
+    const mass = load.baseMass + payload
+    const x =
+      (load.baseMass * load.baseOffset + payload * load.payloadOffset) / mass
+    const height =
+      (load.baseMass * load.baseHeight + payload * load.payloadHeight) / mass
+    return (
+      load.track / 2 -
+      Math.abs(x) -
+      height * Math.tan(Math.abs(load.roll)) -
+      (height * Math.abs(load.lateralAcceleration)) / 9.80665 -
+      load.uncertainty
+    )
+  }
+  const lateralReserve = reserve(load.payload)
+  const projectedReserve = reserve(load.payload + load.nextFruit)
+  if (
+    ![load.baseMass + load.payload, lateralReserve, projectedReserve].every(
+      Number.isFinite
+    )
+  )
+    throw new Error('Load arithmetic exceeds finite range')
+  const stop: string[] = []
+  const exchange: string[] = []
+  if (!load.latched) stop.push('crate-unlatched')
+  if (!load.scaleTrusted) stop.push('untrusted-scale')
+  if (load.payload > load.payloadLimit) stop.push('overload')
+  if (lateralReserve <= 0) stop.push('lateral-reserve')
+  if (
+    load.payload >= load.payloadLimit ||
+    load.payload + load.nextFruit > load.payloadLimit
+  )
+    exchange.push('payload-capacity')
+  if (load.fill >= load.returnFill) exchange.push('fill-capacity')
+  if (projectedReserve <= 0) exchange.push('projected-lateral-reserve')
+  let action: 'stop' | 'exchange' | 'continue-screening' = 'continue-screening'
+  if (exchange.length) action = 'exchange'
+  if (stop.length) action = 'stop'
+  return {
+    action,
+    stop,
+    exchange,
+    totalMass: load.baseMass + load.payload,
+    lateralReserve,
+    projectedReserve
+  }
+}

--- a/apps/fieldscope/src/domain/harvest-policy.ts
+++ b/apps/fieldscope/src/domain/harvest-policy.ts
@@ -1,0 +1,75 @@
+export interface HarvestObservations {
+  energy: 'hold' | 'return-to-charge' | 'continue-screening'
+  emergencyStop: boolean
+  person: boolean
+  unstable: boolean
+  crateUnlatched: boolean
+  sensorsFresh: boolean
+  communicationFresh: boolean
+  obstacle: boolean
+  toolContact: boolean
+  fruitAndStemVerified: boolean
+  load: 'stop' | 'exchange' | 'continue-screening'
+}
+
+/** Advisory priority only. Return travel still needs a stowed tool and admitted route. */
+export function adviseHarvestAction(observations: HarvestObservations) {
+  const keys: (keyof HarvestObservations)[] = [
+    'emergencyStop',
+    'person',
+    'unstable',
+    'crateUnlatched',
+    'sensorsFresh',
+    'communicationFresh',
+    'obstacle',
+    'toolContact',
+    'fruitAndStemVerified'
+  ]
+  if (
+    !['hold', 'return-to-charge', 'continue-screening'].includes(
+      observations.energy
+    )
+  )
+    throw new Error('Invalid energy advice')
+  if (!['stop', 'exchange', 'continue-screening'].includes(observations.load))
+    throw new Error('Invalid load advice')
+  for (const key of keys)
+    if (typeof observations[key] !== 'boolean')
+      throw new Error(`Invalid observation ${key}`)
+  let action:
+    | 'protect-people'
+    | 'immobilize'
+    | 'await-observation'
+    | 'wait-or-replan'
+    | 'hold-tool'
+    | 'observe-or-defer'
+    | 'return-to-dock'
+    | 'return-to-charge'
+    | 'continue-screening' = 'continue-screening'
+  if (!observations.fruitAndStemVerified) action = 'observe-or-defer'
+  if (observations.load === 'exchange') action = 'return-to-dock'
+  if (observations.energy === 'return-to-charge') action = 'return-to-charge'
+  if (observations.energy === 'hold') action = 'await-observation'
+  if (observations.toolContact) action = 'hold-tool'
+  if (observations.obstacle) action = 'wait-or-replan'
+  if (!observations.sensorsFresh || !observations.communicationFresh)
+    action = 'await-observation'
+  if (
+    observations.unstable ||
+    observations.crateUnlatched ||
+    observations.load === 'stop'
+  )
+    action = 'immobilize'
+  if (observations.person || observations.emergencyStop)
+    action = 'protect-people'
+  return {
+    action,
+    inhibitCutting: action !== 'continue-screening',
+    stopTravel:
+      action !== 'continue-screening' &&
+      action !== 'return-to-dock' &&
+      action !== 'return-to-charge',
+    requireReturnAdmission:
+      action === 'return-to-dock' || action === 'return-to-charge'
+  }
+}

--- a/docs/ai/apps/fieldscope/ARCHITECTURE.md
+++ b/docs/ai/apps/fieldscope/ARCHITECTURE.md
@@ -15,3 +15,13 @@ There is no framework package modification, robot controller, server, collision 
 SceneTree owns the canonical structured settings element and its transaction history. SpatialLayer owns derived 3D output; retained projections are neither editable state nor a second SceneTree. This composition follows the public custom-composition guide rather than copying the design app's 2D schema.
 
 UI language is owned by `ui/i18n/locale.tsx` and its typed message catalogs. Its provider wraps the existing workbench without replacing runtime or configuration ownership. Language-neutral `ConfigurationError` codes/parameters originate in the configuration validator; UI error formatting never parses localized strings. Locale changes bypass site projection, scene admission and history.
+
+## Harvest feasibility domain
+
+The four `domain/harvest-*.ts` modules provide deterministic lane, crate/load,
+energy and hazard assessments. They consume existing farm layout/planting-row
+owners and explicit observations; they do not create a second farm model,
+generate crop meshes, drive animation, mutate Core or command hardware. M1 is
+headless and has no UI consumer yet. Reports are necessary engineering screens,
+not physical clearance or safety certificates. The [harvest owner flow](/docs/ai/apps/fieldscope/plans/harvest-robot/inspector-flow.md)
+owns the boundaries for subsequent mission composition and projection.

--- a/docs/ai/apps/fieldscope/PLANS.md
+++ b/docs/ai/apps/fieldscope/PLANS.md
@@ -2,7 +2,7 @@
 
 ## Active
 
-None.
+- [Harvest robot and crate logistics](/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md) - IN PROGRESS. M1 feasibility/load/energy/hazard domain implemented; mission UI, simulation and hardware validation remain planned; previous crop/workspace plans remain completed.
 
 ## Completed
 
@@ -29,3 +29,9 @@ These are completed stages of the archived water/crop plan, not separate active 
 | First-person and mobile navigation | [Camera specification](/docs/ai/apps/fieldscope/specs/camera.md), [touch gestures](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#mobile-camera-gestures) |
 | Traditional Chinese/English UI | [Bilingual interface](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#bilingual-interface) |
 | CI dependency-test isolation | [CI validation](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md#ci-projection-test-isolation) |
+
+## Retrospective development stages
+
+- [Cultivar realism and harvested-target preparation](/docs/ai/apps/fieldscope/plans/completed/crop-realism/plan.md) - DONE; a sub-stage of PR #174.
+- [Responsive editing and scene ownership](/docs/ai/apps/fieldscope/plans/completed/responsive-workbench/plan.md) - DONE; a sub-stage of PR #174.
+- [Navigation, mobile controls and localization](/docs/ai/apps/fieldscope/plans/completed/navigation-and-localization/plan.md) - DONE; a sub-stage of PR #174.

--- a/docs/ai/apps/fieldscope/PLANS.md
+++ b/docs/ai/apps/fieldscope/PLANS.md
@@ -6,6 +6,8 @@
 
 ## Completed
 
+- [Harvest feasibility - M1](/docs/ai/apps/fieldscope/plans/completed/harvest-feasibility/plan.md) - DONE 2026-09-12. PR #191 closeout precedes its current-head CI and merge gate; M2-M6 remain active planned work.
+
 - [Greenhouse workspace baseline](/docs/ai/apps/fieldscope/plans/completed/greenhouse-workspace/plan.md) - DONE 2026-09-09 (Asia/Taipei), retrospective closeout recorded 2026-09-11. PR #170 delivered the initial private 0.1.0 modeling workspace; its original baseline decision is retained.
 
 - [Water and crop population](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md) - DONE 2026-09-11. PR #174 merged with all five checks passing; delivered water/crops, responsive scene updates, immediate editing/history, camera gestures and bilingual UI. See the [closeout decision](/docs/ai/apps/fieldscope/decisions/releases/unreleased.md).

--- a/docs/ai/apps/fieldscope/README.md
+++ b/docs/ai/apps/fieldscope/README.md
@@ -12,6 +12,7 @@ Read [App essentials](APP_ESSENTIALS.md), [Architecture](ARCHITECTURE.md), [API 
 - [Configuration and history](specs/configuration.md)
 - [Camera controls](specs/camera.md)
 - [Water and crop specification](specs/water-and-crops.md)
+- [Harvest robot contract](specs/harvest-robot.md), [hardware and charging concept](specs/harvest-hardware.md), and [staged scenarios](bdd-features/harvest-robot.feature)
 - [Rendering module](modules/rendering.md)
 - [Product scope](prd/overview.md)
 - [Executable product scenarios](bdd-features/greenhouse.feature)

--- a/docs/ai/apps/fieldscope/bdd-features/harvest-robot.feature
+++ b/docs/ai/apps/fieldscope/bdd-features/harvest-robot.feature
@@ -1,0 +1,177 @@
+Feature: Harvest robot feasibility and supervised harvesting
+  M1 lane/load/hazard scenarios are covered by domain Vitest tests.
+  M2-M6 scenarios are acceptance requirements, not claims of implemented behavior.
+
+  @M1
+  Scenario: The existing water drain is not a robot road
+    Given the default 0.30 metre soil drain and a 0.55 metre chassis
+    When the drain is selected as a patrol lane
+    Then the lane is blocked even if the ground is marked prepared
+
+  @M1
+  Scenario: A shared passage contains columns
+    Given 0.35 metre side margins and a 0.076 metre central column
+    When a 0.55 metre chassis requests the shared passage
+    Then the straight lane uses only one side of the column
+    And the lane is blocked for insufficient width
+
+  @M1
+  Scenario: Unknown soil is not approved by geometry
+    Given a geometrically wide soil lane with unknown ground bearing
+    When feasibility is evaluated
+    Then its result is unverified
+    And no actuator permission is produced
+
+  @M1
+  Scenario: Exact-width screening with measured entrance and headland
+    Given usable width equals chassis width plus both clearance margins
+    And prepared ground and measured entrance and headlands
+    When the stowed straight route fits
+    Then the result is screened
+    And full swept-path and physical validation remain unresolved
+
+  @M1
+  Scenario: End plant setback is too short for the base
+    Given the center route starts at 0.25 metres and the base is 0.90 metres long
+    And no usable external headland exists
+    When the route is assessed
+    Then the footprint crossing the entrance is reported
+
+  @M1
+  Scenario: The next cucumber would overload the crate
+    Given a retained crate below its mass limit
+    When the next fruit would exceed that limit
+    Then exchange is requested before picking the fruit
+
+  @M1
+  Scenario: A light tomato tray is spatially full
+    Given payload is below its permitted mass
+    And measured fill reaches the operational return threshold
+    Then exchange is requested
+
+  @M1
+  Scenario: Sinkage takes priority over saving produce
+    Given the crate is full and the base loses support
+    When the advisory policy runs
+    Then travel and cutting are inhibited
+    And no crate release or blind arm swing is commanded
+
+  @M1
+  Scenario: A person takes priority over every machine task
+    Given a person enters while the platform is unstable and the box is full
+    Then the advisory action protects people first
+
+  @M2
+  Scenario: Editing a route and undoing restores the mission
+    Given an idle admitted mission
+    When the user changes its lane interval and undoes the edit
+    Then canonical route settings and assessment return together
+    And crop meshes are not rebuilt
+
+  @M3
+  Scenario: Repeated schedules do not overlap
+    Given a patrol takes longer than its configured period
+    When two schedule deadlines pass
+    Then at most one patrol remains active and one future patrol is pending
+
+  @M3
+  Scenario: An obstacle blocks both advance and return
+    Given a person or fallen hose blocks the route
+    And no surveyed alternative or return segment is available
+    Then the robot stops and requests assistance without crossing plants or drains
+
+  @M3
+  Scenario: Wet soil causes one wheel to sink
+    Given a previously surveyed route and newly observed roll or traction loss
+    Then cut and base travel stop
+    And the mechanically retained crate stays latched
+    And recovery requires reinspection and explicit acknowledgement
+
+  @M3
+  Scenario: Occluded fruit requires another view
+    Given a fruit is partly behind a leaf
+    When stem identity or cut clearance is uncertain
+    Then reobservation or deferral is recorded
+    And the blade stays inhibited
+
+  @M3
+  Scenario: Fruit is behind the climbing net
+    Given a ripe fruit and a strand crossing the extraction corridor
+    Then use a verified alternative approach or defer
+    And never pull the fruit through the strand
+
+  @M3 @M4
+  Scenario: A row with no visible fruit is not known empty
+    Given dense leaves conceal part of a row
+    And leaf manipulation has not passed physical qualification
+    Then the scan records unknown coverage
+    And no blind leaf probing occurs
+
+  @M4
+  Scenario: Qualified leaf displacement meets unexpected resistance
+    Given a compliant leaf tool with measured crop-specific limits
+    When force or displacement exceeds its validated envelope
+    Then contact motion stops
+    And retreat occurs only along a verified free path
+
+  @M3
+  Scenario: A cut command is not harvest confirmation
+    Given the tool supports a cucumber
+    When cut confirmation or fruit retention is missing
+    Then it is not counted as boxed
+    And the plant model does not lose the fruit
+
+  @M3
+  Scenario: Sensor or link loss invalidates a planned action
+    Given a valid approach with an older observation
+    When sensing becomes stale or communication is lost
+    Then stop and await current evidence without automatic fault restart
+
+  @M3 @M5
+  Scenario: Manual exchange requires a stationary secured base
+    Given an admitted exchange station and a full crate
+    When the operator requests removal
+    Then the platform is immobilized and the tool is inhibited
+    And resumption requires a new crate ID, valid tare and confirmed latch
+
+  @M5
+  Scenario: Power loss does not drop a loaded axis
+    Given the arm holds a fruit above the retained crate
+    When power is removed during a supervised test
+    Then independent brakes and mechanical retention satisfy the reviewed stop design
+    And software does not claim a safe stop without the test evidence
+
+  @M6
+  Scenario: A future carrier loses its coupling or heartbeat
+    Given a loaded carrier follows the robot
+    When coupling or authenticated fresh communication is lost
+    Then both machines execute their validated stop behavior
+    And the carrier does not coast into the robot or workers
+
+  @M1
+  Scenario: Work must preserve loaded return and charging reserve
+    Given enough battery for return but not another harvest segment and reserve
+    Then return to charge is requested before starting that segment
+
+  @M1
+  Scenario: Battery cannot support the requested mission even when full
+    Given mission energy and estimation uncertainty exceed usable pack capacity
+    Then the report identifies insufficient capacity without clamping required SOC
+
+  @M1
+  Scenario: A charger marker does not prove the robot can return
+    Given a blocked return path or unavailable charging dock
+    Then dispatch is held even with a full battery
+
+  @M3 @M5
+  Scenario: A charging robot cannot depart on the patrol timer alone
+    Given a scheduled patrol while charge budget is insufficient
+    Then the patrol remains pending
+    And no traction or arm motion occurs while charging contacts are engaged
+
+  @M5
+  Scenario: Charging fails or contacts become wet
+    Given an aligned dock and a previously charging pack
+    When charger power fails or a BMS/contact/water fault occurs
+    Then charging is inhibited and a fault is retained
+    And no automatic energized redocking or patrol restart occurs

--- a/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
+++ b/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
@@ -65,3 +65,18 @@ safely. Unknown soil, observations and access remain explicit. M2-M6 stay active
 planned work; there is no robot mesh, live mission runtime or hardware connection
 yet. New software code carries an empty Changeset independently of historical
 closeout; no versions, deployment or manufacturing action are introduced.
+
+## 2026-09-12 - Close M1 before authorized integration
+
+Context: the user authorized rebasing PR #191 onto current main, pushing, merging
+only after all current-head checks pass, then creating a fresh worktree for M2.
+They explicitly requested M1 closeout before pushing and monitoring.
+
+Decision: archive the [completed M1 stage](/docs/ai/apps/fieldscope/plans/completed/harvest-feasibility/plan.md)
+and retain M2-M6 in the active parent plan. The original head passed CI; the
+rebased implementation passed 229 app tests and typecheck. The new pushed head
+must independently pass CI before merge.
+
+Consequences: stage acceptance does not claim the new CI has passed or that the
+PR has merged. No new release record, version, tag, publication or deployment is
+created by closeout. M2 implementation starts in its own post-merge worktree.

--- a/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
+++ b/docs/ai/apps/fieldscope/decisions/releases/unreleased.md
@@ -33,3 +33,35 @@ Consequences: no active FieldScope plan remains through this stage. The existing
 PR still requires review and merge; archived status does not claim main contains
 these changes. Closeout adds documentation only and creates no Changeset, version,
 tag, publication or deployment.
+
+## 2026-09-12 - Separate historical stages before harvest robotics
+
+Context: the user requested several completed plans matching the earlier app
+development stages before starting robotics in a new worktree.
+
+Decision: expose separate retrospective crop realism, responsive workbench and
+navigation/localization records in [Plans](/docs/ai/apps/fieldscope/PLANS.md), each
+linked to its original completed PR #174 parent. The baseline and documentation/CI
+closeouts already merged through PR #190 remain unchanged.
+
+Consequences: stage discovery is explicit without claiming new implementation,
+independent historical test totals or physical robot capabilities. A separate
+active harvest-robot plan owns future work. No release action is part of closeout.
+
+## 2026-09-12 - Start harvest robotics with explicit feasibility boundaries
+
+Decision: start the [harvest robot plan](/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md)
+with deterministic necessary-condition screens and primary-source hardware
+research. Prefer an onboard latched crate for the first prototype; treat prepared
+lanes and manual end exchange as provisional assumptions pending site input.
+Include a dry charging station and conservative loaded-return energy admission.
+
+Evidence: M1 passes 57 new cases and all 229 app unit tests, typecheck, lint,
+naming and 17 filtered build tasks. These are local results; PR checks are a
+separate gate. The app UI and scene are unchanged by this milestone.
+
+Consequences: M1 does not prove a physical robot fits, avoids damage or operates
+safely. Unknown soil, observations and access remain explicit. M2-M6 stay active
+planned work; there is no robot mesh, live mission runtime or hardware connection
+yet. New software code carries an empty Changeset independently of historical
+closeout; no versions, deployment or manufacturing action are introduced.

--- a/docs/ai/apps/fieldscope/plans/completed/crop-realism/plan.md
+++ b/docs/ai/apps/fieldscope/plans/completed/crop-realism/plan.md
@@ -1,0 +1,26 @@
+# Cultivar realism and harvested-target preparation - Retrospective stage closeout
+
+Status: DONE
+Implementation completed: 2026-09-11
+Stage closeout recorded: 2026-09-12 (Asia/Taipei)
+
+## Outcome and decision
+
+Water, crop population, eight unharvested cucumber stages, leaf and stem detail, tomato color variation, occlusion and deterministic planting.
+
+Accept this stage of PR #174 as completed. This is a separate historical stage
+record requested by the user, not a reconstructed original plan or duplicate
+implementation. The [parent plan](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md)
+retains the detailed implementation history and its final evidence.
+
+## Validation and boundary
+
+PR #174 merged as `59c8c1d36ffb4cc95683616d931ca4407607ed8c` with all five CI
+checks passing. Its parent record reports 172 app tests, 31 browser cases and
+expanded bilingual layout checks. These are parent-plan historical results,
+not isolated test totals for this sub-stage or newly rerun evidence.
+
+Crop appearance is implemented; a fruit detection model or harvesting controller was not delivered.
+
+No implementation remains in this stage. No Changeset, version change, release,
+tag or deployment is introduced by this retrospective closeout.

--- a/docs/ai/apps/fieldscope/plans/completed/harvest-feasibility/plan.md
+++ b/docs/ai/apps/fieldscope/plans/completed/harvest-feasibility/plan.md
@@ -1,0 +1,33 @@
+# Harvest feasibility - M1 closeout
+
+Status: DONE
+Completed: 2026-09-12 (Asia/Taipei)
+
+## Outcome and decision
+
+Accept M1 of the [harvest robot plan](/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md)
+as complete. PR #191 implements deterministic lane, crate/load, charging-energy
+and hazard assessments, with explicit blocked/unverified outcomes and no physical
+actuation. The six-stage plan and hardware/scenario contracts remain the basis
+for subsequent work. M2-M6 are not closed by this record.
+
+## Evidence
+
+The original implementation head `9b54490e0f5b4732a17fc7039f4947c75ed022c9`
+passed every reported CI check. Local validation passed 57 new domain cases,
+229 total app cases, typecheck, app lint, naming and all 17 filtered build tasks.
+After rebase onto `36daf54a4`, all 229 app cases and typecheck passed again.
+This record is committed before the new current-head CI run; merge requires that
+new run to pass, rather than relying on the pre-rebase result.
+
+## Boundaries
+
+M1 is headless. It does not deliver a robot mesh, mission UI, autonomous motion,
+trained perception, contact physics or physical safety qualification. The
+[product contract](/docs/ai/apps/fieldscope/specs/harvest-robot.md) and step A of
+the [owner flow](/docs/ai/apps/fieldscope/plans/harvest-robot/inspector-flow.md)
+remain authoritative for these necessary-condition assessments.
+
+No active implementation remains in M1. This closeout adds no Changeset, version
+change, tag, publication or deployment. PR integration and the new M2 worktree
+follow only after the user-authorized current-head CI/merge gate succeeds.

--- a/docs/ai/apps/fieldscope/plans/completed/navigation-and-localization/plan.md
+++ b/docs/ai/apps/fieldscope/plans/completed/navigation-and-localization/plan.md
@@ -1,0 +1,26 @@
+# Navigation, mobile controls and localization - Retrospective stage closeout
+
+Status: DONE
+Implementation completed: 2026-09-11
+Stage closeout recorded: 2026-09-12 (Asia/Taipei)
+
+## Outcome and decision
+
+First-person movement, optical zoom, touch gestures, Traditional Chinese/English UI and bilingual layout validation.
+
+Accept this stage of PR #174 as completed. This is a separate historical stage
+record requested by the user, not a reconstructed original plan or duplicate
+implementation. The [parent plan](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md)
+retains the detailed implementation history and its final evidence.
+
+## Validation and boundary
+
+PR #174 merged as `59c8c1d36ffb4cc95683616d931ca4407607ed8c` with all five CI
+checks passing. Its parent record reports 172 app tests, 31 browser cases and
+expanded bilingual layout checks. These are parent-plan historical results,
+not isolated test totals for this sub-stage or newly rerun evidence.
+
+Camera navigation is not physical robot localization, autonomous navigation or path planning.
+
+No implementation remains in this stage. No Changeset, version change, release,
+tag or deployment is introduced by this retrospective closeout.

--- a/docs/ai/apps/fieldscope/plans/completed/responsive-workbench/plan.md
+++ b/docs/ai/apps/fieldscope/plans/completed/responsive-workbench/plan.md
@@ -1,0 +1,26 @@
+# Responsive editing and scene ownership - Retrospective stage closeout
+
+Status: DONE
+Implementation completed: 2026-09-11
+Stage closeout recorded: 2026-09-12 (Asia/Taipei)
+
+## Outcome and decision
+
+Immediate edits, configurable geometry, compact controls, continuous clips, dependency-scoped geometry, work-count regressions and Undo/Redo repair.
+
+Accept this stage of PR #174 as completed. This is a separate historical stage
+record requested by the user, not a reconstructed original plan or duplicate
+implementation. The [parent plan](/docs/ai/apps/fieldscope/plans/completed/water-and-crops/plan.md)
+retains the detailed implementation history and its final evidence.
+
+## Validation and boundary
+
+PR #174 merged as `59c8c1d36ffb4cc95683616d931ca4407607ed8c` with all five CI
+checks passing. Its parent record reports 172 app tests, 31 browser cases and
+expanded bilingual layout checks. These are parent-plan historical results,
+not isolated test totals for this sub-stage or newly rerun evidence.
+
+The editable farm remains owned by Core SceneTree; no robot mission document was delivered.
+
+No implementation remains in this stage. No Changeset, version change, release,
+tag or deployment is introduced by this retrospective closeout.

--- a/docs/ai/apps/fieldscope/plans/harvest-robot/inspector-flow.md
+++ b/docs/ai/apps/fieldscope/plans/harvest-robot/inspector-flow.md
@@ -1,0 +1,90 @@
+# Harvest robot owner flow
+
+Product authority: [harvest robot](/docs/ai/apps/fieldscope/specs/harvest-robot.md).
+Physical evidence: [hardware concept](/docs/ai/apps/fieldscope/specs/harvest-hardware.md).
+This architecture contract is not a test ledger or a physical safety certificate.
+
+## A - Feasibility domain (current M1)
+
+Owner: app harvest-domain assessment functions.
+Inputs: validated farm configuration, explicit stowed vehicle envelope, route
+candidate, measured or unknown survey, load/CoG data, battery/return-energy estimates and hazard observations.
+Outputs: lane, load and energy reports with reasons and unresolved obligations; prioritized
+advisory hazard action. The advisory function consumes completed load/energy actions as well as hazard
+observations. No motor commands or inventory mutations.
+Conditions: always validate caller input; unknown evidence stays unknown. No bypass.
+Allowed contributors: existing farm validator, configurationSite/createLayout,
+createPlantingRows and CROP_LAYOUT.rootOffset; deterministic local arithmetic.
+Forbidden: Core mutation, React, engine/Three, crop mesh builders, hidden fruit
+truth, clocks, network, cached model assumptions and physical controller commands.
+Boundary: `apps/fieldscope/src/domain/harvest-assessment.ts`,
+`harvest-load.ts`, `harvest-energy.ts`, `harvest-policy.ts` and their `domain/__tests__` files.
+Spec: A feasibility, crate/load, energy admission, hazard policy and M1 DoD sections.
+Failure owner: A rejects invalid inputs; reports geometry/ground/data restrictions.
+Cache dimensions: none. Two bounded layout passes (including the existing row helper) and one row preparation per assessment;
+results reused within that invocation, no work per plant or animation frame.
+
+## B - Mission document composition (M2, not implemented)
+
+Owner: app runtime through registered Core Features/APIs.
+Inputs: robot/route/patrol edits; validated farm configuration; completed A reports.
+Outputs: canonical robot/mission settings and scoped derived UI values; one edit
+per intended history action. Edits invalidate an incompatible simulation run.
+Conditions: admission must succeed; failed edits leave prior canonical state intact.
+Replay bypasses intent dispatch, uses normal Core state apply and projections.
+Allowed: Core SceneTree/Props, Feature/API transaction path and A reports.
+Forbidden: second React mission model, private Factory internals, render-derived
+clearance or actuator commands. Cannot turn `screened` into `safe`.
+Boundary: app runtime robot/mission composition and formal runtime tests, plus
+locale and mission editor consumers of the approved API.
+Spec: future user-facing contract; readiness must be narrowed to concrete schemas
+and public actions before M2 edits begin.
+Failure owner: B owns validation/history/replacement; A owns assessment reasons.
+Cache dimensions: none proposed.
+
+## C - Robot, crate and fruit projection (M2/M3, not implemented)
+
+Owner: app render projection, engine consumes admitted spatial products.
+Inputs: canonical admitted robot definition, mission settings and completed
+simulation poses/fruit states; existing farm spatial output stays separately owned.
+Outputs: dimensioned concept geometry and state projection through SpatialLayer.
+Conditions: pose updates alter transforms only; definition changes replace affected
+geometry. Blender exports, if used, must match canonical dimensions and ownership.
+Allowed: completed robot geometry/pose products, existing spatial admission/engine.
+Forbidden: perception decisions, harvest success inference, force/soil conclusions,
+rebuilding cultivars per tick or private diagnostic geometry as product output.
+Boundary: app render-app robot projection, existing layer/engine integration and
+formal projection/engine/browser tests. Spec: M2/M3 user-visible contract.
+Failure owner: projection/admission failure is visible; no substitute safe geometry.
+Cache dimensions: none proposed; topology lifetime is the robot definition.
+
+## D - Deterministic simulation (M3, not implemented)
+
+Owner: app simulation session.
+Inputs: admitted mission, completed A reports, explicit observation adapter outputs,
+simulation clock and synthetic contact/cut/retention confirmations.
+Outputs: finite-state transitions, pose intents, target inventory and crate ledger.
+Conditions: no overlapping runs; stale/missing evidence interrupts action; emergency
+priority wins. Cancellation/disposal prevents late writes. No path around B admission.
+Allowed: A advisory policy, declared observation adapter, canonical mission snapshot.
+Forbidden: hidden fruit truth as perception, hardware side effects, implicit wall
+clock scheduling, auto-restart after fault, arbitrary leaf/crop pass-through.
+Boundary: app simulation modules and formal scenario/session tests; concrete state
+schema and observation contract must be ready before implementation.
+Spec: future user-facing contract and Gherkin acceptance cases.
+Failure owner: simulation session retains unresolved/fault state and reason.
+Cache dimensions: none proposed.
+
+## E - Physical adapter (M4-M6, blocked on physical evidence)
+
+Owner: separately authorized hardware integration and safety engineering.
+Inputs: verified calibration, tested components, validated stopping/protection
+functions and authenticated/time-bounded commands.
+Outputs: measured observations and acknowledged physical actions.
+Conditions: physical qualification and separate authorization; no simulation bypass.
+Allowed: reviewed controller interface and independent machine protection system.
+Forbidden: direct browser-to-motor actuation, simulation truth as sensor evidence,
+software-only E-stop or unverified safety claims.
+Boundary: none admitted for implementation yet. Hardware contract owns requirements.
+Failure owner: physical protection system; app reports rather than masks faults.
+Cache dimensions: none.

--- a/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md
+++ b/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md
@@ -1,0 +1,145 @@
+# Harvest robot and crate logistics
+
+Status: IN PROGRESS
+Started: 2026-09-12 (Asia/Taipei)
+Base: origin/main at `4144a25d7`
+Worktree: `.worktrees/fieldscope-harvest-robot`
+
+## Bounded objective
+
+Develop a realizable greenhouse harvesting concept and implement it incrementally
+in FieldScope. This is not a promise that simulated motion proves successful
+harvesting or machine safety. First deliver a tested feasibility domain; then
+compose mission editing and robot/crate projection through Core. Subsequent
+milestones require measurements and physical tests before actuation.
+
+Authorized scope: `apps/fieldscope` and its app documentation, tests and existing
+build/test tooling. No Framework changes, added dependencies, hardware purchases,
+controller connection, automatic deployment, publication or changes to other apps.
+Discovery: existing layout/support/crop owners, current Core composition APIs,
+primary harvesting research and manufacturer specifications. Later review stays
+within this diff and its direct consumers. Do not port Sim's analysis engine.
+
+## Product and architecture
+
+- [Product contract](/docs/ai/apps/fieldscope/specs/harvest-robot.md)
+- [Hardware concept and field trials](/docs/ai/apps/fieldscope/specs/harvest-hardware.md)
+- [Owner flow](/docs/ai/apps/fieldscope/plans/harvest-robot/inspector-flow.md)
+- [Scenarios](/docs/ai/apps/fieldscope/bdd-features/harvest-robot.feature)
+
+## Milestones and dependencies
+
+### M1 - Feasibility and conservative operating rules
+
+Implement owner A: straight-lane geometry screening from the existing layout,
+vehicle envelope and measured/unknown ground admission; payload, box-change and
+quasi-static lateral reserve calculations; battery/return-energy admission;
+conservative hazard arbitration.
+Use explicit SI inputs and return reasons, never a certified-safe flag. Prove
+30 cm drains, central shared-column obstruction, plant-row clearance, insufficient
+headlands, missing survey, growing payload and tip/obstacle/contact priorities.
+Deliver formal domain tests, app typecheck/lint and existing app regression tests.
+This is a headless engineering foundation, not yet a visible or moving robot.
+
+### M2 - Editable robot and mission workspace
+
+After M1, implement B then C: Core-owned robot/mission settings (footprint, tool,
+crate, route lane and longitudinal interval, one-side/both-side scan choice,
+patrol period, battery capacity/energy budget, charge station and start/pause/resume). Project a dimensioned base, folded/working
+mast and arm, camera, latched crate and end exchange station. Label concept
+geometry and show unresolved route restrictions. Use existing icons, units,
+locale catalogs and immediate editing with Undo/Redo. An invalid edit cannot
+silently clear a stop or start physical motion. Editing invalidates a simulation
+run; real-world events are append-only and never undone.
+
+DoD: runtime transaction/history and localized subscription tests; camera/locale
+changes build no robot/farm geometry; robot pose updates rebuild no crop meshes;
+route/robot edits invalidate only their own outputs; bilingual desktop/mobile
+visual review with the existing farm loaded. No success based only on overview.
+
+### M3 - Deterministic patrol, picking and crate simulation
+
+Implement D and C's pose projection. A configurable closed simulation clock drives
+finite route segments and scan checkpoints, not wall-clock UI frames. Missed
+periods coalesce to one pending patrol; no overlapping runs or burst catch-up.
+Model look/reobserve/defer/approach/support/cut/verify/place, stable fruit identities,
+per-fruit state transitions, crate mass/volume/damage exclusions and return/exchange.
+Scheduled patrol requires an admitted return path, available charging dock and
+energy reserve. Include return-to-charge/dock/charge/undock states, stale SOC,
+blocked dock and charger faults; no motion while charging. No connected
+hardware. Simulation observations must be explicitly injected or derived by the
+observation adapter, never read hidden-fruit truth as a successful detector.
+
+DoD: executable scenario tests, cancellation/replacement tests, deterministic
+replay, conservation of picked/held/boxed/dropped fruit and payload; impossible
+cuts/paths remain unresolved; actual close-up arm/net/box visual review. Collision
+queries must include the tool, carried fruit and moving leaves; no teleporting
+through net strands. Physical damage must remain unknown without a calibrated
+contact model, regardless of visual overlap.
+
+### M4 - Bench sensing and crop-specific end effectors
+
+Build only after measured dimensions, budget, component selection and separate
+hardware authorization. Start with a fixed guarded bench, dummy loads and disabled
+blade. Validate camera calibration, lighting, stem discrimination, repeatability,
+force/torque and jaw-pressure limits, tool retention, safe power-loss behavior,
+food-contact cleaning and crate bruising limits. Use a support-and-cut cucumber
+head and a separate small-fruit padded head for individual Yu-Nu tomatoes.
+Evaluate picked fruit immediately and after storage for hidden bruising. Do not
+infer acceptable force from another cultivar or soft gripper advertising.
+
+### M5 - Ballasted mobile platform, then supervised harvest
+
+Before crops: loaded braking, slope, asymmetric sinkage, traction, recovery,
+headland turns, obstacle protection, stop distance, watchdog and emergency stop
+on the intended prepared surface. Then greenhouse trials with operators outside
+the protected area and mechanical blade guarding. Validate full harvest plus box
+exchange with 0%, 50% and 100% permissible payload. Expand one crop/row/condition
+at a time; keep precision/recall, damage, lost fruit, false-safe, recovery and
+cycle-time measurements with environmental context. Limits must be approved from
+measurements, not copied from simulation defaults.
+
+### M6 - Optional separate carrier and controlled fleet operation
+
+Only if M5 logistics data show onboard crate return dominates duty time. Test a
+braked docked carrier first at headlands; do not make an unbraked free-following
+cart the initial design. Prove coupling, drawbar load, off-tracking, reversing,
+jackknife prevention, heartbeat loss and loaded recovery before in-row use.
+Independent powered followers need their own localization, obstacle protection,
+reservation, stopping envelope and loss-of-contact behavior. Hardware/operation
+acceptance remains a separate milestone; app plan completion is not certification.
+
+## Current execution
+
+M1 is implemented and locally validated: 57 new domain cases, 229 total app
+unit cases, typecheck, app lint, naming and the filtered production build's 17
+tasks passed. The domain reports have no UI or hardware consumer yet. M2-M6 remain planned and must not be marked
+DONE by this planning task. Pending site measurements and physical trial results
+are retained in the hardware contract, not replaced by invented values.
+
+## Stop and review boundaries
+
+Stop unsafe/unknown operation in the product, rather than fabricating clearance,
+soil capacity, visibility or grip success. Stop implementation for a contract
+conflict or needed out-of-scope owner/dependency. Replan a bounded owner after
+repeated failed iterations. No claim of a working real harvester until physical
+acceptance evidence exists. Hardware purchasing, deployment and actuation require
+separate authorization. Preserve unrelated servers, worktrees and user changes.
+
+### M1 execution card - A feasibility domain
+
+- Spec: harvest-robot sections A feasibility, crate/load, energy admission and
+  hazard policy; Inspector: step A and its complete input/output contract.
+- Inputs: validated farm configuration, stowed envelope, lane/survey, mass/CoG,
+  battery budgets and explicit hazard flags. Outputs: reports/advisory actions only.
+- Allowed: existing layout/plant-row/root-offset owners and deterministic arithmetic.
+  No bypass; reject invalid numbers and retain unknown measurements.
+- Forbidden: UI/Core writes, crop generation, Three, clocks, network and actuators.
+- Files: the four `domain/harvest-*.ts` modules named in A and their formal tests.
+  A owns errors. No cache; two bounded layout passes and one row preparation per lane call, never per plant.
+- Cases: M1-tagged Gherkin plus invalid numbers, geometry changes, caller isolation,
+  growing payload, combined hazards, SOC uncertainty and exact reserve boundaries.
+- Gates: focused Vitest, naming, app typecheck/lint, existing app unit regressions
+  and filtered build. No visual claim or browser change in this domain-only step.
+- Stop: spec conflict, outside owner dependency, failed work-count isolation or
+  unsafe inference. M2 starts only after its own schema/flow readiness review.

--- a/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md
+++ b/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md
@@ -31,6 +31,8 @@ within this diff and its direct consumers. Do not port Sim's analysis engine.
 
 ### M1 - Feasibility and conservative operating rules
 
+DONE - [stage closeout](/docs/ai/apps/fieldscope/plans/completed/harvest-feasibility/plan.md).
+
 Implement owner A: straight-lane geometry screening from the existing layout,
 vehicle envelope and measured/unknown ground admission; payload, box-change and
 quasi-static lateral reserve calculations; battery/return-energy admission;

--- a/docs/ai/apps/fieldscope/specs/harvest-hardware.md
+++ b/docs/ai/apps/fieldscope/specs/harvest-hardware.md
@@ -1,0 +1,204 @@
+# Harvest hardware concept and validation
+
+## Initial concept, not a manufacturing release
+
+Use a slow electric wheeled platform on a prepared, surveyed load-bearing lane,
+with battery/ballast low in the base, a retractable lift, short reach arm, wrist
+camera, guarded crop-specific support-and-cut tool and a mechanically latched
+onboard crate. This avoids a second vehicle trailing through narrow crops in the
+first prototype. The crate moves as part of the base, never carried by the arm.
+Individual tray inserts separate delicate tomatoes from cucumbers. The receiving
+tray should rise to the placement height or the arm should lower each fruit;
+there is no untested free-fall chute. Oversized cucumbers require a separately
+qualified grip/load envelope or are deferred to a human.
+
+Preliminary packaging target: base 0.55 m wide and 0.90 m long, stowed height
+1.20 m, contact track 0.42 m, four ground contacts. These are adjustable design
+assumptions, not purchased hardware dimensions. Use reversible straight runs and
+turn only in a surveyed headland. Wheel type, wheel diameter, drive/brake torque,
+IP rating, bearing seals, mast stiffness and battery capacity remain selections
+pending measured ground, washdown regime, mass and duty cycle. Do not infer
+these from greenhouse steel sizes or existing net-support poles.
+
+A 0.50 m-reach, 3 kg-payload arm such as the UR3e demonstrates a commercially
+available scale, not a selected bill of materials. Reach must include approach,
+withdrawal and placement poses; payload includes tool, cables and carried fruit
+with the manufacturer's payload/CoG limits. A short arm may need a lift and
+lateral positioning stage; a 3 m canopy is not reachable merely by drawing a tall
+mast. Full swept volume, stiffness, stability and emergency retract clearance
+must be verified before accepting that combination.
+
+## Existing farm fit
+
+The default strips span 6.3 m and leave 0.35 m on each side of a 7 m bay.
+The 0.30 m semicircular drain is water/soil, not a bearing surface or rail.
+A 0.55 m chassis plus 0.05 m clearance per side needs at least 0.65 m before
+foliage, uncertainty, wheel edge distance and wet-soil conditions are considered.
+The nominal 0.70 m inter-bay passage is split by 0.076 m columns at its center;
+it is not an unobstructed 0.70 m travel lane. Routing must include columns,
+doors, braces, nets, root rows, irrigation lines, hoses and actual canopy.
+
+Default internal 1.8 m soil strips have root lines about 0.20 m inward from
+each neighboring drain edge. That leaves about 1.4 m between root centerlines,
+not guaranteed free space. Survey canopy intrusion at wheel, chassis, crate,
+arm and mast heights, including fruit sag under load. A preliminary 0.20 m
+canopy reserve on each side leaves about 1.0 m. Never remove crop rows or widen
+beds silently to fit a robot. End plant setbacks of 0.25 m are not a turning
+headland; require measured external transfer space, door access and return paths.
+
+Initial mode excludes travel inside drains and free travel over wet unverified
+soil. Engineered bridges or pipe rails would be a separate infrastructure design
+with support spacing, anchorage, flood conveyance, load rating and worker-egress
+validation. Greenhouse framing and 20 mm planting tubes are not certified rails.
+
+## Load, mobility and exchange
+
+Select crates by washable food-contact material, internal dimensions, supported
+base, latch engagement and ergonomic handling. Preliminary payload targets for
+trial design: 8 kg cucumbers or 3 kg tomatoes per shallow tray; the lower of the
+crop's validated bruise/stack limit, crate rating, platform capacity and stability
+limit is authoritative. These numbers are not proven crop-handling limits.
+
+Measure tare on insertion; retain crate ID, crop, time, mass and fill estimate.
+Request return/exchange before the next fruit would exceed permissible mass or
+fill volume, at a configurable operational fill threshold (initial trial 80%),
+on imbalance, absent/lost latch, sensor disagreement, contamination, damage,
+wrong crop, low return-energy reserve or box expiry. Volume/fill sensing is
+required because a light box can be spatially full. Stop picking during return.
+
+Exchange at a designated level headland dock: stow tool, immobilize base, inhibit
+blade/arm, confirm station/clear floor, manually unlatch and swap crate, identify
+new crate, verify tare and latch, then explicitly resume. Do not release a crate
+while moving, reset load on a button without exchange evidence, or drive with a
+missing crate. A future powered carrier has a separate braking and fault state;
+free-following is not equivalent to mechanically coupled motion.
+
+For preliminary calculation, total mass is base + arm + tool + battery + crate
++ payload; avoid double-counting components included in base mass. Wheel load
+fractions need measurement under arm reach and slopes. Nominal ground pressure
+is load/contact area; soil allowable pressure requires field measurements with
+moisture/depth and wheel-sinkage tests. Required tractive force is approximately
+m*g*(rolling resistance + sin(slope)) + m*acceleration; drive torque includes
+wheel radius, gearing and efficiency. Brake and motor thermal duty, not only
+peak torque, must meet the maximum permitted payload. No coefficient is assumed
+known from soil color or a rendered water plane.
+
+The software's lateral reserve is only a quasi-static screening calculation:
+weighted lateral CoG offset + h*tan(abs(roll)) + h*abs(lateral acceleration)/g
++ uncertainty must remain inside half the contact track. Test longitudinal
+braking and mast/tool moment separately. Differential sinkage can destroy the
+support polygon even when this formula passes; measured loss of contact forces
+an immediate fault. Dynamic contact/soil behavior needs calibrated trials.
+
+## Battery, charging dock and return policy
+
+Provide a dry, level end-of-row service area with separate crate exchange and
+charging positions, outside irrigation spray/flood exposure and worker egress.
+A charger is not simply a marker on the ground: survey its approach, localization
+reference, contact alignment, wheel restraint, guarded contacts, drainage,
+cable protection and recovery access. Do not put exposed energized contacts in
+the drain or attach a station to unqualified greenhouse framing. Electrical
+protection and charging requirements depend on the chosen battery/BMS/charger and
+local installation rules; have them reviewed before construction.
+
+Choose battery chemistry, pack voltage/capacity, fusing, isolation, enclosure,
+BMS and a matching charger as one reviewed system. A 24/48 V architecture is an
+option, not a selected safe voltage or bill of materials. The BMS owns cell-level
+over/under-voltage, current and temperature protection independently of the app.
+Prevent traction/arm/cutter actuation while docked and charging. Verify alignment,
+station availability, contacts, immobilization and permitted temperature before
+energizing. Contact failure, charger outage, overheating or water ingress causes
+a fault and assistance, not repeated energized docking attempts.
+
+Energy planning uses conservative measured loaded-drive Wh/m, arm-cycle Wh,
+perception/control idle W and waiting time. Usable pack Wh = nominal Wh times
+aged/temperature capacity fraction. Energy now = usable Wh times
+max(0, state-of-charge minus absolute SOC uncertainty). Admit a mission only if
+outbound/work energy plus loaded return-to-dock energy, bounded detour/wait
+allowance and an untouchable reserve fit. Reassess before departure, every lane
+segment and every pick using a fresh battery estimate and currently admitted
+return path. Payload, slope, tire sinkage, temperature and battery aging change
+consumption; measured upper bounds must cover the admitted operating envelope.
+
+At insufficient working budget but enough return reserve, cancel remaining
+picks and return. If even a verified return cannot be funded or its path/dock is
+unavailable, stop accepting work and request recovery; never invent a passable
+shortcut or promise a safe return. Retain energy for controlled stopping, sensors
+and communication in that fault state. Patrol scheduling cannot consume a
+reserve to meet its period. The model is a budget screen, not a runtime guarantee.
+
+Size the pack from the intended complete patrol/harvest/return duty cycle plus
+reserve, not from motor nameplate power alone. Record charger power, conservative
+charge efficiency, usable SOC window and taper: ideal Wh/W gives only a lower
+bound, not a guaranteed ready time. A scheduled patrol waits for a confirmed
+minimum dispatch budget and completed undocking checks; no overlap, no automatic
+fault reset. If charging cannot support the requested patrol period, show the
+schedule as infeasible and revise capacity, charging power or period. Test loss
+of dock, blocked approach, aging, cold/hot pack, sudden SOC drop and charger faults
+with loads before unattended operation.
+
+## Priority and recovery
+
+Priority is people and bystanders, then avoiding uncontrolled motion/cutting,
+then containing the robot/tool/crate energy, then crops and produce. Do not
+command a falling arm to catch a crate or swing a counterweight without a
+verified recovery trajectory. Crate latches and retaining walls work without
+software. On sinkage, roll excursion, slip, blocked path, person entry, stale
+sensors, lost communications or emergency stop: inhibit cutting, stop platform
+motion using the independently validated stop function, retain payload and latch,
+and request intervention. Hold or retract the arm only when its validated stop
+mode and clearance permit it; never blindly pull an entangled tool through vines.
+Electrical emergency stop design must avoid dropping gravity-loaded axes.
+
+A force spike near a leaf/net is not permission to increase force. Stop contact,
+record pose and target, and retreat only along a verified free path. If retreat
+is not known, hold and request help. No automatic repeated attempts after a fault.
+
+## Observation and crop handling
+
+Scan from several base/wrist viewpoints with calibrated lighting before touching
+foliage. No visible fruit means unknown coverage if canopy occludes the row.
+Retain observation age, pose/calibration, fruit identity, crop, ripeness, depth,
+uncertainty, stem/calyx evidence and approach corridor; avoid double-picking from
+multiple views. Detect ripe fruit and the correct peduncle independently. Net
+crossings and a fruit behind a strand need a verified alternate approach; never
+pull the fruit through the net or mistake the main stem for a cutting target.
+
+Leaf interaction is disabled by default. Qualify a separate compliant guarded
+leaf paddle with force/torque feedback, displacement/travel and duration limits,
+plant-specific damage trials, net/tendril entanglement detection and retreat
+clearance. Do not use the cutting jaw to search blindly. Undetected fruit,
+uncertain stem, excessive force, blocked view or unqualified crop -> defer and
+mark the row for a later viewpoint or human inspection. Never infer harvest
+success solely from a gripper command or simulated fruit disappearance.
+
+Cucumber: support its body, isolate the peduncle, cut with an enclosed mechanism,
+confirm separation/retention, then place with low drop height. Tomato: support
+one fruit with pressure-limited pads and a verified individual pedicel tool;
+retain neighboring fruit/truss. Do not assume the same jaws, gripping force,
+ripeness model or cutter motion work for both crops. Clean contact parts and
+cutters with an approved crop/food sanitation process between required batches.
+
+## Measurements required before procurement and actuation
+
+- Smallest actual lane profile, gate width/height, external headland dimensions,
+  column/brace locations, drainage/flood level and emergency access.
+- Wet/dry bearing and traction tests; slope, rut depth, wheel loading, sinkage,
+  braking distance and stability through fully extended arm poses.
+- Fruit size/mass distribution by stage, reach distribution, peduncle geometry,
+  permissible gripping/leaf forces, cut force, drop height and storage bruising.
+- Crate dimensions/tare/load/fill/cleaning limits; full/empty logistics and return
+  energy reserve; access for manual recovery and lifting a disabled platform.
+- Sensor detection limits in sun/shadow, condensation and occlusion; calibration,
+  fault injection and independent stop/watchdog validation.
+- Budget, component availability, maintainability and a reviewed bill of materials,
+  drawings, tolerances, wiring, guards and risk assessment before manufacture.
+
+## Primary references and their limits
+
+- <a href="https://www.wur.nl/upload_mm/5/5/7/c221711e-98da-4865-805a-8fc8531aa624_flyer_cucumber%20harvesting_robot_uk.pdf" target="_blank" rel="noopener noreferrer">Wageningen autonomous cucumber harvester</a>: integrated vehicle, sensing and gripping/cutting; not a fit proof for this farm.
+- <a href="https://doi.org/10.1002/rob.21937" target="_blank" rel="noopener noreferrer">SWEEPER field study</a>: occlusion and crop conditions constrain actual harvest success; logistics is part of the cycle.
+- <a href="https://arxiv.org/abs/2409.17389" target="_blank" rel="noopener noreferrer">Safe Leaf Manipulation for Accurate Shape and Pose Estimation of Occluded Fruits</a>: research into planned leaf displacement; no cultivar-independent force guarantee.
+- <a href="https://www.bogaertsgl.com/index.php/qii-drive-l" target="_blank" rel="noopener noreferrer">Bogaerts Qii-Drive L</a>: examples of powered greenhouse crate logistics on prepared pipe rails; no claim that this farm already has such rails.
+- <a href="https://www.universal-robots.com/products/ur3e/" target="_blank" rel="noopener noreferrer">UR3e manufacturer specifications</a>: reference reach/payload scale; final selection and payload/CoG checks remain open.
+- <a href="https://www.iso.org/standard/62659.html" target="_blank" rel="noopener noreferrer">ISO agricultural machinery safety catalogue</a>: the 2018 edition points to the newer 18497 series. Applicable current parts and local requirements must be reviewed by the hardware safety owner; citing a standard is not compliance.

--- a/docs/ai/apps/fieldscope/specs/harvest-robot.md
+++ b/docs/ai/apps/fieldscope/specs/harvest-robot.md
@@ -1,0 +1,133 @@
+# Harvest robot product contract
+
+## Current milestone: M1
+
+M1 provides pure, deterministic engineering assessments, not actuation, physics,
+a trained detector, a scheduling service or a rendered robot. M2-M6 are defined
+in the [plan](/docs/ai/apps/fieldscope/plans/harvest-robot/plan.md). The physical
+assumptions and validation obligations are in [hardware concept](/docs/ai/apps/fieldscope/specs/harvest-hardware.md).
+No software result may be labeled certified safe or a measured ground property.
+
+## A - Feasibility inputs and results
+
+All dimensions use metres, loads kg, accelerations m/s², angles radians. Numbers
+must be finite and physically ordered; unknown observations are explicit `null`
+or a declared unknown state, never zero. Reject invalid input rather than clamp.
+
+Lane assessment consumes an existing validated FarmConfiguration, a candidate
+lane (soil strip index within one bay, drain strip, or inter-bay passage), stowed
+vehicle width/length/height and lateral clearance, plant-envelope reserve,
+longitudinal center-path interval, measured entrance width/height and front/rear
+headland depths (unknown permitted), and ground survey status. Output records
+usable width, required width, travel bounds and blocking/unverified reasons.
+It is a necessary straight-line screen, never a full swept-path proof.
+
+- Reuse `configurationSite`/`createLayout` and `createPlantingRows`; do not copy
+  strip accumulation, margins or row offsets into a competing farm model.
+- Crop-facing soil-strip bounds stop at adjacent root centerlines plus the
+  configured canopy reserve. Retain at least that reserve even when crop layers
+  are hidden. Plant rows have full longitudinal extent for this screen.
+- Shared passages contain center columns; a fixed straight path must use one
+  side. Available width is one side margin minus half the post diameter.
+- Drains are blocked as bearing surfaces even if a narrower chassis could fit.
+- Required width = stowed width + twice lateral clearance. Width equality passes
+  this necessary test; site calibration/uncertainty remains separate.
+- Center interval must keep half the stowed length within the greenhouse or
+  measured usable external headlands. A 0.25 m plant setback alone is not a dock.
+- Entrance width/height must clear the stowed envelope; unknown measurements are
+  unverified. Stowed height must also fit under the crossbeam.
+- Unknown or unverified soil is unverified. Confirmed soft/sinking ground blocks
+  admission. A prepared/surveyed surface only passes this ground prerequisite;
+  it does not prove full robot/crop collision clearance or physical safety.
+- Any blocking reason -> `blocked`; otherwise any missing evidence ->
+  `unverified`; otherwise `screened`. Each report explicitly retains unresolved
+  full-envelope, braking, stability, dynamic obstacles and physical validation.
+
+No optional cache. One assessment invokes layout and planting-row preparation
+once each (the existing row helper also prepares layout, for two bounded layout
+passes total); downstream checks consume their results. It must not generate any
+crop variants, scene meshes, GPU resources or all per-plant positions. Work is
+bounded by bay/strip count rather than planted length. Calls never mutate input.
+
+## A - Crate and load assessment
+
+Inputs: tare-inclusive base mass, payload mass, proposed next-fruit mass, usable
+payload limit, measured fill fraction, return fill fraction, latch/scale validity,
+contact track, base/payload heights and lateral offsets, roll, lateral acceleration
+and a nonnegative lateral reserve for uncertainty. Base mass excludes fruit but
+includes arm/tool/crate in the declared stowed pose. Assess load only in that pose;
+working-arm configurations need separate mass properties and moment validation.
+
+Total mass = base + payload. Compute weighted lateral CoG and height, then
+lateral reserve = half track - abs(CoG x) - CoG height * tan(abs(roll))
+- CoG height * abs(lateral acceleration)/9.80665 - uncertainty reserve.
+No positive reserve proves safe motion; this is a quasi-static screen. Roll is
+restricted below pi/2; negative masses/dimensions, fill outside [0,1] and non-finite
+values are invalid. Next fruit must not be admitted when projected mass exceeds
+the limit. At exact capacity or operational fill threshold request exchange.
+Crate latch loss, untrusted scale, current overload or nonpositive current lateral
+reserve -> `stop`; projected overload/nonpositive projected reserve, capacity or
+fill threshold -> `exchange`; otherwise `continue-screening`. Report current and
+projected reserves. No inventory or mass changes occur in assessment.
+
+## A - Energy admission
+
+Inputs are nominal pack Wh, usable aged/temperature capacity fraction in (0,1],
+SOC fraction, absolute SOC uncertainty, next-work Wh, verified loaded-return Wh,
+contingency Wh and positive reserve Wh; all finite and nonnegative with fractions
+in [0,1]. Fresh battery evidence, return-path admission and dock availability are
+explicit booleans. Consumption estimates include drive, arm, perception, idle and
+bounded waiting, and must be measured separately before hardware use.
+
+Available Wh = nominal Wh * usable fraction * max(0, SOC - SOC uncertainty).
+Return requirement = return Wh + contingency Wh + reserve Wh.
+Mission requirement = next-work Wh + return requirement.
+Missing/stale battery, blocked return, unavailable dock or energy below return
+requirement -> `hold`; enough for return but not the next work -> `return-to-charge`;
+otherwise `continue-screening`. Equality is admitted only with the declared
+positive reserve intact. Report dispatch minimum SOC and whether the mission
+would be impossible even at full charge. Do not clamp that minimum to 100% and
+hide an undersized battery. No dock control or runtime guarantee is produced.
+
+## A - Hazard policy
+
+Given explicitly supplied observations and completed load/energy actions, return
+one prioritized advisory action. A load stop (including untrusted scale or current
+overload) always immobilizes before return requests.
+Emergency stop/person -> `protect-people`; traction loss/sinkage/tilt/lost crate
+retention -> `immobilize`; stale sensing/communication -> `await-observation`;
+obstacle -> `wait-or-replan`; contact with leaf/net -> `hold-tool`; insufficient return energy -> `await-observation`; energy return request ->
+`return-to-charge`; capacity -> `return-to-dock`; uncertain fruit/peduncle or unseen
+fruit -> `observe-or-defer`;
+otherwise `continue-screening`. Every action except continue inhibits cutting.
+Every hazard stops travel; only `return-to-dock` or `return-to-charge` permits travel after a separate
+admitted return route and stowed-tool check. Do not let load logic override
+people, instability, contact or sensing faults. No policy output commands a blind
+arm retraction, releases the crate, enables leaf manipulation or certifies safety.
+
+## Future user-facing contract (M2/M3)
+
+Users select lane IDs and direction, a bounded longitudinal route, scan sides,
+patrol period and exchange station; no route may silently jump between bays.
+Route obstacles/headland transitions require explicit valid segments. Start,
+pause, resume and fault acknowledgement are distinct actions. Periods are measured
+from scheduled starts; unfinished runs block overlap and missed intervals coalesce.
+A terminal fault requires explicit acknowledgement and renewed valid observations.
+Browser backgrounding/reload must not imply physical autonomy; simulation time and
+real timestamps remain distinct. No backend scheduler is delivered by M1.
+
+Per-fruit states: attached -> supported -> detached/held -> boxed, with explicit
+failed/deferred/dropped branches. Confirmation of cut and retained fruit is required
+before weight/inventory changes. A lost observation does not remove a fruit. Mixed
+cultivars cannot enter an incompatible crate. Each state change carries target ID,
+run ID, evidence and time. Machine sensor evidence cannot be undone with plan edits.
+Geometry can illustrate observed or synthetic states but cannot declare a successful
+real harvest. Mark synthetic data, assumptions, stale observations and deferred rows.
+
+## M1 definition of done
+
+Formal tests exercise valid, exact-boundary, unknown, invalid and failure-priority
+cases, plus geometry-preparation work counts and configuration changes. Typecheck,
+app lint and existing app unit regressions pass. No UI, render, runtime or hardware
+consumer is introduced until its subsequent owner step is ready. M1 completion is
+not closure of the full harvest-robot plan.


### PR DESCRIPTION
FieldScope now has an explicit path from greenhouse geometry to a physical harvesting prototype. Add historical stage closeouts and a six-milestone plan covering onboard crates, exchange logistics, patrols, occluded-fruit handling, soft ground, emergency priorities and automatic return to a charging dock.

Implement M1 only: deterministic straight-lane screening using the existing layout and planting-row owners, crate payload/fill and lateral-reserve assessment, conservative battery/return-energy admission, and hazard priority. Unknown ground/access stays unverified; drains and undersized column-split passages are blocked. The policy consumes completed load/energy advice so stop requests cannot be overridden by return tasks.

This is a headless engineering foundation. It does not add a rendered robot, mission UI, harvesting animation, trained perception, physics certification or hardware actuation. M2-M6 remain planned. Vehicle/crate dimensions and prepared-lane/manual-exchange assumptions are provisional and the hardware document names the required measurements, component selection and trials. No existing scene or app UI changes.

Validation: 57 new domain cases and all 229 app unit tests pass; typecheck, app lint, naming and all 17 filtered production-build tasks pass. Tests cover geometry work counts independent of plant count, invalid/unknown values, payload growth, load-stop priority, return reserve, unavailable docks and numeric overflow. 74 documentation links/anchors resolve. The Gherkin file distinguishes implemented M1 cases from future acceptance scenarios. No new dependencies or version changes; the empty Changeset records software work independently of historical closeout.
